### PR TITLE
Harden winget version lookup integration

### DIFF
--- a/modules/WingetMaintainerModule/Public/Get-LatestVersionInWinget.ps1
+++ b/modules/WingetMaintainerModule/Public/Get-LatestVersionInWinget.ps1
@@ -6,6 +6,11 @@ function Get-LatestVersionInWinget {
     Write-Host "Checking if $PackageId is already in winget (via GH) and find latest Version"
 
     $publishedVersionInfo = Get-WingetPublishedVersionsFromGitHub -PackageIdentifier $PackageId
+    if (-not $publishedVersionInfo.PackageExists) {
+        Write-Host "Package $PackageId was not found in winget"
+        return $null
+    }
+
     $latestVersion = $publishedVersionInfo.Versions |
         Sort-Object { Get-WingetSortableVersionKey -Version $_ } -Descending |
         Select-Object -First 1

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -116,6 +116,8 @@ function Update-WingetPackage {
     $canonicalVersion = if ($canonicalVersionProperty) { [string]$canonicalVersionProperty.Value } else { $Latest.Version }
     $publishedVersionProperty = $PackageAndVersionInWinget.PSObject.Properties['PublishedVersion']
     $publishedVersion = if ($publishedVersionProperty) { [string]$publishedVersionProperty.Value } else { $null }
+    $latestPublishedVersionProperty = $PackageAndVersionInWinget.PSObject.Properties['LatestPublishedVersion']
+    $latestPublishedVersion = if ($latestPublishedVersionProperty) { [string]$latestPublishedVersionProperty.Value } else { $null }
 
     if ($PackageAndVersionInWinget.VersionExists -and -not [string]::IsNullOrWhiteSpace($publishedVersion)) {
         $result.Version = $publishedVersion
@@ -220,7 +222,7 @@ function Update-WingetPackage {
                 throw "$EffectiveWith update failed for $wingetPackage $($Latest.Version) with exit code $LASTEXITCODE"
             }
 
-            Test-GeneratedInstallerArchitecture -PackageIdentifier $wingetPackage -CurrentVersion $Latest.Version -ManifestOutPath $ManifestOutPath -RequestedInstallerValues $RequestedInstallerValues -PreviousVersion $PackageAndVersionInWinget.LatestPublishedVersion
+            Test-GeneratedInstallerArchitecture -PackageIdentifier $wingetPackage -CurrentVersion $Latest.Version -ManifestOutPath $ManifestOutPath -RequestedInstallerValues $RequestedInstallerValues -PreviousVersion $latestPublishedVersion
 
             # If release notes are provided, add them to the manifest
             if ($Latest.releaseNotes) {


### PR DESCRIPTION
## Summary

Follow up on #142 and its post-merge review feedback:

- access `LatestPublishedVersion` defensively so callers or mocks returning the older status shape remain compatible
- distinguish a missing package folder from an existing package with no version directories in `Get-LatestVersionInWinget`

## Verification

- all module PowerShell files parse successfully
- `git diff --check` passes
- `AquaSecurity.Trivy` still resolves `0.72.0`
- the architecture post-check passes against the replayed `0.73.0` Trivy manifest
- a missing package returns `$null` with the package-missing message
- a legacy status object without `LatestPublishedVersion` falls back to `$null`