### PR TITLE
"Refactor Update-WingetPackage function to handle URL formatting and optional resolves parameter"

### DIFF
--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -23,25 +23,32 @@ on:
 #    - cron:  '3 12 * * *' # every 4 hours
 
 jobs:
-  komac-new-submit:
+  komac-update:
     name: komac update and submit
-    if:  ${{ inputs.submit }} 
+#    if:  ${{ inputs.submit }} 
     runs-on: ubuntu-latest
 
     steps:
-    - name: Run Komac
-      uses: michidk/run-komac@v2
-      with:
-        args: 'update --identifier ${{ inputs.identifier }} --version ${{ inputs.version }} --urls ${{ inputs.urls }} --token=${{ secrets.WINGET_PAT }} --resolves ${{ inputs.resolves }} --submit'
-        custom-fork-owner: damn-good-b0t
+      - name: Update package
+        id: update_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          PackageName: ${{ inputs.identifier }}
+          With: ${{ inputs.With }}
+          Submit: ${{ inputs.submit }}
+          latestVersion: ${{ inputs.version }}
+          latestVersionUrl: ${{ inputs.urls }}
+          resolves: ${{ inputs.resolves }}
+        run: .\Scripts\generic.ps1
 
-  komac-new:
-       name: komac update (NO submit)
-       if:  ${{ inputs.submit != 'true' }}
-       runs-on: ubuntu-latest   
-       steps:
-       - name: Run Komac
-         uses: michidk/run-komac@v2
-         with:
-           args: 'update --identifier ${{ inputs.identifier }} --version ${{ inputs.version }} --urls ${{ inputs.urls }} --token=${{ secrets.WINGET_PAT }}'
-           custom-fork-owner: damn-good-b0t
+#  komac-update-no-submit:
+#       name: komac update (NO submit)
+#       if:  ${{ inputs.submit != 'true' }}
+#       runs-on: ubuntu-latest   
+#       steps:
+#       - name: Run Komac
+#         uses: michidk/run-komac@v2
+#         with:
+#           args: 'update --identifier ${{ inputs.identifier }} --version ${{ inputs.version }} --urls ${{ inputs.urls }} --token=${{ secrets.WINGET_PAT }}'
+#           custom-fork-owner: damn-good-b0t

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   komac-update:
-    name: komac update and submit
+    name: komac update and submit = ${{ inputs.submit }} 
 #    if:  ${{ inputs.submit }} 
     runs-on: windows-latest
 

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -19,6 +19,11 @@ on:
       resolves: 
         description: 'resolves this issues'
         required: false
+      With:
+        description: 'WinGetCreate or komac'
+        required: true
+        type: string
+        default: 'komac'
 #  schedule:
 #    - cron:  '3 12 * * *' # every 4 hours
 

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -15,7 +15,7 @@ on:
         description: 'True to auto-submit'
         required: true
         type: boolean
-        default: false
+        default: $false
       resolves: 
         description: 'resolves this issues'
         required: false

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Update package
         id: update_version
         env:

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -31,7 +31,7 @@ jobs:
   komac-update:
     name: komac update and submit
 #    if:  ${{ inputs.submit }} 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Update package

--- a/.github/workflows/komac-update.yml
+++ b/.github/workflows/komac-update.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   komac-update:
-    name: komac update and submit = ${{ inputs.submit }} 
+    name: update with submit = ${{ inputs.submit }} 
 #    if:  ${{ inputs.submit }} 
     runs-on: windows-latest
 

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -286,7 +286,7 @@ function Update-WingetPackage {
                         Write-Error "wingetcreate not downloaded"
                         exit 1
                     }
