### PR TITLE
Fix package update false positives

### DIFF
--- a/.github/workflows/single-update.yml
+++ b/.github/workflows/single-update.yml
@@ -31,6 +31,9 @@ on:
         - winmatsch
         - komac
         - WinGetCreate
+      overridePack:
+        description: 'Repository-relative WinMatsch override-pack YAML path'
+        required: false
 #  schedule:
 #    - cron:  '3 12 * * *' # every 4 hours
 
@@ -61,4 +64,5 @@ jobs:
           latestVersionUrl: ${{ inputs.urls }}
           resolves: ${{ inputs.resolves }}
           WebsiteURL: ${{ inputs.WebsiteURL }}
+          WinMatschOverridePack: ${{ inputs.overridePack }}
         run: .\scripts\Update-Package.ps1

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -78,7 +78,7 @@ jobs:
             url: https://github.com/cantino/mcfly/releases/download/v{VERSION}/mcfly-v{VERSION}-x86_64-pc-windows-msvc.zip
           - id: Anki.Anki
             repo: ankitects/anki
-            url: https://github.com/ankitects/anki/releases/download/{VERSION}/anki-launcher-{VERSION}-windows.exe
+            url: https://github.com/ankitects/anki/releases/download/{VERSION}/anki-{VERSION}-win-x64.msi https://github.com/ankitects/anki/releases/download/{VERSION}/anki-{VERSION}-win-arm64.msi
           - id: ANTOrg-Inc.ASCIIEngine
             repo: hdfsyu/ASCIIEngine
             url: https://github.com/hdfsyu/ASCIIEngine/releases/download/v{VERSION}/ASCIIEngine.msi
@@ -135,7 +135,7 @@ jobs:
             url: https://github.com/bootandy/dust/releases/download/v{VERSION}/dust-v{VERSION}-i686-pc-windows-gnu.zip https://github.com/bootandy/dust/releases/download/v{VERSION}/dust-v{VERSION}-x86_64-pc-windows-gnu.zip
           - id: bornova.numara
             repo: bornova/numara-calculator
-            url: https://github.com/bornova/numara-calculator/releases/download/v{VERSION}/Numara-{VERSION}.exe https://github.com/bornova/numara-calculator/releases/download/v{VERSION}/Numara-{VERSION}.exe
+            url: https://github.com/bornova/numara-calculator/releases/download/v{VERSION}/Numara-{VERSION}-x64.exe
           - id: bufbuild.buf
             repo: bufbuild/buf
             url: https://github.com/bufbuild/buf/releases/download/v{VERSION}/buf-Windows-x86_64.zip https://github.com/bufbuild/buf/releases/download/v{VERSION}/buf-Windows-arm64.zip
@@ -144,7 +144,7 @@ jobs:
             url: https://github.com/bytecodealliance/wasmtime/releases/download/v{VERSION}/wasmtime-v{VERSION}-x86_64-windows.zip
           - id: CameronSutter.Plottr
             repo: cameronsutter/plottr_electron
-            url: https://github.com/cameronsutter/plottr_electron/releases/download/v{VERSION}/Plottr-win-installer-latest.exe
+            url: https://github.com/cameronsutter/plottr_electron/releases/download/v{VERSION}/Plottr-win-installer-latest.exe|x64
           - id: CargoLambda.CargoLambda
             repo: cargo-lambda/cargo-lambda
             url: https://github.com/cargo-lambda/cargo-lambda/releases/download/v{VERSION}/cargo-lambda-v{VERSION}.windows-x64.zip
@@ -159,7 +159,7 @@ jobs:
             url: https://github.com/TranslucentTB/TranslucentTB/releases/download/{VERSION}/bundle.msixbundle https://github.com/TranslucentTB/TranslucentTB/releases/download/{VERSION}/bundle.msixbundle
           - id: ChiaNetwork.GUIforChiaBlockchain
             repo: Chia-Network/chia-blockchain
-            url: https://github.com/Chia-Network/chia-blockchain/releases/download/{VERSION}/ChiaSetup-{VERSION}.exe
+            url: https://github.com/Chia-Network/chia-blockchain/releases/download/{VERSION}/ChiaSetup-{VERSION}.exe|x64
           - id: chylex.DiscordHistoryTracker
             repo: chylex/Discord-History-Tracker
             url: https://github.com/chylex/Discord-History-Tracker/releases/download/v{VERSION}/win-x64.zip
