### PR TITLE
Add PR link and failed-generation table to job summaries, fix ARP diff

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -82,6 +82,45 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record generation failure
+        if: failure()
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.id }}
+          MATRIX_PACKAGENAME: ${{ matrix.id }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./generate-failure | Out-Null
+
+          $errorText = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          if ([string]::IsNullOrWhiteSpace($errorText)) {
+            $errorText = "Generation failed before the manifest generator reported a result - see job log."
+          }
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            error     = $errorText
+          } | ConvertTo-Json | Out-File -FilePath ./generate-failure/failure.json -Encoding utf8
+
+          Get-Content -Path ./generate-failure/failure.json
+
+      - name: Upload generation failure marker
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: generate-failure__${{ matrix.id }}
+          path: ./generate-failure
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Job 2: Collect successful manifest generations into a dynamic matrix
   collect-generated:
     name: Collect Generated Manifests
@@ -124,6 +163,53 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8 -Value "has_packages=$hasPackages"
           Write-Host "Matrix: $matrix"
           Write-Host "Has packages: $hasPackages"
+
+      - name: Download generation failure markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: generate-failure__*
+          path: ./generate-failures
+
+      - name: Summarize failed generations
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./generate-failures -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No generation failures recorded."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :x: Failed generations ($($rows.Count))"
+            ""
+            "| Failed Job | Package | Version | Exit Code | Error |"
+            "| --- | --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.job, $row.package, $row.version, $row.exitCode, $row.error) | ForEach-Object {
+              # Collapse to a single line and escape pipes so the markdown table stays intact.
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) failed generation(s) in the job summary."
 
   # Job 3: Validate and test manifests in sandbox (self-hosted runner with Windows Sandbox)
   # Uses dynamic matrix - only runs for packages that generated manifests
@@ -596,10 +682,21 @@ jobs:
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green
             # Add to job summary
-            "## :rocket: PR Submitted" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Package:** $env:MATRIX_PACKAGENAME" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Version:** $env:MATRIX_VERSION" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            $summary = @(
+              "## :rocket: PR Submitted"
+              ""
+              "**Package:** $env:MATRIX_PACKAGENAME"
+              "**Version:** $env:MATRIX_VERSION"
+            )
+
+            if ($result.PrUrl) {
+              $prLabel = if ($result.PrNumber) { "#$($result.PrNumber)" } else { $result.PrUrl }
+              $summary += "**Pull request:** [$prLabel]($($result.PrUrl))"
+            } else {
+              $summary += "**Pull request:** _URL could not be determined - see step log._"
+            }
+
+            ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -823,6 +823,45 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record generation failure
+        if: failure()
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.id }}
+          MATRIX_PACKAGENAME: ${{ matrix.id }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./generate-failure | Out-Null
+
+          $errorText = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          if ([string]::IsNullOrWhiteSpace($errorText)) {
+            $errorText = "Generation failed before the manifest generator reported a result - see job log."
+          }
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            error     = $errorText
+          } | ConvertTo-Json | Out-File -FilePath ./generate-failure/failure.json -Encoding utf8
+
+          Get-Content -Path ./generate-failure/failure.json
+
+      - name: Upload generation failure marker
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: generate-failure__${{ matrix.id }}
+          path: ./generate-failure
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Job 2: Collect successful manifest generations into a dynamic matrix
   collect-generated:
     name: Collect Generated Manifests
@@ -865,6 +904,53 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8 -Value "has_packages=$hasPackages"
           Write-Host "Matrix: $matrix"
           Write-Host "Has packages: $hasPackages"
+
+      - name: Download generation failure markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: generate-failure__*
+          path: ./generate-failures
+
+      - name: Summarize failed generations
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./generate-failures -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No generation failures recorded."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :x: Failed generations ($($rows.Count))"
+            ""
+            "| Failed Job | Package | Version | Exit Code | Error |"
+            "| --- | --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.job, $row.package, $row.version, $row.exitCode, $row.error) | ForEach-Object {
+              # Collapse to a single line and escape pipes so the markdown table stays intact.
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) failed generation(s) in the job summary."
 
   # Job 3: Validate and test manifests in sandbox (self-hosted runner with Windows Sandbox)
   # Uses dynamic matrix - only runs for packages that generated manifests
