### PR TITLE
Fix concurrent package-state persistence

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -1,0 +1,37 @@
+name: Module tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/module-tests.yml"
+      - "modules/WingetMaintainerModule/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/module-tests.yml"
+      - "modules/WingetMaintainerModule/**"
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  package-state:
+    name: Package state (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run regression tests
+        shell: pwsh
+        run: ./tests/Save-PackageState.Tests.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 manifests/
 Tests
+!tests/
+!tests/Save-PackageState.Tests.ps1
 scripts/package-cleanup/broken_packages.csv
 scripts/package-cleanup/cleaned_packages.csv
 *.msi

--- a/modules/WingetMaintainerModule/Public/Save-PackageState.ps1
+++ b/modules/WingetMaintainerModule/Public/Save-PackageState.ps1
@@ -1,17 +1,22 @@
 function Save-PackageState {
     <#
     .SYNOPSIS
-        Commits and pushes the package state file to the repository.
+        Merges, commits, and pushes the package state file to the repository.
 
     .DESCRIPTION
-        Performs git add, commit, and push for the state file. Handles the case where
-        nothing has changed (no error if state is unchanged).
+        Computes the local JSON changes relative to the checked-out commit, merges
+        them with the latest upstream state at package/field granularity, and pushes
+        the resulting commit. Non-fast-forward push races are retried boundedly.
+        Concurrent changes to the same scalar value fail rather than dropping data.
 
     .PARAMETER StateFilePath
         Path to the package-state.json file (relative or absolute).
 
     .PARAMETER RepoPath
         Path to the repository working directory. Defaults to current directory.
+
+    .PARAMETER MaxPushAttempts
+        Maximum number of fetch/merge/commit/push attempts for non-fast-forward races.
     #>
     [CmdletBinding()]
     param(
@@ -19,47 +24,376 @@ function Save-PackageState {
         [string] $StateFilePath,
 
         [Parameter(Mandatory = $false)]
-        [string] $RepoPath = '.'
+        [string] $RepoPath = '.',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 10)]
+        [int] $MaxPushAttempts = 3
     )
 
-    Push-Location -Path $RepoPath
+    function Invoke-StateGit {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string[]] $Arguments,
 
-    try {
-        # Get the relative path for git operations
-        $relativePath = Resolve-Path -Path $StateFilePath -Relative -ErrorAction SilentlyContinue
-        if ([string]::IsNullOrWhiteSpace($relativePath)) {
-            $relativePath = $StateFilePath
+            [Parameter(Mandatory = $false)]
+            [switch] $AllowFailure
+        )
+
+        $output = @(& git @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+        $outputText = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+
+        if ($exitCode -ne 0 -and -not $AllowFailure) {
+            throw "git $($Arguments -join ' ') failed with exit code ${exitCode}: $outputText"
         }
 
-        git add $relativePath
+        return [pscustomobject]@{
+            ExitCode = $exitCode
+            Output   = $outputText
+        }
+    }
 
-        # Check if there are staged changes for this file
-        $status = git diff --cached --name-only
-        if ([string]::IsNullOrWhiteSpace($status)) {
+    function Clear-InterruptedGitOperation {
+        $gitDirectoryResult = Invoke-StateGit -Arguments @('rev-parse', '--git-dir')
+        $gitDirectory = $gitDirectoryResult.Output.Trim()
+        if (-not [IO.Path]::IsPathRooted($gitDirectory)) {
+            $gitDirectory = Join-Path (Get-Location).Path $gitDirectory
+        }
+
+        $cleanupCommands = @()
+        if ((Test-Path (Join-Path $gitDirectory 'rebase-merge')) -or
+            (Test-Path (Join-Path $gitDirectory 'rebase-apply'))) {
+            $cleanupCommands += , @('rebase', '--abort')
+        }
+        if (Test-Path (Join-Path $gitDirectory 'MERGE_HEAD')) {
+            $cleanupCommands += , @('merge', '--abort')
+        }
+        if (Test-Path (Join-Path $gitDirectory 'CHERRY_PICK_HEAD')) {
+            $cleanupCommands += , @('cherry-pick', '--abort')
+        }
+        if (Test-Path (Join-Path $gitDirectory 'REVERT_HEAD')) {
+            $cleanupCommands += , @('revert', '--abort')
+        }
+
+        foreach ($command in $cleanupCommands) {
+            $cleanupResult = Invoke-StateGit -Arguments $command -AllowFailure
+            if ($cleanupResult.ExitCode -ne 0) {
+                throw "Failed to clean interrupted git operation with 'git $($command -join ' ')': $($cleanupResult.Output)"
+            }
+        }
+    }
+
+    function Read-StateJson {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Content,
+
+            [Parameter(Mandatory = $true)]
+            [string] $Source
+        )
+
+        try {
+            $state = $Content | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        }
+        catch {
+            throw "Package state from $Source is not valid JSON: $_"
+        }
+
+        if ($state -isnot [System.Collections.IDictionary]) {
+            throw "Package state from $Source must be a JSON object."
+        }
+
+        return $state
+    }
+
+    function Get-StateAtCommit {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string] $Commit,
+
+            [Parameter(Mandatory = $true)]
+            [string] $RelativePath
+        )
+
+        $objectName = "${Commit}:$RelativePath"
+        $existsResult = Invoke-StateGit -Arguments @('cat-file', '-e', $objectName) -AllowFailure
+        if ($existsResult.ExitCode -ne 0) {
+            return @{}
+        }
+
+        $contentResult = Invoke-StateGit -Arguments @('show', $objectName)
+        return Read-StateJson -Content $contentResult.Output -Source $objectName
+    }
+
+    function Test-StateValueEqual {
+        param(
+            [Parameter(Mandatory = $true)]
+            [bool] $LeftExists,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object] $Left,
+
+            [Parameter(Mandatory = $true)]
+            [bool] $RightExists,
+
+            [Parameter(Mandatory = $false)]
+            [AllowNull()]
+            [object] $Right
+        )
+
+        if ($LeftExists -ne $RightExists) {
+            return $false
+        }
+        if (-not $LeftExists) {
+            return $true
+        }
+        if ($null -eq $Left -or $null -eq $Right) {
+            return $null -eq $Left -and $null -eq $Right
+        }
+
+        if ($Left -is [System.Collections.IDictionary] -and
+            $Right -is [System.Collections.IDictionary]) {
+            if ($Left.Count -ne $Right.Count) {
+                return $false
+            }
+
+            foreach ($key in $Left.Keys) {
+                if (-not $Right.Contains($key)) {
+                    return $false
+                }
+                if (-not (Test-StateValueEqual -LeftExists $true -Left $Left[$key] -RightExists $true -Right $Right[$key])) {
+                    return $false
+                }
+            }
+
+            return $true
+        }
+
+        $leftIsArray = $Left -is [System.Collections.IEnumerable] -and $Left -isnot [string]
+        $rightIsArray = $Right -is [System.Collections.IEnumerable] -and $Right -isnot [string]
+        if ($leftIsArray -or $rightIsArray) {
+            if (-not ($leftIsArray -and $rightIsArray)) {
+                return $false
+            }
+
+            $leftItems = @($Left)
+            $rightItems = @($Right)
+            if ($leftItems.Count -ne $rightItems.Count) {
+                return $false
+            }
+
+            for ($index = 0; $index -lt $leftItems.Count; $index++) {
+                if (-not (Test-StateValueEqual -LeftExists $true -Left $leftItems[$index] -RightExists $true -Right $rightItems[$index])) {
+                    return $false
+                }
+            }
+
+            return $true
+        }
+
+        return $Left.GetType() -eq $Right.GetType() -and $Left -ceq $Right
+    }
+
+    function Merge-StateObject {
+        param(
+            [Parameter(Mandatory = $true)]
+            [System.Collections.IDictionary] $Base,
+
+            [Parameter(Mandatory = $true)]
+            [System.Collections.IDictionary] $Local,
+
+            [Parameter(Mandatory = $true)]
+            [System.Collections.IDictionary] $Remote,
+
+            [Parameter(Mandatory = $false)]
+            [string] $Path = '$'
+        )
+
+        $keys = @($Base.Keys) + @($Local.Keys) + @($Remote.Keys) |
+            Sort-Object -Unique
+        $result = [ordered]@{}
+
+        foreach ($key in $keys) {
+            $baseExists = $Base.Contains($key)
+            $localExists = $Local.Contains($key)
+            $remoteExists = $Remote.Contains($key)
+            $baseValue = if ($baseExists) { $Base[$key] } else { $null }
+            $localValue = if ($localExists) { $Local[$key] } else { $null }
+            $remoteValue = if ($remoteExists) { $Remote[$key] } else { $null }
+            $childPath = "$Path.$key"
+
+            $localMatchesBase = Test-StateValueEqual -LeftExists $localExists -Left $localValue -RightExists $baseExists -Right $baseValue
+            $remoteMatchesBase = Test-StateValueEqual -LeftExists $remoteExists -Left $remoteValue -RightExists $baseExists -Right $baseValue
+            $localMatchesRemote = Test-StateValueEqual -LeftExists $localExists -Left $localValue -RightExists $remoteExists -Right $remoteValue
+
+            if ($localMatchesBase) {
+                if ($remoteExists) {
+                    $result[$key] = $remoteValue
+                }
+                continue
+            }
+
+            if ($remoteMatchesBase -or $localMatchesRemote) {
+                if ($localExists) {
+                    $result[$key] = $localValue
+                }
+                continue
+            }
+
+            if ($baseExists -and $localExists -and $remoteExists -and
+                $baseValue -is [System.Collections.IDictionary] -and
+                $localValue -is [System.Collections.IDictionary] -and
+                $remoteValue -is [System.Collections.IDictionary]) {
+                $result[$key] = Merge-StateObject -Base $baseValue -Local $localValue -Remote $remoteValue -Path $childPath
+                continue
+            }
+
+            throw "Concurrent package state conflict at '$childPath'. Both writers changed the same value."
+        }
+
+        return $result
+    }
+
+    function Write-StateJson {
+        param(
+            [Parameter(Mandatory = $true)]
+            [System.Collections.IDictionary] $State,
+
+            [Parameter(Mandatory = $true)]
+            [string] $Path
+        )
+
+        $State | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $Path -Encoding utf8 -Force
+    }
+
+    Push-Location -Path $RepoPath
+    $upstreamRef = $null
+    $remoteName = $null
+    $remoteBranch = $null
+
+    try {
+        Clear-InterruptedGitOperation
+
+        $repositoryRoot = (Invoke-StateGit -Arguments @('rev-parse', '--show-toplevel')).Output.Trim()
+        $stateFullPath = if ([IO.Path]::IsPathRooted($StateFilePath)) {
+            [IO.Path]::GetFullPath($StateFilePath)
+        }
+        else {
+            [IO.Path]::GetFullPath((Join-Path (Get-Location).Path $StateFilePath))
+        }
+        $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $stateFullPath).Replace('\', '/')
+        if ($relativePath -eq '..' -or $relativePath.StartsWith('../')) {
+            throw "State file '$stateFullPath' must be inside repository '$repositoryRoot'."
+        }
+        if (-not (Test-Path -LiteralPath $stateFullPath -PathType Leaf)) {
+            throw "Package state file not found: $stateFullPath"
+        }
+
+        $changedPaths = @()
+        $changedPaths += (Invoke-StateGit -Arguments @('diff', '--name-only')).Output -split "`n"
+        $changedPaths += (Invoke-StateGit -Arguments @('diff', '--cached', '--name-only')).Output -split "`n"
+        $otherChangedPaths = @($changedPaths |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) -and $_.Trim() -ne $relativePath } |
+                Sort-Object -Unique)
+        if ($otherChangedPaths.Count -gt 0) {
+            throw "Refusing to reset repository with unrelated tracked changes: $($otherChangedPaths -join ', ')"
+        }
+
+        $baseCommit = (Invoke-StateGit -Arguments @('rev-parse', 'HEAD')).Output.Trim()
+        $baseState = Get-StateAtCommit -Commit $baseCommit -RelativePath $relativePath
+        $localState = Read-StateJson -Content (Get-Content -LiteralPath $stateFullPath -Raw -ErrorAction Stop) -Source $stateFullPath
+        if (Test-StateValueEqual -LeftExists $true -Left $localState -RightExists $true -Right $baseState) {
             Write-Host "No changes to package state file — nothing to commit." -ForegroundColor Yellow
             return
         }
 
