### PR TITLE
Fix winget version post-generation check

### DIFF
--- a/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
@@ -143,7 +143,10 @@ function Test-GeneratedInstallerArchitecture {
         [string]$ManifestOutPath,
 
         [Parameter(Mandatory = $true)]
-        [string[]]$RequestedInstallerValues
+        [string[]]$RequestedInstallerValues,
+
+        [Parameter(Mandatory = $false)]
+        [string]$PreviousVersion
     )
 
     $requestedEntries = @(Get-InstallerUrlEntries -InstallerValues $RequestedInstallerValues)
@@ -183,14 +186,13 @@ function Test-GeneratedInstallerArchitecture {
     }
 
     try {
-        $previousVersion = Get-LatestVersionInWinget -PackageId $PackageIdentifier
-        if ($previousVersion -and $previousVersion -ne $CurrentVersion) {
-            $previousManifestUrl = "https://raw.githubusercontent.com/microsoft/winget-pkgs/refs/heads/master/manifests/$firstChar/$packagePath/$previousVersion/$PackageIdentifier.installer.yaml"
+        if ($PreviousVersion -and $PreviousVersion -ne $CurrentVersion) {
+            $previousManifestUrl = "https://raw.githubusercontent.com/microsoft/winget-pkgs/refs/heads/master/manifests/$firstChar/$packagePath/$PreviousVersion/$PackageIdentifier.installer.yaml"
             $previousInstallerManifestContent = (Invoke-WebRequest -Uri $previousManifestUrl -UseBasicParsing).Content
             $previousEntries = @(Get-InstallerManifestEntries -Content $previousInstallerManifestContent)
 
             if ($previousEntries) {
-                $knownVersions = @($CurrentVersion, $previousVersion) | Sort-Object -Unique
+                $knownVersions = @($CurrentVersion, $PreviousVersion) | Sort-Object -Unique
                 $previousEntriesByNormalizedUrl = @{}
 
                 foreach ($previousEntry in $previousEntries) {

--- a/modules/WingetMaintainerModule/Public/Get-LatestVersionInWinget.ps1
+++ b/modules/WingetMaintainerModule/Public/Get-LatestVersionInWinget.ps1
@@ -3,23 +3,18 @@ function Get-LatestVersionInWinget {
         [Parameter(Mandatory = $true)] [string] $PackageId
     )
 
-    $packagePath = $PackageId -replace '\.', '/'
-    $firstChar = $PackageId[0].ToString().ToLower()
-
     Write-Host "Checking if $PackageId is already in winget (via GH) and find latest Version"
-    
-    $ghVersionSearchString = "manifests/$($firstChar)/$($packagePath)/"
-    $ghResponse = gh search code $ghVersionSearchString $PackageId".yaml" --match path --repo microsoft/winget-pkgs -L 1000 --json path | ConvertFrom-Json
-    $versions = $ghResponse.path | ForEach-Object { $_ -replace ".*$ghVersionSearchString", "" -replace "/.*", "" } | Sort-Object -Descending -Unique
-    $sortedVersions = $versions| Get-STNumericalSorted -Descending
-    $latestVersion = $sortedVersions | Select-Object -First 1
+
+    $publishedVersionInfo = Get-WingetPublishedVersionsFromGitHub -PackageIdentifier $PackageId
+    $latestVersion = $publishedVersionInfo.Versions |
+        Sort-Object { Get-WingetSortableVersionKey -Version $_ } -Descending |
+        Select-Object -First 1
 
     if ($latestVersion) {
         Write-Host "Latest Version of $PackageId in Winget: $latestVersion"
         return $latestVersion
-    } 
-    else {
-        Write-Host "No Version found for Package $PackageId"
-        exit 1
     }
+
+    Write-Host "No Version found for Package $PackageId"
+    return $null
 }

--- a/modules/WingetMaintainerModule/Public/Test-PackageAndVersionInGithub.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-PackageAndVersionInGithub.ps1
@@ -23,15 +23,19 @@ function Test-PackageAndVersionInGithub {
     Write-Host "Checking if $wingetPackage is already in winget (via GH) and version $latestVersion is already present"
     $publishedVersionInfo = Get-WingetPublishedVersionsFromGitHub -PackageIdentifier $wingetPackage
     $publishedVersions = @($publishedVersionInfo.Versions)
+    $latestPublishedVersion = $publishedVersions |
+        Sort-Object { Get-WingetSortableVersionKey -Version $_ } -Descending |
+        Select-Object -First 1
 
     $result = [PSCustomObject]@{
-        PackageExists    = $true
-        VersionExists    = $false
-        ShouldGenerate   = $false
-        RequestedVersion = $latestVersion
-        PublishedVersion = $null
-        VersionMatchType = $null
-        CanonicalVersion = $latestVersion
+        PackageExists          = $true
+        VersionExists          = $false
+        ShouldGenerate         = $false
+        RequestedVersion       = $latestVersion
+        PublishedVersion       = $null
+        LatestPublishedVersion = $latestPublishedVersion
+        VersionMatchType       = $null
+        CanonicalVersion       = $latestVersion
     }
 
     if (-not $publishedVersionInfo.PackageExists) {

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -220,7 +220,7 @@ function Update-WingetPackage {
                 throw "$EffectiveWith update failed for $wingetPackage $($Latest.Version) with exit code $LASTEXITCODE"
             }
 
-            Test-GeneratedInstallerArchitecture -PackageIdentifier $wingetPackage -CurrentVersion $Latest.Version -ManifestOutPath $ManifestOutPath -RequestedInstallerValues $RequestedInstallerValues
+            Test-GeneratedInstallerArchitecture -PackageIdentifier $wingetPackage -CurrentVersion $Latest.Version -ManifestOutPath $ManifestOutPath -RequestedInstallerValues $RequestedInstallerValues -PreviousVersion $PackageAndVersionInWinget.LatestPublishedVersion
 
             # If release notes are provided, add them to the manifest
             if ($Latest.releaseNotes) {


### PR DESCRIPTION
## Summary

- reuse the published-version list already fetched before manifest generation
- pass the latest published version into installer architecture validation instead of running a second GitHub code search
- make `Get-LatestVersionInWinget` use the GitHub Contents API and return `$null` rather than terminating the PowerShell host

## Why

In [GH Packages 1-Q run 30834256811](https://github.com/b0t-at/winget-pkgs-updates/actions/runs/30834256811), WinMatsch successfully generated manifests for packages such as `AquaSecurity.Trivy`, but the optional post-generation architecture check called a code-search query that returned no versions. `Get-LatestVersionInWinget` then executed `exit 1`, failing the job and preventing artifact upload even though the generated manifest set was valid.

## Verification

- `AquaSecurity.Trivy` now resolves published version `0.72.0` through the Contents API
- the initial package status carries `LatestPublishedVersion = 0.72.0`
- the architecture post-check passes against the replayed `0.73.0` Trivy manifest
- a genuinely missing package returns normally without terminating PowerShell
- all module PowerShell files parse successfully and `git diff --check` passes