@@ -1337,10 +1423,21 @@ jobs:
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green
             # Add to job summary
-            "## :rocket: PR Submitted" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Package:** $env:MATRIX_PACKAGENAME" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Version:** $env:MATRIX_VERSION" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            $summary = @(
+              "## :rocket: PR Submitted"
+              ""
+              "**Package:** $env:MATRIX_PACKAGENAME"
+              "**Version:** $env:MATRIX_VERSION"
+            )
+
+            if ($result.PrUrl) {
+              $prLabel = if ($result.PrNumber) { "#$($result.PrNumber)" } else { $result.PrUrl }
+              $summary += "**Pull request:** [$prLabel]($($result.PrUrl))"
+            } else {
+              $summary += "**Pull request:** _URL could not be determined - see step log._"
+            }
+
+            ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -412,6 +412,45 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record generation failure
+        if: failure()
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.id }}
+          MATRIX_PACKAGENAME: ${{ matrix.id }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./generate-failure | Out-Null
+
+          $errorText = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          if ([string]::IsNullOrWhiteSpace($errorText)) {
+            $errorText = "Generation failed before the manifest generator reported a result - see job log."
+          }
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            error     = $errorText
+          } | ConvertTo-Json | Out-File -FilePath ./generate-failure/failure.json -Encoding utf8
+
+          Get-Content -Path ./generate-failure/failure.json
+
+      - name: Upload generation failure marker
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: generate-failure__${{ matrix.id }}
+          path: ./generate-failure
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Job 2: Collect successful manifest generations into a dynamic matrix
   collect-generated:
     name: Collect Generated Manifests
@@ -454,6 +493,53 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8 -Value "has_packages=$hasPackages"
           Write-Host "Matrix: $matrix"
           Write-Host "Has packages: $hasPackages"
+
+      - name: Download generation failure markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: generate-failure__*
+          path: ./generate-failures
+
+      - name: Summarize failed generations
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./generate-failures -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No generation failures recorded."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :x: Failed generations ($($rows.Count))"
+            ""
+            "| Failed Job | Package | Version | Exit Code | Error |"
+            "| --- | --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.job, $row.package, $row.version, $row.exitCode, $row.error) | ForEach-Object {
+              # Collapse to a single line and escape pipes so the markdown table stays intact.
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) failed generation(s) in the job summary."
 
   # Job 3: Validate and test manifests in sandbox (self-hosted runner with Windows Sandbox)
   # Uses dynamic matrix - only runs for packages that generated manifests
@@ -926,10 +1012,21 @@ jobs:
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green
             # Add to job summary
-            "## :rocket: PR Submitted" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Package:** $env:MATRIX_PACKAGENAME" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Version:** $env:MATRIX_VERSION" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            $summary = @(
+              "## :rocket: PR Submitted"
+              ""
+              "**Package:** $env:MATRIX_PACKAGENAME"
+              "**Version:** $env:MATRIX_VERSION"
+            )
+
+            if ($result.PrUrl) {
+              $prLabel = if ($result.PrNumber) { "#$($result.PrNumber)" } else { $result.PrUrl }
+              $summary += "**Pull request:** [$prLabel]($($result.PrUrl))"
+            } else {
+              $summary += "**Pull request:** _URL could not be determined - see step log._"
+            }
+
+            ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -122,6 +122,45 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record generation failure
+        if: failure()
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.PackageName }}
+          MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./generate-failure | Out-Null
+
+          $errorText = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          if ([string]::IsNullOrWhiteSpace($errorText)) {
+            $errorText = "Generation failed before the manifest generator reported a result - see job log."
+          }
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            error     = $errorText
+          } | ConvertTo-Json | Out-File -FilePath ./generate-failure/failure.json -Encoding utf8
+
+          Get-Content -Path ./generate-failure/failure.json
+
+      - name: Upload generation failure marker
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: generate-failure__${{ matrix.PackageName }}
+          path: ./generate-failure
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Job 2: Collect successful manifest generations into a dynamic matrix
   collect-generated:
     name: Collect Generated Manifests