@@ -516,7 +516,7 @@ jobs:
             url: https://github.com/Keeper-Security/Commander/releases/download/v{VERSION}/keeper-commander-windows-v{VERSION}.exe
           - id: Kitware.CMake
             repo: Kitware/CMake
-            url: https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-i386.msi https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-x86_64.msi https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-arm64.msi
+            url: https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-i386.msi https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-x86_64.msi https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-arm64.msi https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-i386.zip https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-x86_64.zip https://github.com/Kitware/CMake/releases/download/v{VERSION}/cmake-{VERSION}-windows-arm64.zip
           - id: KoalaBear84.OpenDirectoryDownloader
             repo: KoalaBear84/OpenDirectoryDownloader
             url: https://github.com/KoalaBear84/OpenDirectoryDownloader/releases/download/v{VERSION}/OpenDirectoryDownloader-{VERSION}-win-x64.zip
@@ -741,7 +741,7 @@ jobs:
             url: https://github.com/PolarGoose/ShowWhatProcessLocksFile/releases/download/v{VERSION}/ShowWhatProcessLocksFile.msi.zip
           - id: PolyMC.PolyMC
             repo: PolyMC/PolyMC
-            url: https://github.com/PolyMC/PolyMC/releases/download/{VERSION}/PolyMC-Windows-Setup-{VERSION}.exe
+            url: https://github.com/PolyMC/PolyMC/releases/download/{VERSION}/PolyMC-Windows-Setup-amd64-{VERSION}.exe
           - id: Primecount.Primecount
             repo: kimwalisch/primecount-winget
             url: https://github.com/kimwalisch/primecount-winget/releases/download/v{VERSION}/Primecount-{VERSION}-win-x64.exe https://github.com/kimwalisch/primecount-winget/releases/download/v{VERSION}/Primecount-{VERSION}-win-arm64.exe
@@ -781,6 +781,7 @@ jobs:
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
           GHTagPattern: ${{ matrix.tagPattern }}
+          WinMatschOverridePack: ${{ matrix.overridePack }}
           PackageName: ${{ matrix.id }}
           With: ${{ matrix.With }}
           Submit: "false"

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -375,6 +375,7 @@ jobs:
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
           GHTagPattern: ${{ matrix.tagPattern }}