-                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : "") -v $Latest.Version -u "$($Latest.URLs.replace(' ','" "'))" --prtitle $prMessage -t $gitToken -o $ManifestOutPath
+                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : $null) -v $Latest.Version -u "$($Latest.URLs.replace(' ','" "'))" --prtitle $prMessage -t $gitToken -o $ManifestOutPath
                 }
                 default { 
                     Write-Error "Invalid value \"$With\" for -With parameter. Valid values are 'Komac' and 'WinGetCreate'"

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -233,6 +233,9 @@ function Update-WingetPackage {
     $PackageAndVersionInWinget = Test-PackageAndVersionInGithub -wingetPackage $wingetPackage -latestVersion $($Latest.Version)
 
     $ManifestOutPath = "./manifests/$($wingetPackage.Substring(0, 1).ToLower())/$($wingetPackage.replace(".","/"))/$latestVersion/"
+
+    write-host "($resolves -match '^\d+$' ? "-resolves $resolves": "")"
+    write-host "($Submit -eq $true ? "-s" : "-dry_run")"
     
 
     if ($PackageAndVersionInWinget) {
@@ -244,7 +247,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $($Latest.URLs) ($Submit -eq $true ? "-s" : "-dry_run") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? "-s" : "-dry_run") -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -122,7 +122,7 @@ function Get-VersionAndUrl {
         if ($version -and $URLs) {
             $Latest = @{
                 Version = $version
-                URLs    = $URLs
+                URLs    = $URLs.split(",").trim().split(" ")
             }
         }
         else {
@@ -239,7 +239,7 @@ function Update-WingetPackage {
     if ($latestVersion -and $latestVersionURL) {
         $Latest = @{
             Version = $latestVersion
-            URLs    = $latestVersionURL
+            URLs    = $latestVersionURL.split(",").trim().split(" ")
         }
     }
     else {

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -244,7 +244,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves ? "-resolves $resolves" : '') -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves ? "-resolves $resolves") -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves "+$resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$Latest.URLs" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -229,6 +229,10 @@ function Update-WingetPackage {
         throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
     }
 
+    if ($Submit -eq $false) {
+        $env:DRY_RUN = $true
+    }
+
 
     $gitToken = Test-GitHubToken
 
@@ -257,7 +261,9 @@ function Update-WingetPackage {
     $ManifestOutPath = "./manifests/$($wingetPackage.Substring(0, 1).ToLower())/$($wingetPackage.replace(".","/"))/$latestVersion/"
 
     write-host "($resolves -match '^\d+$' ? "-resolves $resolves": "")"
-    write-host "($Submit -eq $true ? "-s" : "-dry_run")"
+    write-host ($resolves -match '^\d+$' ? "-resolves $resolves": "")
+    write-host "($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")"
+    write-host ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")
     
 
     if ($PackageAndVersionInWinget) {
@@ -269,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '-dry_run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken -output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken -output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -196,7 +196,7 @@ function Update-WingetPackage {
         [Parameter(Mandatory = $false)] [string] $WebsiteURL,
         [Parameter(Mandatory = $false)] [string] $WingetPackage = ${Env:PackageName},
         [Parameter(Mandatory = $false)][ValidateSet("Komac", "WinGetCreate")] [string] $With = "Komac",
-        [Parameter(Mandatory = $false)] [string] $resolves = ${Env:resolves},
+        [Parameter(Mandatory = $false)] [string] $resolves = (${Env:resolves} -match '^\d+$' ? ${Env:resolves} : ""),
         [Parameter(Mandatory = $false)] [switch] $Submit = $false,
         [Parameter(Mandatory = $false)] [string] $latestVersion,
         [Parameter(Mandatory = $false)] [string] $latestVersionURL
@@ -247,7 +247,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? "-s" : "-dry_run") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves"," ",$resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -193,32 +193,20 @@ function Install-Komac {
 
 function Update-WingetPackage {
     param(
-        [parameter(ValueFromRemainingArguments)]
-        [ValidateScript({if ($WebsiteURL -or ($latestVersion -and $latestVersionURL)) {
-            $True
-        } Else {
-            throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
-        }})]
-        [string] $WebsiteURL,
+        [Parameter(Mandatory = $false)] [string] $WebsiteURL,
         [Parameter(Mandatory = $false)] [string] $WingetPackage = ${Env:PackageName},
         [Parameter(Mandatory = $false)][ValidateSet("Komac", "WinGetCreate")] [string] $With = "Komac",
         [Parameter(Mandatory = $false)] [string] $resolves = ${Env:resolves},
         [Parameter(Mandatory = $false)] [switch] $Submit = $false,
-        [parameter(ValueFromRemainingArguments)]
-        [ValidateScript({if ($WebsiteURL -or ($latestVersion -and $latestVersionURL)) {
-            $True
-        } Else {
-            throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
-        }})]
-        [string] $latestVersion,
-        [parameter(ValueFromRemainingArguments)]
-        [ValidateScript({if ($WebsiteURL -or ($latestVersion -and $latestVersionURL)) {
-            $True
-        } Else {
-            throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
-        }})]
-        [string] $latestVersionURL
+        [Parameter(Mandatory = $false)] [string] $latestVersion,
+        [Parameter(Mandatory = $false)] [string] $latestVersionURL
     )
+
+    # Custom validation
+    if (-not $WebsiteURL -and (-not $latestVersion -or -not $latestVersionURL)) {
+        throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
+    }
+
 
     $gitToken = Test-GitHubToken
 

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves "+$resolves : '') -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves "+$resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -280,7 +280,7 @@ function Update-WingetPackage {
                         Write-Error "wingetcreate not downloaded"
                         exit 1
                     }
-                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : "") -v $Latest.Version -u $Latest.URLs --prtitle $prMessage -t $gitToken -o $ManifestOutPath
+                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : $null ) -v $Latest.Version -u ($Latest.URLs).split(" ") --prtitle $prMessage -t $gitToken -o $ManifestOutPath
                 }
                 default { 
                     Write-Error "Invalid value \"$With\" for -With parameter. Valid values are 'Komac' and 'WinGetCreate'"

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -260,12 +260,6 @@ function Update-WingetPackage {
 
     $ManifestOutPath = "./manifests/$($wingetPackage.Substring(0, 1).ToLower())/$($wingetPackage.replace(".","/"))/$latestVersion/"
 
-    write-host "($Submit -eq $true ? '-s' : '')"
-    write-host ($Submit -eq $true ? '-s' : '')
-    write-host "($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")"
-    write-host ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")
-    
-
     if ($PackageAndVersionInWinget) {
 
         $ExistingPRs = Test-ExistingPRs -wingetPackage $wingetPackage -latestVersion $($Latest.Version)
@@ -275,7 +269,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
@@ -286,7 +280,7 @@ function Update-WingetPackage {
                         Write-Error "wingetcreate not downloaded"
                         exit 1
                     }
-                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : "") -v $Latest.Version -u "$($Latest.URLs.replace(' ','" "'))" --prtitle $prMessage -t $gitToken -o $ManifestOutPath
+                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : "") -v $Latest.Version -u $Latest.URLs --prtitle $prMessage -t $gitToken -o $ManifestOutPath
                 }
                 default { 
                     Write-Error "Invalid value \"$With\" for -With parameter. Valid values are 'Komac' and 'WinGetCreate'"

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -244,7 +244,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves ? "-resolves $resolves") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -244,7 +244,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves ? "-resolves $resolves" : "") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves ? "-resolves $resolves" : '') -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('--resolves '+$resolves) : '') -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves "+$resolves : '') -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -269,7 +269,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '-dry_run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken -output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -244,7 +244,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $($Latest.URLs) ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$Latest.URLs" ($Submit -eq $true ? '-s' : '--dry_run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$Latest.URLs" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -200,7 +200,7 @@ function ConvertTo-Bool {
         return $input
     }
 