@@ -164,6 +203,53 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8 -Value "has_packages=$hasPackages"
           Write-Host "Matrix: $matrix"
           Write-Host "Has packages: $hasPackages"
+
+      - name: Download generation failure markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: generate-failure__*
+          path: ./generate-failures
+
+      - name: Summarize failed generations
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./generate-failures -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No generation failures recorded."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :x: Failed generations ($($rows.Count))"
+            ""
+            "| Failed Job | Package | Version | Exit Code | Error |"
+            "| --- | --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.job, $row.package, $row.version, $row.exitCode, $row.error) | ForEach-Object {
+              # Collapse to a single line and escape pipes so the markdown table stays intact.
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) failed generation(s) in the job summary."
 
   # Job 3: Validate and test manifests in sandbox (self-hosted runner with Windows Sandbox)
   # Uses dynamic matrix - only runs for packages that generated manifests
@@ -637,10 +723,21 @@ jobs:
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green
             # Add to job summary
-            "## :rocket: PR Submitted" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Package:** $env:MATRIX_PACKAGENAME" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
-            "**Version:** $env:MATRIX_VERSION" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+            $summary = @(
+              "## :rocket: PR Submitted"
+              ""
+              "**Package:** $env:MATRIX_PACKAGENAME"
+              "**Version:** $env:MATRIX_VERSION"
+            )
+
+            if ($result.PrUrl) {
+              $prLabel = if ($result.PrNumber) { "#$($result.PrNumber)" } else { $result.PrUrl }
+              $summary += "**Pull request:** [$prLabel]($($result.PrUrl))"
+            } else {
+              $summary += "**Pull request:** _URL could not be determined - see step log._"
+            }
+
+            ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/modules/WingetMaintainerModule/Private/Get-GeneratorFailureMessage.ps1
+++ b/modules/WingetMaintainerModule/Private/Get-GeneratorFailureMessage.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Picks the most useful single-line error message out of a manifest generator's output.
+
+.DESCRIPTION
+    WinMatsch, Komac and WinGetCreate report failures as free-form console text, so the
+    only signal available to the workflow today is the exit code plus whatever the tool
+    printed. This helper reduces that output to one short, table-friendly line for the
+    job summary: it strips ANSI colour codes, then prefers the first line the tool itself
+    flagged as an error and falls back to the last non-empty line.
+
+    This is deliberately format-agnostic - it makes no assumption about a specific error
+    grammar - and becomes redundant as soon as a generator emits a machine-readable result.
+
+.PARAMETER GeneratorOutput
+    The captured stdout/stderr of the generator.
+
+.PARAMETER MaxLength
+    Maximum length of the returned message before it is truncated.
+
+.OUTPUTS
+    System.String - a single-line error message, or $null when nothing usable was printed.
+#>
+function Get-GeneratorFailureMessage {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object] $GeneratorOutput,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(20, 2000)]
+        [int] $MaxLength = 300
+    )
+
+    if ($null -eq $GeneratorOutput) {
+        return $null
+    }
+
+    $lines = @(
+        ($GeneratorOutput | Out-String) -split '\r?\n' |
+            ForEach-Object { ($_ -replace '\x1b\[[0-9;]*[A-Za-z]', '').Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+
+    if ($lines.Count -eq 0) {
+        return $null
+    }
+
+    $flagged = $lines | Where-Object { $_ -match '(?i)\b(error|failed|failure|fatal)\b' } | Select-Object -First 1
+    $message = if ($flagged) { $flagged } else { $lines[-1] }
+
+    if ($message.Length -gt $MaxLength) {
+        $message = $message.Substring(0, $MaxLength - 1) + [char]0x2026
+    }
+
+    return $message
+}

--- a/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
+++ b/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Resolves the winget-pkgs pull request URL for a package that was just submitted.
+
+.DESCRIPTION
+    WinMatsch, Komac and WinGetCreate all print the created pull request URL to
+    stdout on success, but each uses a different wording. This helper first scans
+    the captured tool output for a GitHub pull request URL. If none is found (for
+    example because the tool changed its output format or the URL was swallowed by
+    ANSI formatting), it falls back to querying GitHub for the most recently opened
+    pull request whose title matches the package and version.
+
+.PARAMETER SubmitOutput
+    The captured stdout/stderr of the submission tool.
+
+.PARAMETER PackageId
+    The package identifier, used by the GitHub CLI fallback lookup.
+
+.PARAMETER Version
+    The package version, used by the GitHub CLI fallback lookup.
+
+.OUTPUTS
+    System.String - the pull request URL, or $null when it could not be determined.
+#>
+function Get-WingetPkgsPrUrl {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [object] $SubmitOutput,
+
+        [Parameter(Mandatory = $false)]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Version
+    )
+
+    # Preferred source: the submission tool printed the URL itself.
+    if ($null -ne $SubmitOutput) {
+        $outputText = ($SubmitOutput | Out-String)
+        $urlMatches = [regex]::Matches(
+            $outputText,
+            'https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/\d+'
+        )
+
+        if ($urlMatches.Count -gt 0) {
+            # The newly created PR is the last one mentioned; earlier hits are
+            # typically references to related/duplicate pull requests.
+            $prUrl = $urlMatches[$urlMatches.Count - 1].Value
+            Write-Verbose "Resolved PR URL from submission output: $prUrl"
+            return $prUrl
+        }
+    }
+
+    Write-Verbose "No PR URL found in submission output, falling back to GitHub CLI lookup."
+
+    if ([string]::IsNullOrWhiteSpace($PackageId) -or [string]::IsNullOrWhiteSpace($Version)) {
+        return $null
+    }
+
+    if (-not (Get-Command -Name gh -ErrorAction SilentlyContinue)) {
+        Write-Verbose "GitHub CLI not available, cannot resolve PR URL."
+        return $null
+    }
+
+    try {
+        $json = gh pr list `
+            --search "$PackageId $Version in:title" `
+            --state 'open' `
+            --limit 10 `
+            --json 'url,createdAt' `
+            --repo 'microsoft/winget-pkgs' 2>$null
+
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
+            return $null
+        }
+
+        $pullRequests = @($json | ConvertFrom-Json)
+        if ($pullRequests.Count -eq 0) {
+            return $null
+        }
+
+        $newest = $pullRequests |
+            Sort-Object -Property { [datetime] $_.createdAt } -Descending |
+            Select-Object -First 1
+
+        Write-Verbose "Resolved PR URL via GitHub CLI: $($newest.url)"
+        return $newest.url
+    }
+    catch {
+        Write-Verbose "Could not resolve PR URL via GitHub CLI: $($_.Exception.Message)"
+        return $null
+    }
+}

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -42,6 +42,8 @@
     PSCustomObject with properties:
     - Success: Boolean indicating if PR was created
     - Error: Error message (if failed)
+    - PrUrl: URL of the created pull request ($null if it could not be determined)
+    - PrNumber: Number of the created pull request ($null if it could not be determined)
 #>
 
 function Submit-WingetPackage {
@@ -89,8 +91,10 @@ function Submit-WingetPackage {
 
     if ([string]::IsNullOrWhiteSpace($Token)) {
         return @{
-            Success = $false
-            Error   = "No GitHub token provided. Set GITHUB_TOKEN or WINGET_PAT environment variable."
+            Success  = $false
+            Error    = "No GitHub token provided. Set GITHUB_TOKEN or WINGET_PAT environment variable."
+            PrUrl    = $null
+            PrNumber = $null
         }
     }
 
@@ -141,8 +145,10 @@ function Submit-WingetPackage {
 
                 if ($exitCode -ne 0) {
                     return @{
-                        Success = $false
-                        Error   = "WinMatsch submit failed with exit code $exitCode. Output: $output"
+                        Success  = $false
+                        Error    = "WinMatsch submit failed with exit code $exitCode. Output: $output"
+                        PrUrl    = $null
+                        PrNumber = $null
                     }
                 }
             }
@@ -174,8 +180,10 @@ function Submit-WingetPackage {
 
                 if ($exitCode -ne 0) {
                     return @{
-                        Success = $false
-                        Error   = "Komac submit failed with exit code $exitCode. Output: $output"
+                        Success  = $false
+                        Error    = "Komac submit failed with exit code $exitCode. Output: $output"
+                        PrUrl    = $null
+                        PrNumber = $null
                     }
                 }
             }
@@ -193,8 +201,10 @@ function Submit-WingetPackage {
 
                 if ($exitCode -ne 0) {
                     return @{
-                        Success = $false
-                        Error   = "WinGetCreate submit failed with exit code $exitCode. Output: $output"
+                        Success  = $false
+                        Error    = "WinGetCreate submit failed with exit code $exitCode. Output: $output"
+                        PrUrl    = $null
+                        PrNumber = $null
                     }
                 }
             }
@@ -203,9 +213,24 @@ function Submit-WingetPackage {
         Write-Host ""
         Write-Host "PR submitted successfully!" -ForegroundColor Green
 
+        $prUrl = Get-WingetPkgsPrUrl -SubmitOutput $output -PackageId $PackageId -Version $Version
+        $prNumber = $null
+
+        if ($prUrl) {
+            if ($prUrl -match '/pull/(?<Number>\d+)$') {
+                $prNumber = $Matches['Number']
+            }
+            Write-Host "PR URL:   $prUrl" -ForegroundColor Cyan
+        }
+        else {
+            Write-Warning "PR was created but its URL could not be determined."
+        }
+
         return @{
-            Success = $true
-            Error   = $null
+            Success  = $true
+            Error    = $null
+            PrUrl    = $prUrl
+            PrNumber = $prNumber
         }
     }
     catch {
@@ -213,8 +238,10 @@ function Submit-WingetPackage {
         Write-Host "ERROR: $errorMessage" -ForegroundColor Red
 
         return @{
-            Success = $false
-            Error   = $errorMessage
+            Success  = $false
+            Error    = $errorMessage
+            PrUrl    = $null
+            PrNumber = $null
         }
     }
 }

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -203,7 +203,7 @@ function Update-WingetPackage {
 
                     $displayArgs = $winmatschArgs | ForEach-Object { if ($_ -eq $gitToken) { '***' } else { $_ } }
                     Write-Host "Running: winmatsch $($displayArgs -join ' ')"
-                    & winmatsch @winmatschArgs
+                    & winmatsch @winmatschArgs 2>&1 | Tee-Object -Variable generatorOutput | Out-Host
                 }
                 "Komac" {
                     Install-Komac
@@ -227,7 +227,7 @@ function Update-WingetPackage {
 
                     $displayArgs = $komacArgs | ForEach-Object { if ($_ -eq $gitToken) { '***' } else { $_ } }
                     Write-Host "Running: komac $($displayArgs -join ' ')"
-                    & komac @komacArgs
+                    & komac @komacArgs 2>&1 | Tee-Object -Variable generatorOutput | Out-Host
                 }
                 "WinGetCreate" {
                     if ($GHRepo -and $versionTag -and !$Latest.ReleaseNotes) {
@@ -235,7 +235,8 @@ function Update-WingetPackage {
                     }
                     Install-WingetCreate
                     # Always generate locally (no -s flag)
-                    .\wingetcreate.exe update $wingetPackage -v $Latest.Version -u $RequestedInstallerValues --prtitle $prMessage -t $gitToken -o $ManifestOutPath
+                    .\wingetcreate.exe update $wingetPackage -v $Latest.Version -u $RequestedInstallerValues --prtitle $prMessage -t $gitToken -o $ManifestOutPath 2>&1 |
+                        Tee-Object -Variable generatorOutput | Out-Host
                 }
                 default {
                     Write-Error "Invalid value \"$EffectiveWith\" for -With parameter. Valid values are 'WinMatsch', 'Komac' and 'WinGetCreate'"
@@ -243,7 +244,22 @@ function Update-WingetPackage {
             }
 
             if ($LASTEXITCODE -ne 0) {
-                throw "$EffectiveWith update failed for $wingetPackage $($Latest.Version) with exit code $LASTEXITCODE"
+                $generatorExitCode = $LASTEXITCODE
+                $generatorError = Get-GeneratorFailureMessage -GeneratorOutput $generatorOutput
+                $result.Reason = "GeneratorFailed"
+
+                # Surface the failure details so the workflow can render them in the run summary.
+                if ($env:GITHUB_OUTPUT) {
+                    "generated=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "reason=GeneratorFailed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "package-id=$wingetPackage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "version=$($Latest.Version)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "generator=$EffectiveWith" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "generator-exit-code=$generatorExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    "error=$generatorError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                }
+
+                throw "$EffectiveWith update failed for $wingetPackage $($Latest.Version) with exit code $generatorExitCode. $generatorError"
             }
 
             Test-GeneratedInstallerArchitecture -PackageIdentifier $wingetPackage -CurrentVersion $Latest.Version -ManifestOutPath $ManifestOutPath -RequestedInstallerValues $RequestedInstallerValues -PreviousVersion $latestPublishedVersion

--- a/scripts/validation/Test-Manifest-Host.ps1
+++ b/scripts/validation/Test-Manifest-Host.ps1
@@ -182,7 +182,10 @@ if (-Not [String]::IsNullOrWhiteSpace($Manifest)) {
     Write-Host "--> Refreshing environment variables"
     Update-EnvironmentVariables
     Write-Host "--> Comparing ARP Entries"
-    $arpDiff = (Compare-Object (Get-ARPTable) $originalARP -Property DisplayName, DisplayVersion, Publisher, ProductCode, Scope) | Select-Object -Property * -ExcludeProperty SideIndicator
+    # @() guards against a null table (a clean machine can report zero ARP entries, which
+    # makes Compare-Object throw); '<=' keeps only entries the install actually added.
+    $arpDiff = @(Compare-Object @(Get-ARPTable) @($originalARP) -Property DisplayName, DisplayVersion, Publisher, ProductCode, Scope |
+        Where-Object { $_.SideIndicator -eq '<=' } | Select-Object -Property * -ExcludeProperty SideIndicator)
     $arpDiff | Format-Table
 }
 

--- a/scripts/validation/Test-Manifest-Sandbox.ps1
+++ b/scripts/validation/Test-Manifest-Sandbox.ps1
@@ -758,7 +758,10 @@ if (`$manifestFolder) {
     `$newARP | Export-Csv -Path (Join-Path `$LogsFolder 'ARP_After.csv') -NoTypeInformation
     `$newARP | ConvertTo-Json | Out-File -FilePath (Join-Path `$LogsFolder 'ARP_After.json') -Encoding utf8
     