+          WinMatschOverridePack: ${{ matrix.overridePack }}
           PackageName: ${{ matrix.id }}
           With: ${{ matrix.With }}
           Submit: "false"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,20 @@
 
 ## Tools:
 **[Orca](https://learn.microsoft.com/de-de/windows/win32/msi/orca-exe)**: database table editor for creating and editing Windows Installer packages
+
+## Package-specific WinMatsch overrides
+
+Keep safety questions enabled by default. When a package has reviewed, stable
+exceptions, add a WinMatsch override-pack YAML file to the repository and set
+its matrix entry's `overridePack` field to that repository-relative path:
+
+```yaml
+- id: Publisher.App
+	repo: publisher/app
+	url: https://github.com/publisher/app/releases/download/v{VERSION}/setup.exe
+	overridePack: overrides/Publisher.App.yaml
+```
+
+The single-package workflow exposes the same path as `overridePack`. The wrapper
+rejects missing files and rejects override packs with Komac or WinGetCreate, so
+an override cannot be silently ignored.

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -30,7 +30,8 @@ function Update-WingetPackage {
         [Parameter(Mandatory = $false)] [string] $releaseNotes,
         [Parameter(Mandatory = $false)] [string] $GHRepo,
         [Parameter(Mandatory = $false)] [string] $GHURLs,
-        [Parameter(Mandatory = $false)] [string] $GHTagPattern
+        [Parameter(Mandatory = $false)] [string] $GHTagPattern,
+        [Parameter(Mandatory = $false)] [string] $WinMatschOverridePack
     )
 
     # Initialize result object
@@ -107,6 +108,17 @@ function Update-WingetPackage {
         $EffectiveWith = 'WinGetCreate'
     }
 
+    $ResolvedWinMatschOverridePack = $null
+    if (-not [string]::IsNullOrWhiteSpace($WinMatschOverridePack)) {
+        if ($EffectiveWith -ne 'WinMatsch') {
+            throw 'WinMatschOverridePack can only be used with the WinMatsch generator.'
+        }
+        if (-not (Test-Path -LiteralPath $WinMatschOverridePack -PathType Leaf)) {
+            throw "WinMatsch override pack not found: $WinMatschOverridePack"
+        }
+        $ResolvedWinMatschOverridePack = (Resolve-Path -LiteralPath $WinMatschOverridePack).Path
+    }
+
     $result.Version = $Latest.Version
     $prMessage = "Update version: $wingetPackage version $($Latest.Version)"
     $result.PrTitle = $prMessage
@@ -174,12 +186,17 @@ function Update-WingetPackage {
                         $winmatschArgs += "--resolves"
                         $winmatschArgs += $resolves
                     }
+                    if ($ResolvedWinMatschOverridePack) {
+                        $winmatschArgs += "--override-pack"
+                        $winmatschArgs += $ResolvedWinMatschOverridePack
+                    }
                     $winmatschArgs += "--token"
                     $winmatschArgs += $gitToken
                     $winmatschArgs += "--output"
                     $winmatschArgs += "$ManifestOutPath"
 
-                    Write-Host "Running: winmatsch $($winmatschArgs -replace $gitToken, '***' -join ' ')"
+                    $displayArgs = $winmatschArgs | ForEach-Object { if ($_ -eq $gitToken) { '***' } else { $_ } }
+                    Write-Host "Running: winmatsch $($displayArgs -join ' ')"
                     & winmatsch @winmatschArgs
                 }
                 "Komac" {
@@ -202,7 +219,8 @@ function Update-WingetPackage {
                     $komacArgs += "--output"
                     $komacArgs += "$ManifestOutPath"
 
-                    Write-Host "Running: komac $($komacArgs -replace $gitToken, '***' -join ' ')"
+                    $displayArgs = $komacArgs | ForEach-Object { if ($_ -eq $gitToken) { '***' } else { $_ } }
+                    Write-Host "Running: komac $($displayArgs -join ' ')"
                     & komac @komacArgs
                 }
                 "WinGetCreate" {

--- a/scripts/Update-Package.ps1
+++ b/scripts/Update-Package.ps1
@@ -51,5 +51,8 @@ if ($Env:GHRepo) {
 if ($Env:GHTagPattern) {
     $params.Add("GHTagPattern", $Env:GHTagPattern)
 }
+if ($Env:WinMatschOverridePack) {
+    $params.Add("WinMatschOverridePack", $Env:WinMatschOverridePack)
+}
 
 Update-WingetPackage @params

--- a/scripts/validation/Test-ManifestContent.ps1
+++ b/scripts/validation/Test-ManifestContent.ps1
@@ -448,6 +448,10 @@ function Read-PublishedManifestSet {
         }
     }
 
+    if ($documents.Count -eq 0) {
+        return $null
+    }
+
     return ConvertTo-ManifestSet -Documents $documents -Source $VersionSource.Name
 }
 
@@ -731,7 +735,10 @@ if ($errors.Count -eq 0) {
 
                 $publishedManifestSets = @()
                 foreach ($publishedVersionSource in $publishedVersionSources) {
-                    $publishedManifestSets += Read-PublishedManifestSet -VersionSource $publishedVersionSource
+                    $publishedManifestSet = Read-PublishedManifestSet -VersionSource $publishedVersionSource
+                    if ($null -ne $publishedManifestSet) {
+                        $publishedManifestSets += $publishedManifestSet
+                    }
                 }
 
                 $exactVersionMatch = $publishedManifestSets | Where-Object { $_.PackageVersion -eq $localManifestSet.PackageVersion } | Select-Object -First 1


### PR DESCRIPTION
## Summary

- correct verified stale/incomplete asset patterns for Anki, Numara, CMake, and PolyMC
- add explicit x64 evidence for Chia and Plottr
- skip empty historical manifest folders in content validation instead of crashing
- support checked-in, package-specific WinMatsch override packs in both matrix workflows and single-package dispatch
- redact generator tokens by exact argument equality

## Verification

- all edited workflows parse as YAML
- all PowerShell files parse successfully
- `git diff --check`
- exact local replays succeeded for all six matrix URL changes when combined with b0t-at/winmatsch#13
- AdGuardHome's downloaded artifact passes validation with an empty historical version folder
- Prometheus output from b0t-at/winmatsch#13 passes this content validator against published 0.31.7
- override transport, missing-file rejection, and non-WinMatsch rejection were exercised through `Update-WingetPackage`

## Deployment note

This PR does not auto-approve package questions. Override packs are opt-in and checked in per package. Chia/Plottr and the other analyzer/mapping fixes require a future WinMatsch release after b0t-at/winmatsch#13 merges; this PR intentionally does not publish one.