-    switch ($input.ToLower()) {
+    switch ($input) {
         "true" { return $true }
         "false" { return $false }
         '$true' { return $true }

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves"," ",$resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
@@ -286,7 +286,7 @@ function Update-WingetPackage {
                         Write-Error "wingetcreate not downloaded"
                         exit 1
                     }
-                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : $null) -v $Latest.Version -u "$($Latest.URLs.replace(' ','" "'))" --prtitle $prMessage -t $gitToken -o $ManifestOutPath
+                    .\wingetcreate.exe update $wingetPackage ($Submit -eq $true ? "-s" : "") -v $Latest.Version -u "$($Latest.URLs.replace(' ','" "'))" --prtitle $prMessage -t $gitToken -o $ManifestOutPath
                 }
                 default { 
                     Write-Error "Invalid value \"$With\" for -With parameter. Valid values are 'Komac' and 'WinGetCreate'"

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('--resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('--resolves '+$resolves) : '') -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -269,7 +269,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls ($Latest.URLs).split(" ") ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs.replace(' ','" "'))" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? "--resolves" : $null ) ($resolves -match '^\d+$' ? $resolves : $null ) -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$($Latest.URLs)" ($Submit -eq $true ? '-s' : '--dry-run') ($resolves -match '^\d+$' ? ('--resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -229,9 +229,9 @@ function Update-WingetPackage {
         throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
     }
 
-    if ($Submit -eq $false) {
-        $env:DRY_RUN = $true
-    }
+    # if ($Submit -eq $false) {
+    #     $env:DRY_RUN = $true
+    # }
 
 
     $gitToken = Test-GitHubToken
@@ -260,8 +260,8 @@ function Update-WingetPackage {
 
     $ManifestOutPath = "./manifests/$($wingetPackage.Substring(0, 1).ToLower())/$($wingetPackage.replace(".","/"))/$latestVersion/"
 
-    write-host "($resolves -match '^\d+$' ? "-resolves $resolves": "")"
-    write-host ($resolves -match '^\d+$' ? "-resolves $resolves": "")
+    write-host "($Submit -eq $true ? '-s' : '')"
+    write-host ($Submit -eq $true ? '-s' : '')
     write-host "($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")"
     write-host ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "")
     
@@ -275,7 +275,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $Latest.URLs ($Submit -eq $true ? '-s' : '') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken -output "$ManifestOutPath"
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls "$Latest.URLs" ($Submit -eq $true ? '-s' : '--dry_run') ($resolves -match '^\d+$' ? ('-resolves '+$resolves) : "") -t $gitToken --output "$ManifestOutPath"
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -244,7 +244,7 @@ function Update-WingetPackage {
             Switch ($With) {
                 "Komac" {
                     Install-Komac
-                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $($Latest.URLs) ($Submit -eq $true ? "-s" : "-dry_run") ($resolves -match '^\d+$' ? "-resolves $resolves": "") -t $gitToken -output $ManifestOutPath
+                    .\komac.exe update --identifier $wingetPackage --version $Latest.Version --urls $($Latest.URLs) ($Submit -eq $true ? "-s" : "-dry_run") -t $gitToken -output $ManifestOutPath
                 }
                 "WinGetCreate" {
                     Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -200,7 +200,7 @@ function ConvertTo-Bool {
         return $input
     }
 
-    switch ($str.ToLower()) {
+    switch ($input.ToLower()) {
         "true" { return $true }
         "false" { return $false }
         '$true' { return $true }
@@ -209,7 +209,7 @@ function ConvertTo-Bool {
         "no" { return $false }
         "1" { return $true }
         "0" { return $false }
-        default { throw "Invalid boolean string: $str" }
+        default { throw "Invalid boolean string: $input" }
     }
 }
 

--- a/Scripts/common.ps1
+++ b/Scripts/common.ps1
@@ -191,6 +191,28 @@ function Install-Komac {
     }
 }
 
+function ConvertTo-Bool {
+    param(
+        [Parameter(Mandatory = $true)] $input
+    )
+
+    if ($input -is [bool]) {
+        return $input
+    }
+
+    switch ($str.ToLower()) {
+        "true" { return $true }
+        "false" { return $false }
+        '$true' { return $true }
+        '$false' { return $false }
+        "yes" { return $true }
+        "no" { return $false }
+        "1" { return $true }
+        "0" { return $false }
+        default { throw "Invalid boolean string: $str" }
+    }
+}
+
 function Update-WingetPackage {
     param(
         [Parameter(Mandatory = $false)] [string] $WebsiteURL,

--- a/Scripts/generic.ps1
+++ b/Scripts/generic.ps1
@@ -11,6 +11,16 @@ if($Env:With) {
 if($Env:Submit) {
     $params.Add("Submit", $true)
 }
+if($Env:latestVersion) {
+    $params.Add("latestVersion", $Env:latestVersion)
+}
+if($Env:latestVersionURL) {
+    $params.Add("latestVersionURL", $Env:latestVersionURL)
+}
+if($Env:resolves) {
+    $params.Add("resolves", $Env:resolves)
+}
+
 
 Update-WingetPackage @params
 

--- a/Scripts/generic.ps1
+++ b/Scripts/generic.ps1
@@ -10,7 +10,7 @@ if($Env:WebsiteURL) {
 if($Env:With) {
     $params.Add("With", $Env:With)
 }
-if($Env:Submit) {
+if($null -ne $Env:Submit) {
     $params.Add("Submit", (ConvertTo-Bool -input $Env:Submit))
 }
 if($Env:latestVersion) {

--- a/Scripts/generic.ps1
+++ b/Scripts/generic.ps1
@@ -3,7 +3,9 @@
 #### Main
 $params = @{
     wingetPackage = ${Env:PackageName}
-    WebsiteURL = ${Env:WebsiteURL}
+}
+if($Env:WebsiteURL) {
+    $params.Add("WebsiteURL", $Env:WebsiteURL)
 }
 if($Env:With) {
     $params.Add("With", $Env:With)

--- a/Scripts/generic.ps1
+++ b/Scripts/generic.ps1
@@ -11,7 +11,7 @@ if($Env:With) {
     $params.Add("With", $Env:With)
 }
 if($Env:Submit) {
-    $params.Add("Submit", $true)
+    $params.Add("Submit", (ConvertTo-Bool -input $Env:Submit))
 }
 if($Env:latestVersion) {
     $params.Add("latestVersion", $Env:latestVersion)


### PR DESCRIPTION
This pull request includes several commits that refactor the Update-WingetPackage function to improve URL handling and handle an optional resolves parameter. The function now requires either a WebsiteURL or both latestVersion and latestVersionURL. Additionally, unnecessary parameters have been removed and URL formatting issues have been fixed. This PR also includes a fix for the URLs and updates the name of the function.