-    `$arpDifference = Compare-Object `$newARP `$originalARP -Property DisplayName,DisplayVersion,Publisher,ProductCode,Scope | Select-Object -Property * -ExcludeProperty SideIndicator
+    # @() guards against a null table (a clean sandbox can report zero ARP entries, which
+    # makes Compare-Object throw); '<=' keeps only entries the install actually added.
+    `$arpDifference = Compare-Object @(`$newARP) @(`$originalARP) -Property DisplayName,DisplayVersion,Publisher,ProductCode,Scope |
+        Where-Object { `$_.SideIndicator -eq '<=' } | Select-Object -Property * -ExcludeProperty SideIndicator
     `$arpDifference | Format-Table
     `$arpDifference | Export-Csv -Path (Join-Path `$LogsFolder 'ARP_Differences.csv') -NoTypeInformation
     `$arpDifference | ConvertTo-Json | Out-File -FilePath (Join-Path `$LogsFolder 'ARP_Differences.json') -Encoding utf8


### PR DESCRIPTION
## Summary

Three related improvements to run visibility, plus one real bug fix.

### 1. PR link in the "PR Submitted" summary

`Submit-WingetPackage` now resolves and returns `PrUrl` / `PrNumber`, and the `Submit PR` step renders it:

```
**Pull request:** [#312455](https://github.com/microsoft/winget-pkgs/pull/312455)
```

