### PR TITLE
Constrain package override paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ its matrix entry's `overridePack` field to that repository-relative path:
 
 ```yaml
 - id: Publisher.App
-	repo: publisher/app
-	url: https://github.com/publisher/app/releases/download/v{VERSION}/setup.exe
-	overridePack: overrides/Publisher.App.yaml
+  repo: publisher/app
+  url: https://github.com/publisher/app/releases/download/v{VERSION}/setup.exe
+  overridePack: overrides/Publisher.App.yaml
 ```
 
 The single-package workflow exposes the same path as `overridePack`. The wrapper

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -113,10 +113,28 @@ function Update-WingetPackage {
         if ($EffectiveWith -ne 'WinMatsch') {
             throw 'WinMatschOverridePack can only be used with the WinMatsch generator.'
         }
-        if (-not (Test-Path -LiteralPath $WinMatschOverridePack -PathType Leaf)) {
+        if ([IO.Path]::IsPathRooted($WinMatschOverridePack)) {
+            throw 'WinMatschOverridePack must be a repository-relative path.'
+        }
+
+        $workspaceRoot = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            (Get-Location).Path
+        }
+        else {
+            $env:GITHUB_WORKSPACE
+        }
+        $workspaceRoot = [IO.Path]::GetFullPath($workspaceRoot)
+        $candidatePath = [IO.Path]::GetFullPath((Join-Path $workspaceRoot $WinMatschOverridePack))
+        $relativePath = [IO.Path]::GetRelativePath($workspaceRoot, $candidatePath)
+        if ([IO.Path]::IsPathRooted($relativePath) -or
+            $relativePath -eq '..' -or
+            $relativePath.StartsWith("..$([IO.Path]::DirectorySeparatorChar)", [StringComparison]::Ordinal)) {
+            throw 'WinMatschOverridePack must stay within the repository workspace.'
+        }
+        if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
             throw "WinMatsch override pack not found: $WinMatschOverridePack"
         }
-        $ResolvedWinMatschOverridePack = (Resolve-Path -LiteralPath $WinMatschOverridePack).Path
+        $ResolvedWinMatschOverridePack = (Resolve-Path -LiteralPath $candidatePath).Path
     }
 
     $result.Version = $Latest.Version


### PR DESCRIPTION
## Summary

Follow up on post-merge review feedback from #144:

- require `WinMatschOverridePack` to be repository-relative
- reject rooted paths and paths that escape `GITHUB_WORKSPACE`
- retain missing-file and WinMatsch-only generator validation
- replace invalid tab indentation in the README YAML example with spaces

## Verification

- valid in-workspace relative override reaches `--override-pack` exactly once
- rooted, `..` traversal, and missing paths are rejected
- token output remains exactly redacted as `--token ***`
- all PowerShell files parse successfully
- README contains no tab characters
- `git diff --check`