-        git commit -m "Update package validation state [skip ci]"
-
-        # Rebase our commit on top of any commits pushed since checkout (e.g. by
-        # orchestrate-gh-packages or a concurrent unrelated push) so that a clean
-        # fast-forward push is always possible.  If a genuine conflict occurs on
-        # package-state.json itself, the rebase will fail loudly here rather than
-        # silently losing data on push.
-        $rebaseResult = git pull --rebase 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "git pull --rebase failed: $rebaseResult"
-            throw "Failed to rebase package state update: $rebaseResult"
+        $branch = (Invoke-StateGit -Arguments @('symbolic-ref', '--quiet', '--short', 'HEAD')).Output.Trim()
+        if ([string]::IsNullOrWhiteSpace($branch)) {
+            throw 'Save-PackageState requires a checked-out branch; detached HEAD is not supported.'
         }
 
-        $pushResult = git push 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Warning "git push failed: $pushResult"
-            throw "Failed to push package state update: $pushResult"
+        $upstreamResult = Invoke-StateGit -Arguments @('rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}') -AllowFailure
+        if ($upstreamResult.ExitCode -eq 0) {
+            $upstreamRef = $upstreamResult.Output.Trim()
+        }
+        else {
+            $upstreamRef = "origin/$branch"
         }
 