A new private helper `Get-WingetPkgsPrUrl` reads the URL out of the submission tool's output (works for WinMatsch, Komac and WinGetCreate, tolerates ANSI colour codes, picks the *last* URL so a "duplicate PR found" mention doesn't win), with a `gh pr list` fallback. Falls back to a `_URL could not be determined_` note so the step never fails over a missing link.

> Side effect: `.github/actions/validate-and-submit/action.yml` already read `$result.PrUrl` and exposed a `pr-url` output — that output was always empty because the function never returned it. It works now.

### 2. Failed-generation summary table

Failures in the `generate-manifest` matrix are recorded as `generate-failure__<pkg>` artifacts and rendered as a table in the `collect-generated` job summary:

| Failed Job | Package | Version | Exit Code | Error |
| --- | --- | --- | --- | --- |
| Generate RivaFarabi.Deckboard | RivaFarabi.Deckboard | 3.2.0 | 4 | MAP_REMOVED : Previous installer assets (v3.1.4) have no compatible release assets in v3.2.0 |
| Generate SUSE.RancherDesktop | SUSE.RancherDesktop | 1.24.0 | 5 | Other WinMatsch validation failure |

`Update-WingetPackage` captures generator output (`Tee-Object | Out-Host`, so logs still stream live) and emits structured `GITHUB_OUTPUT` values on failure. The recording step uses `if: failure()`, so it catches *any* failure in the job, not just generator ones.

