### PR TITLE
Fix duplicate WinMatsch installer URL arguments

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -34,4 +34,6 @@ jobs:
 
       - name: Run regression tests
         shell: pwsh
-        run: ./tests/Save-PackageState.Tests.ps1
+        run: |
+          ./tests/Save-PackageState.Tests.ps1
+          ./tests/Update-WingetPackage.Tests.ps1

--- a/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
@@ -46,6 +46,26 @@ function Get-InstallerUrlEntries {
     }
 }
 
+function Get-WinMatschInstallerUrlArguments {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$InstallerEntries
+    )
+
+    foreach ($installerEntry in $InstallerEntries) {
+        if ($installerEntry.ArchitectureHint) {
+            '--url'
+            $installerEntry.OriginalValue
+        }
+        else {
+            '--urls'
+            $installerEntry.InstallerUrl
+        }
+    }
+}
+
 function Get-InstallerManifestEntries {
     [CmdletBinding(DefaultParameterSetName = 'Path')]
     param(

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -187,17 +187,7 @@ function Update-WingetPackage {
                         $wingetPackage
                         "--version", $Latest.Version
                     )
-                    foreach ($RequestedUrl in $RequestedInstallerUrls) {
-                        $winmatschArgs += "--urls"
-                        $winmatschArgs += $RequestedUrl
-                    }
-                    # Installer hints are supported natively via --url overrides.
-                    foreach ($RequestedEntry in $RequestedInstallerEntries) {
-                        if ($RequestedEntry.ArchitectureHint) {
-                            $winmatschArgs += "--url"
-                            $winmatschArgs += $RequestedEntry.OriginalValue
-                        }
-                    }
+                    $winmatschArgs += Get-WinMatschInstallerUrlArguments -InstallerEntries $RequestedInstallerEntries
                     if ($resolves -match '^\d+$') {
                         $winmatschArgs += "--resolves"
                         $winmatschArgs += $resolves

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -1,0 +1,149 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+
+function Assert-SequenceEqual {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Actual,
+
+        [Parameter(Mandatory = $true)]
+        [object[]]$Expected,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    $actualJson = ConvertTo-Json @($Actual) -Compress
+    $expectedJson = ConvertTo-Json @($Expected) -Compress
+    if ($actualJson -cne $expectedJson) {
+        throw "$Message Expected $expectedJson, got $actualJson."
+    }
+}
+
+function Get-TestWinMatschUrlArguments {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$InstallerValues
+    )
+
+    return @(& $module {
+            param([string[]]$Values)
+
+            $entries = @(Get-InstallerUrlEntries -InstallerValues $Values)
+            Get-WinMatschInstallerUrlArguments -InstallerEntries $entries
+        } $InstallerValues)
+}
+
+function Invoke-TestUpdateWingetPackage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallerValue
+    )
+
+    return @(& $module {
+            param([string]$Value)
+
+            function Test-GitHubToken { 'test-token' }
+            function Test-PackageAndVersionInGithub {
+                [PSCustomObject]@{
+                    PackageExists         = $true
+                    ShouldGenerate        = $true
+                    VersionExists         = $false
+                    CanonicalVersion      = '1.0.0'
+                    PublishedVersion      = $null
+                    LatestPublishedVersion = $null
+                }
+            }
+            function Test-ExistingPRs { $false }
+            function Install-WinMatsch {}
+            function Test-GeneratedInstallerArchitecture {}
+            function winmatsch {
+                $script:CapturedWinMatschArguments = @($args)
+                $global:LASTEXITCODE = 0
+            }
+
+            $script:CapturedWinMatschArguments = @()
+            Update-WingetPackage `
+                -WingetPackage 'Test.Package' `
+                -With 'WinMatsch' `
+                -latestVersion '1.0.0' `
+                -latestVersionURL $Value | Out-Null
+
+            $script:CapturedWinMatschArguments
+        } $InstallerValue)
+}
+
+Write-Host 'TEST: plain URL is passed only through --urls'
+$plainUrl = 'https://example.invalid/app.zip'
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $plainUrl) `
+    -Expected @('--urls', $plainUrl) `
+    -Message 'Plain URL arguments were incorrect.'
+
+Write-Host 'TEST: multiple plain URLs are each passed only through --urls'
+$plainUrls = @(
+    'https://example.invalid/app-x64.zip'
+    'https://example.invalid/app-arm64.zip'
+)
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $plainUrls) `
+    -Expected @('--urls', $plainUrls[0], '--urls', $plainUrls[1]) `
+    -Message 'Multiple plain URL arguments were incorrect.'
+
+Write-Host 'TEST: architecture-qualified URL is passed only through --url'
+$architectureUrl = 'https://github.com/sunfish-shogi/shogihome/releases/download/v1.0.0/release-v1.0.0-win.zip|x86'
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $architectureUrl) `
+    -Expected @('--url', $architectureUrl) `
+    -Message 'Architecture-qualified URL arguments were incorrect.'
+
+Write-Host 'TEST: F95Checker neutral URL is not passed a second time as a plain URL'
+$f95CheckerUrl = 'https://github.com/Willy-JL/F95Checker/releases/download/12.0.0/F95Checker-Windows.zip|neutral'
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $f95CheckerUrl) `
+    -Expected @('--url', $f95CheckerUrl) `
+    -Message 'F95Checker URL arguments were incorrect.'
+
+Write-Host 'TEST: scoped URL is passed only through --url'
+$scopedUrl = 'https://example.invalid/app.zip|neutral|machine'
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $scopedUrl) `
+    -Expected @('--url', $scopedUrl) `
+    -Message 'Scoped URL arguments were incorrect.'
+
+Write-Host 'TEST: mixed URL list passes every installer exactly once'
+$mixedUrls = @(
+    'https://example.invalid/plain-x64.zip'
+    'https://example.invalid/qualified-x86.zip|x86'
+    'https://example.invalid/plain-arm64.zip'
+    'https://example.invalid/qualified-neutral.zip|neutral|user'
+)
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $mixedUrls) `
+    -Expected @(
+        '--urls', $mixedUrls[0]
+        '--url', $mixedUrls[1]
+        '--urls', $mixedUrls[2]
+        '--url', $mixedUrls[3]
+    ) `
+    -Message 'Mixed URL arguments were incorrect.'
+
+Write-Host 'TEST: Update-WingetPackage sends the production-shaped URL only once'
+$updateArguments = Invoke-TestUpdateWingetPackage -InstallerValue $f95CheckerUrl
+$updateUrlArguments = [System.Collections.Generic.List[string]]::new()
+for ($index = 0; $index -lt $updateArguments.Count; $index++) {
+    if ($updateArguments[$index] -in @('--url', '--urls')) {
+        $updateUrlArguments.Add($updateArguments[$index])
+        $updateUrlArguments.Add($updateArguments[$index + 1])
+        $index++
+    }
+}
+Assert-SequenceEqual `
+    -Actual $updateUrlArguments `
+    -Expected @('--url', $f95CheckerUrl) `
+    -Message 'Update-WingetPackage duplicated the F95Checker URL.'
+
+Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

- partition parsed installer entries before composing WinMatsch arguments
- pass plain URLs only as `--urls <url>`
- pass architecture/scope-qualified specs only as `--url <original spec>`
- add regression coverage for plain, multiple plain, `url|arch`, `url|arch|scope`, mixed lists, sunfish-shogi.shogihome, and WillyJL.F95Checker

## Production failure

This fixes the `Generate WillyJL.F95Checker` job in [run 30991425675](https://github.com/b0t-at/winget-pkgs-updates/actions/runs/30991425675), where `F95Checker-Windows.zip|neutral` was sent once as a plain `--urls` value and again as a qualified `--url` override. WinMatsch consequently failed with exit 4 and `MAP_DUPLICATE_INSTALLER_KEY` / `MAP_AMBIGUOUS` for effective key `Neutral|Zip||`.

## Exact behavior change

Before:

```text
--urls https://.../F95Checker-Windows.zip
--url  https://.../F95Checker-Windows.zip|neutral
```

After:

```text
--url https://.../F95Checker-Windows.zip|neutral
```

Plain URLs remain `--urls <url>`, and mixed lists preserve their original order while emitting each requested installer exactly once. Komac, WinGetCreate, retry, single-update, and submit paths were inspected; no other path duplicated URL representations.

## Test evidence

- `pwsh -NoLogo -NoProfile -File .\tests\Save-PackageState.Tests.ps1` — passed
- `pwsh -NoLogo -NoProfile -File .\tests\Update-WingetPackage.Tests.ps1` — passed
- PowerShell parser check across module and test scripts — passed
- `actionlint .github\workflows\module-tests.yml` — passed
- `git diff --check` — passed

Local repository-wide lint also surfaces pre-existing unrelated findings: four matrix-property errors in the generated update workflows from `actionlint`, and the existing low-confidence `artipacked` finding on the module-test checkout from `zizmor`. This PR does not alter those areas.