-        Write-Host "Package state file committed and pushed successfully." -ForegroundColor Green
+        $separatorIndex = $upstreamRef.IndexOf('/')
+        if ($separatorIndex -le 0 -or $separatorIndex -eq $upstreamRef.Length - 1) {
+            throw "Unsupported upstream ref '$upstreamRef'."
+        }
+        $remoteName = $upstreamRef.Substring(0, $separatorIndex)
+        $remoteBranch = $upstreamRef.Substring($separatorIndex + 1)
+
+        for ($attempt = 1; $attempt -le $MaxPushAttempts; $attempt++) {
+            Write-Host "Saving package state (attempt $attempt of $MaxPushAttempts)..."
+            Invoke-StateGit -Arguments @(
+                'fetch',
+                '--no-tags',
+                $remoteName,
+                "+refs/heads/${remoteBranch}:refs/remotes/${remoteName}/${remoteBranch}"
+            ) | Out-Null
+
+            $remoteCommit = (Invoke-StateGit -Arguments @('rev-parse', $upstreamRef)).Output.Trim()
+            $remoteState = Get-StateAtCommit -Commit $remoteCommit -RelativePath $relativePath
+            $mergedState = Merge-StateObject -Base $baseState -Local $localState -Remote $remoteState
+
+            Invoke-StateGit -Arguments @('reset', '--hard', $remoteCommit) | Out-Null
+            Write-StateJson -State $mergedState -Path $stateFullPath
+
+            if (Test-StateValueEqual -LeftExists $true -Left $mergedState -RightExists $true -Right $remoteState) {
+                Write-Host "Package state changes are already present upstream — nothing to commit." -ForegroundColor Yellow
+                return
+            }
+
+            Invoke-StateGit -Arguments @('add', '--', $relativePath) | Out-Null
+            Invoke-StateGit -Arguments @('commit', '-m', 'Update package validation state [skip ci]', '--', $relativePath) | Out-Null
+
+            $pushResult = Invoke-StateGit -Arguments @(
+                'push',
+                $remoteName,
+                "HEAD:refs/heads/$remoteBranch"
+            ) -AllowFailure
+            if ($pushResult.ExitCode -eq 0) {
+                Write-Host "Package state file committed and pushed successfully." -ForegroundColor Green
+                return
+            }
+
+            $isNonFastForward = $pushResult.Output -match '(?i)non-fast-forward|fetch first|failed to push some refs|\[rejected\]'
+            if (-not $isNonFastForward) {
+                throw "Failed to push package state update: $($pushResult.Output)"
+            }
+            if ($attempt -eq $MaxPushAttempts) {
+                throw "Failed to push package state update after $MaxPushAttempts attempts: $($pushResult.Output)"
+            }
+
+            Write-Warning "Package state push raced with another writer; retrying: $($pushResult.Output)"
+            Start-Sleep -Seconds ([Math]::Min($attempt, 3))
+        }
+    }
+    catch {
+        if ($remoteName -and $remoteBranch -and $upstreamRef) {
+            Invoke-StateGit -Arguments @(
+                'fetch',
+                '--no-tags',
+                $remoteName,
+                "+refs/heads/${remoteBranch}:refs/remotes/${remoteName}/${remoteBranch}"
+            ) -AllowFailure | Out-Null
+            Invoke-StateGit -Arguments @('reset', '--hard', $upstreamRef) -AllowFailure | Out-Null
+        }
+
+        try {
+            Clear-InterruptedGitOperation
+        }
+        catch {
+            Write-Warning $_
+        }
+
+        throw
     }
     finally {
         Pop-Location

--- a/tests/Save-PackageState.Tests.ps1
+++ b/tests/Save-PackageState.Tests.ps1
@@ -1,0 +1,223 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
+
+function Invoke-TestGit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Repository,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $Arguments,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $AllowFailure
+    )
+
+    $output = @(& git -C $Repository @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+    $text = ($output | ForEach-Object { $_.ToString() }) -join "`n"
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "git -C $Repository $($Arguments -join ' ') failed with exit code ${exitCode}: $text"
+    }
+
+    return [pscustomobject]@{ ExitCode = $exitCode; Output = $text }
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object] $Actual,
+
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object] $Expected,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Message
+    )
+
+    if ($Actual -cne $Expected) {
+        throw "$Message Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool] $Condition,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Write-TestState {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary] $State
+    )
+
+    $State | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+function New-StateEntry {
+    param(
+        [string] $State = 'VALIDATION_FAILED',
+        [string] $Description = ''
+    )
+
+    return [ordered]@{
+        version         = '1.0.0'
+        manifestHash    = 'manifest-hash'
+        installerHashes = @('installer-hash')
+        state           = $State
+        validationCount = 1
+        description     = $Description
+        lastUpdated     = '2026-08-04T00:00:00.0000000Z'
+    }
+}
+
+function New-TestRepositories {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Root
+    )
+
+    $remote = Join-Path $Root 'remote.git'
+    $seed = Join-Path $Root 'seed'
+    $writerA = Join-Path $Root 'writer-a'
+    $writerB = Join-Path $Root 'writer-b'
+
+    New-Item -ItemType Directory -Path $Root -Force | Out-Null
+    Invoke-TestGit -Repository $Root -Arguments @('init', '--bare', $remote) | Out-Null
+    Invoke-TestGit -Repository $Root -Arguments @('init', $seed) | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('config', 'user.name', 'State Test') | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('config', 'user.email', 'state-test@example.invalid') | Out-Null
+
+    $statePath = Join-Path $seed 'data/package-state.json'
+    New-Item -ItemType Directory -Path (Split-Path -Parent $statePath) -Force | Out-Null
+    Write-TestState -Path $statePath -State ([ordered]@{
+            'Shared.Package' = New-StateEntry -Description 'base description'
+        })
+    Invoke-TestGit -Repository $seed -Arguments @('add', 'data/package-state.json') | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('commit', '-m', 'Initial state') | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('branch', '-M', 'main') | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('remote', 'add', 'origin', $remote) | Out-Null
+    Invoke-TestGit -Repository $seed -Arguments @('push', '-u', 'origin', 'main') | Out-Null
+
+    Invoke-TestGit -Repository $Root -Arguments @('clone', '--branch', 'main', $remote, $writerA) | Out-Null
+    Invoke-TestGit -Repository $Root -Arguments @('clone', '--branch', 'main', $remote, $writerB) | Out-Null
+    foreach ($writer in @($writerA, $writerB)) {
+        Invoke-TestGit -Repository $writer -Arguments @('config', 'user.name', 'State Test') | Out-Null
+        Invoke-TestGit -Repository $writer -Arguments @('config', 'user.email', 'state-test@example.invalid') | Out-Null
+    }
+
+    return [pscustomobject]@{
+        Remote  = $remote
+        WriterA = $writerA
+        WriterB = $writerB
+    }
+}
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) "Save-PackageState-$([guid]::NewGuid().ToString('N'))"
+
+try {
+    Write-Host 'TEST: divergent writers reproduce a rebase conflict and merge without data loss'
+    $repos = New-TestRepositories -Root (Join-Path $testRoot 'merge')
+    $writerAStatePath = Join-Path $repos.WriterA 'data/package-state.json'
+    $writerBStatePath = Join-Path $repos.WriterB 'data/package-state.json'
+
+    $writerAState = Get-Content -LiteralPath $writerAStatePath -Raw | ConvertFrom-Json -AsHashtable
+    $writerAState['Shared.Package']['description'] = 'description from writer A'
+    $writerAState['WriterA.Package'] = New-StateEntry -Description 'writer A package'
+    Write-TestState -Path $writerAStatePath -State $writerAState
+    Save-PackageState -StateFilePath $writerAStatePath -RepoPath $repos.WriterA
+
+    $writerBState = Get-Content -LiteralPath $writerBStatePath -Raw | ConvertFrom-Json -AsHashtable
+    $writerBState['Shared.Package']['state'] = 'VALIDATION_PASSED'
+    $writerBState['WriterB.Package'] = New-StateEntry -State 'VALIDATION_PASSED' -Description 'writer B package'
+    Write-TestState -Path $writerBStatePath -State $writerBState
+
+    Invoke-TestGit -Repository $repos.WriterB -Arguments @('add', 'data/package-state.json') | Out-Null
+    Invoke-TestGit -Repository $repos.WriterB -Arguments @('commit', '-m', 'Divergent state update') | Out-Null
+    $rebaseResult = Invoke-TestGit -Repository $repos.WriterB -Arguments @('pull', '--rebase') -AllowFailure
+    Assert-True -Condition ($rebaseResult.ExitCode -ne 0) -Message 'The divergent whole-file update should reproduce the original rebase failure.'
+    Assert-True -Condition ($rebaseResult.Output -match 'CONFLICT') -Message 'The reproduced rebase failure should be a content conflict.'
+    Invoke-TestGit -Repository $repos.WriterB -Arguments @('rebase', '--abort') | Out-Null
+    Invoke-TestGit -Repository $repos.WriterB -Arguments @('reset', '--mixed', 'HEAD~1') | Out-Null
+
+    Save-PackageState -StateFilePath 'data/package-state.json' -RepoPath $repos.WriterB
+
+    $verificationClone = Join-Path $testRoot 'verification'
+    Invoke-TestGit -Repository $testRoot -Arguments @('clone', '--branch', 'main', $repos.Remote, $verificationClone) | Out-Null
+    $mergedState = Get-Content -LiteralPath (Join-Path $verificationClone 'data/package-state.json') -Raw |
+        ConvertFrom-Json -AsHashtable
+    Assert-True -Condition $mergedState.ContainsKey('WriterA.Package') -Message 'Writer A package entry was lost.'
+    Assert-True -Condition $mergedState.ContainsKey('WriterB.Package') -Message 'Writer B package entry was lost.'
+    Assert-Equal -Actual $mergedState['Shared.Package']['description'] -Expected 'description from writer A' -Message 'Writer A field update was lost.'
+    Assert-Equal -Actual $mergedState['Shared.Package']['state'] -Expected 'VALIDATION_PASSED' -Message 'Writer B field update was lost.'
+
+    Write-Host 'TEST: retry exhaustion fails loudly and leaves a clean repository'
+    $retryRepos = New-TestRepositories -Root (Join-Path $testRoot 'retry')
+    $retryStatePath = Join-Path $retryRepos.WriterB 'data/package-state.json'
+    $retryState = Get-Content -LiteralPath $retryStatePath -Raw | ConvertFrom-Json -AsHashtable
+    $retryState['Retry.Package'] = New-StateEntry -Description 'must not be silently dropped'
+    Write-TestState -Path $retryStatePath -State $retryState
+
+    $counterPath = Join-Path $testRoot 'push-attempts.txt'
+    $counterShellPath = $counterPath.Replace('\', '/')
+    $hookPath = Join-Path $retryRepos.Remote 'hooks/pre-receive'
+    @"
+#!/bin/sh
+echo attempt >> "$counterShellPath"
+echo "non-fast-forward race injected by test" >&2
+exit 1
+"@ | Set-Content -LiteralPath $hookPath -Encoding utf8NoBOM
+    if (-not $IsWindows) {
+        $mode = [IO.File]::GetUnixFileMode($hookPath)
+        [IO.File]::SetUnixFileMode(
+            $hookPath,
+            $mode -bor [IO.UnixFileMode]::UserExecute -bor
+                [IO.UnixFileMode]::GroupExecute -bor
+                [IO.UnixFileMode]::OtherExecute)
+    }
+
+    $caught = $null
+    try {
+        Save-PackageState -StateFilePath $retryStatePath -RepoPath $retryRepos.WriterB -MaxPushAttempts 2
+    }
+    catch {
+        $caught = $_
+    }
+
+    Assert-True -Condition ($null -ne $caught) -Message 'Retry exhaustion should throw.'
+    Assert-True -Condition ($caught.Exception.Message -match 'after 2 attempts') -Message 'Retry exhaustion should report the bounded attempt count.'
+    Assert-Equal -Actual @((Get-Content -LiteralPath $counterPath)).Count -Expected 2 -Message 'Push should be attempted exactly twice.'
+    Assert-Equal -Actual (Invoke-TestGit -Repository $retryRepos.WriterB -Arguments @('status', '--porcelain')).Output -Expected '' -Message 'Repository should be clean after retry exhaustion.'
+
+    $gitDirectory = (Invoke-TestGit -Repository $retryRepos.WriterB -Arguments @('rev-parse', '--git-dir')).Output
+    if (-not [IO.Path]::IsPathRooted($gitDirectory)) {
+        $gitDirectory = Join-Path $retryRepos.WriterB $gitDirectory
+    }
+    foreach ($operationPath in @('rebase-merge', 'rebase-apply', 'MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD')) {
+        Assert-True -Condition (-not (Test-Path (Join-Path $gitDirectory $operationPath))) -Message "Interrupted git operation remains at $operationPath."
+    }
+
+    Write-Host 'All Save-PackageState regression tests passed.' -ForegroundColor Green
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- replace whole-file `git pull --rebase` persistence with a three-way JSON merge against the checkout base and latest upstream state
- retain independent concurrent package entries and fields, reject true same-value conflicts, and retry non-fast-forward push races boundedly
- clean interrupted Git operations and restore a clean upstream worktree on failure
- add real Git repository regression tests on Windows and Linux CI

## Root cause
Workflow-run checkouts remain pinned to their trigger SHA. Job-level `package-state-write` concurrency serializes the writers, but later jobs still start from stale package-state content. Committing the complete JSON file and rebasing it onto a previous writer therefore creates a textual conflict even when the package updates are logically independent.

## Validation
- `pwsh -NoLogo -NoProfile -File .\\tests\\Save-PackageState.Tests.ps1`
- regression reproduces the old divergent whole-file rebase conflict, then verifies both package entries and independent fields survive
- retry-exhaustion regression verifies the bounded attempt count and clean Git state