### 3. Bug fix — ARP diff always reported "No new ARP entries detected"

`Compare-Object $newARP $originalARP` throws `Cannot bind argument to parameter 'DifferenceObject' because it is null` whenever the ARP table before install is empty — which is the normal state of a clean Windows Sandbox. `$arpDifference` stayed null, `ARP_Differences.csv` was written empty, and the analyzer reported no new entries. Because the error was raised *inside the sandbox VM*, it never surfaced in the Actions log.

Symptom (run 30991440034, `pluveto.Upgit`) — self-contradictory numbers:

```
ARP_Before.csv - 0 entries
ARP_After.csv  - 1 entries
ARP_Differences.csv - 0 entries
No new ARP entries detected. Installation may have failed or not created ARP entries.
```

Fixed by coercing both sides with `@()` and keeping only `<=` entries, so removals are not miscounted as new installs.

In `Test-Manifest-Sandbox.ps1` this was cosmetic (the analyzer never sets an exit code). In **`Test-Manifest-Host.ps1` it was fatal** — `exit 1` when `$arpDiff.Count -eq 0` meant any clean machine produced a bogus FAILURE.

`scripts/validation/Test-Sandbox-Org.ps1` has the same defect but is unreferenced by any workflow and looks like a vendored upstream baseline, so it was left alone.

## Note on generated files

Only `.github/workflows-templates/github-releases.yml` and `update-script-packages.yml` were hand-edited. `update-github-packages-*.yml` were regenerated with `scripts/orchestrate_gh-packages.py`; regeneration was confirmed byte-identical, so there is no template drift.

## Validation

- All 4 workflows parse as YAML; step scripts extracted via the YAML parser and parse-checked as PowerShell
- Failure path simulated end-to-end (record → JSON → table), including pipes, empty version/exit code and multi-line errors; no-failure path writes nothing
- PR URL extraction tested against winmatsch / komac-with-ANSI / wingetcreate / duplicate-PR / no-URL outputs
- ARP fix: expanded the here-string as the script does at runtime, executed the generated code, and ran the result through the real `Invoke-SandboxLogValidation.ps1` — output flips to `Detected 1 new ARP entry/entries`. Host gate verified for 0→1, 0→0, 3→4, 2→2
- Error messages are guaranteed single-line, so `GITHUB_OUTPUT` cannot be corrupted
- Existing Pester suites pass (including the new `Update-WingetPackage` regression tests from #150); zizmor reports no findings; private helpers do not leak into the module's public surface