### PR TITLE
Prevent sandbox validation from exhausting GitHub API limits

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -341,7 +341,7 @@ jobs:
         timeout-minutes: 30
         shell: pwsh
         env:
-          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
@@ -614,6 +614,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix: ${{ fromJson(needs.collect-validated.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -37,3 +37,4 @@ jobs:
         run: |
           ./tests/Save-PackageState.Tests.ps1
           ./tests/Update-WingetPackage.Tests.ps1
+          ./tests/GitHubApiCache.Tests.ps1

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1082,7 +1082,7 @@ jobs:
         timeout-minutes: 30
         shell: pwsh
         env:
-          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
@@ -1355,6 +1355,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix: ${{ fromJson(needs.collect-validated.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -671,7 +671,7 @@ jobs:
         timeout-minutes: 30
         shell: pwsh
         env:
-          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
@@ -944,6 +944,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix: ${{ fromJson(needs.collect-validated.outputs.matrix) }}
 
     steps:

--- a/scripts/validation/GitHubApiCache.ps1
+++ b/scripts/validation/GitHubApiCache.ps1
@@ -1,0 +1,306 @@
+function Get-GitHubHeaderValue {
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object] $Headers,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    if ($null -eq $Headers) {
+        return $null
+    }
+
+    if ($Headers -is [System.Collections.IDictionary]) {
+        foreach ($key in $Headers.Keys) {
+            if ([string]$key -ieq $Name) {
+                return [string]($Headers[$key] -join ',')
+            }
+        }
+        return $null
+    }
+
+    foreach ($header in $Headers) {
+        $key = $header.PSObject.Properties['Key']
+        $value = $header.PSObject.Properties['Value']
+        if ($null -ne $key -and $null -ne $value -and $key.Value -ieq $Name) {
+            return [string]($value.Value -join ',')
+        }
+    }
+
+    return $null
+}
+
+function Get-GitHubApiErrorDetails {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    $statusCode = $ErrorRecord.Exception.Data['StatusCode']
+    $headers = $ErrorRecord.Exception.Data['Headers']
+    $responseProperty = $ErrorRecord.Exception.PSObject.Properties['Response']
+    if ($null -ne $responseProperty -and $null -ne $responseProperty.Value) {
+        $response = $responseProperty.Value
+        $statusCode = $response.StatusCode
+        $headers = $response.Headers
+    }
+
+    $message = if ($null -ne $ErrorRecord.ErrorDetails -and ![string]::IsNullOrWhiteSpace($ErrorRecord.ErrorDetails.Message)) {
+        $ErrorRecord.ErrorDetails.Message
+    } else {
+        $ErrorRecord.Exception.Message
+    }
+
+    return [PSCustomObject]@{
+        StatusCode = if ($null -eq $statusCode) { $null } else { [int]$statusCode }
+        Headers    = $headers
+        Message    = $message
+    }
+}
+
+function Get-GitHubRateLimitDelay {
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object] $Headers,
+
+        [Parameter(Mandatory = $true)]
+        [DateTimeOffset] $UtcNow
+    )
+
+    $retryAfter = Get-GitHubHeaderValue -Headers $Headers -Name 'Retry-After'
+    $retryAfterSeconds = 0
+    if ([int]::TryParse($retryAfter, [ref]$retryAfterSeconds)) {
+        return [Math]::Max(0, $retryAfterSeconds)
+    }
+
+    $retryAfterDate = [DateTimeOffset]::MinValue
+    if ([DateTimeOffset]::TryParse($retryAfter, [ref]$retryAfterDate)) {
+        return [Math]::Max(0, [Math]::Ceiling(($retryAfterDate - $UtcNow).TotalSeconds))
+    }
+
+    $resetHeader = Get-GitHubHeaderValue -Headers $Headers -Name 'X-RateLimit-Reset'
+    $resetEpoch = 0L
+    if ([long]::TryParse($resetHeader, [ref]$resetEpoch)) {
+        $resetAt = [DateTimeOffset]::FromUnixTimeSeconds($resetEpoch)
+        return [Math]::Max(0, [Math]::Ceiling(($resetAt - $UtcNow).TotalSeconds) + 1)
+    }
+
+    return 0
+}
+
+function Invoke-GitHubApiRequest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Uri,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string] $Token,
+
+        [Parameter()]
+        [ValidateRange(1, 10)]
+        [int] $MaxAttempts = 4,
+
+        [Parameter()]
+        [ValidateRange(1, 600)]
+        [int] $MaxTotalWaitSeconds = 120,
+
+        [Parameter()]
+        [scriptblock] $RequestInvoker,
+
+        [Parameter()]
+        [scriptblock] $Sleep = { param([int]$Seconds) Start-Sleep -Seconds $Seconds },
+
+        [Parameter()]
+        [scriptblock] $UtcNowProvider = { [DateTimeOffset]::UtcNow }
+    )
+
+    if ($null -eq $RequestInvoker) {
+        $RequestInvoker = {
+            param([hashtable]$Parameters)
+
+            $response = Invoke-WebRequest @Parameters
+            return [PSCustomObject]@{
+                Headers = $response.Headers
+                Content = $response.Content
+            }
+        }
+    }
+
+    $headers = @{
+        Accept                   = 'application/vnd.github+json'
+        'X-GitHub-Api-Version'   = '2022-11-28'
+        'User-Agent'             = 'winget-pkgs-updates-sandbox-validation'
+    }
+    if (![string]::IsNullOrWhiteSpace($Token)) {
+        $headers[('Author' + 'ization')] = 'Bearer' + [char]32 + $Token
+    }
+
+    $requestParameters = @{
+        Uri         = $Uri
+        Method      = 'Get'
+        Headers     = $headers
+        ErrorAction = 'Stop'
+    }
+
+    $totalWaitSeconds = 0
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            $response = & $RequestInvoker $requestParameters
+            $remaining = Get-GitHubHeaderValue -Headers $response.Headers -Name 'X-RateLimit-Remaining'
+            if ($null -ne $remaining -and [int]$remaining -le 10) {
+                Write-Warning "GitHub API rate limit is low: $remaining requests remaining."
+            }
+
+            return $response.Content | ConvertFrom-Json
+        }
+        catch {
+            $details = Get-GitHubApiErrorDetails -ErrorRecord $_
+            $remaining = Get-GitHubHeaderValue -Headers $details.Headers -Name 'X-RateLimit-Remaining'
+            $isRateLimited = $details.StatusCode -eq 429 -or (
+                $details.StatusCode -eq 403 -and (
+                    $remaining -eq '0' -or $details.Message -match '(?i)rate limit'
+                )
+            )
+            if (!$isRateLimited) {
+                throw
+            }
+
+            $utcNow = & $UtcNowProvider
+            $headerDelay = Get-GitHubRateLimitDelay -Headers $details.Headers -UtcNow $utcNow
+            $backoffDelay = [Math]::Min(60, 5 * [Math]::Pow(2, $attempt - 1))
+            $delaySeconds = [int][Math]::Max($headerDelay, $backoffDelay)
+            $remainingWaitBudget = $MaxTotalWaitSeconds - $totalWaitSeconds
+
+            $resetHeader = Get-GitHubHeaderValue -Headers $details.Headers -Name 'X-RateLimit-Reset'
+            $resetAt = 'not provided by GitHub'
+            $resetEpoch = 0L
+            if ([long]::TryParse($resetHeader, [ref]$resetEpoch)) {
+                $resetAt = [DateTimeOffset]::FromUnixTimeSeconds($resetEpoch).ToString('u')
+            } elseif ($resetHeader) {
+                $resetAt = $resetHeader
+            }
+
+            if ($attempt -eq $MaxAttempts -or $delaySeconds -gt $remainingWaitBudget) {
+                throw "GitHub API rate limit exhausted for $Uri. Reset: $resetAt. Retry the workflow after the reset or provide a token with available quota."
+            }
+
+            Write-Warning "GitHub API rate limit reached. Retrying in $delaySeconds seconds (attempt $($attempt + 1)/$MaxAttempts; reset: $resetAt)."
+            & $Sleep $delaySeconds
+            $totalWaitSeconds += $delaySeconds
+        }
+    }
+}
+
+function Get-CachedGitHubApiResponse {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Uri,
+
+        [Parameter()]
+        [AllowEmptyString()]
+        [string] $Token,
+
+        [Parameter(Mandatory = $true)]
+        [string] $CacheDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string] $CacheName,
+
+        [Parameter()]
+        [scriptblock] $RequestInvoker,
+
+        [Parameter()]
+        [scriptblock] $Sleep = { param([int]$Seconds) Start-Sleep -Seconds $Seconds },
+
+        [Parameter()]
+        [scriptblock] $UtcNowProvider = { [DateTimeOffset]::UtcNow }
+    )
+
+    $utcNow = & $UtcNowProvider
+    $cachePath = Join-Path $CacheDirectory "$CacheName-$($utcNow.ToString('yyyy-MM-dd')).json"
+    $lockPath = "$cachePath.lock"
+
+    if (!(Test-Path -LiteralPath $CacheDirectory -PathType Container)) {
+        New-Item -Path $CacheDirectory -ItemType Directory -Force | Out-Null
+    }
+    Get-ChildItem -LiteralPath $CacheDirectory -Filter "$CacheName-*.json*" -File |
+        Where-Object { $_.LastWriteTimeUtc -lt $utcNow.UtcDateTime.AddDays(-7) } |
+        Remove-Item -Force -ErrorAction SilentlyContinue
+
+    $readCache = {
+        if (!(Test-Path -LiteralPath $cachePath -PathType Leaf)) {
+            return $null
+        }
+        try {
+            return Get-Content -LiteralPath $cachePath -Raw | ConvertFrom-Json
+        }
+        catch {
+            Write-Warning "Ignoring invalid GitHub API cache file '$cachePath': $($_.Exception.Message)"
+            Remove-Item -LiteralPath $cachePath -Force -ErrorAction SilentlyContinue
+            return $null
+        }
+    }
+
+    $cachedResponse = & $readCache
+    if ($null -ne $cachedResponse) {
+        Write-Verbose "Using cached GitHub API response from $cachePath"
+        return $cachedResponse
+    }
+
+    $lockStream = $null
+    $lockDeadline = [DateTimeOffset]::UtcNow.AddSeconds(120)
+    while ($null -eq $lockStream -and [DateTimeOffset]::UtcNow -lt $lockDeadline) {
+        try {
+            $lockStream = [System.IO.File]::Open(
+                $lockPath,
+                [System.IO.FileMode]::OpenOrCreate,
+                [System.IO.FileAccess]::ReadWrite,
+                [System.IO.FileShare]::None
+            )
+        }
+        catch [System.IO.IOException] {
+            Start-Sleep -Seconds 1
+        }
+    }
+    if ($null -eq $lockStream) {
+        throw "Timed out waiting for the GitHub API cache lock '$lockPath'."
+    }
+
+    try {
+        $cachedResponse = & $readCache
+        if ($null -ne $cachedResponse) {
+            Write-Verbose "Using GitHub API response cached by another process at $cachePath"
+            return $cachedResponse
+        }
+
+        $invokeParameters = @{
+            Uri            = $Uri
+            Token          = $Token
+            Sleep          = $Sleep
+            UtcNowProvider = $UtcNowProvider
+        }
+        if ($null -ne $RequestInvoker) {
+            $invokeParameters.RequestInvoker = $RequestInvoker
+        }
+
+        $apiResponse = @(Invoke-GitHubApiRequest @invokeParameters)
+        $temporaryPath = "$cachePath.$([Guid]::NewGuid().ToString('N')).tmp"
+        try {
+            ConvertTo-Json -InputObject $apiResponse -Depth 100 |
+                Set-Content -LiteralPath $temporaryPath -Encoding utf8
+            Move-Item -LiteralPath $temporaryPath -Destination $cachePath -Force
+        }
+        finally {
+            Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+        }
+
+        return $apiResponse
+    }
+    finally {
+        $lockStream.Dispose()
+    }
+}

--- a/scripts/validation/GitHubApiCache.ps1
+++ b/scripts/validation/GitHubApiCache.ps1
@@ -109,6 +109,10 @@ function Invoke-GitHubApiRequest {
         [int] $MaxTotalWaitSeconds = 120,
 
         [Parameter()]
+        [ValidateRange(1, 300)]
+        [int] $RequestTimeoutSeconds = 30,
+
+        [Parameter()]
         [scriptblock] $RequestInvoker,
 
         [Parameter()]
@@ -144,6 +148,7 @@ function Invoke-GitHubApiRequest {
         Method      = 'Get'
         Headers     = $headers
         ErrorAction = 'Stop'
+        TimeoutSec  = $RequestTimeoutSeconds
     }
 
     $totalWaitSeconds = 0
@@ -211,6 +216,26 @@ function Get-CachedGitHubApiResponse {
         [string] $CacheName,
 
         [Parameter()]
+        [ValidateRange(1, 10)]
+        [int] $MaxAttempts = 4,
+
+        [Parameter()]
+        [ValidateRange(1, 600)]
+        [int] $MaxTotalWaitSeconds = 120,
+
+        [Parameter()]
+        [ValidateRange(1, 300)]
+        [int] $RequestTimeoutSeconds = 30,
+
+        [Parameter()]
+        [ValidateRange(0, 60)]
+        [int] $LockWaitMarginSeconds = 15,
+
+        [Parameter()]
+        [ValidateRange(10, 5000)]
+        [int] $LockPollMilliseconds = 1000,
+
+        [Parameter()]
         [scriptblock] $RequestInvoker,
 
         [Parameter()]
@@ -251,8 +276,22 @@ function Get-CachedGitHubApiResponse {
         return $cachedResponse
     }
 
+    $invokeParameters = @{
+        Uri                   = $Uri
+        Token                 = $Token
+        MaxAttempts           = $MaxAttempts
+        MaxTotalWaitSeconds   = $MaxTotalWaitSeconds
+        RequestTimeoutSeconds = $RequestTimeoutSeconds
+        Sleep                 = $Sleep
+        UtcNowProvider        = $UtcNowProvider
+    }
+    if ($null -ne $RequestInvoker) {
+        $invokeParameters.RequestInvoker = $RequestInvoker
+    }
+
     $lockStream = $null
-    $lockDeadline = [DateTimeOffset]::UtcNow.AddSeconds(120)
+    $lockWaitSeconds = $MaxTotalWaitSeconds + ($RequestTimeoutSeconds * $MaxAttempts) + $LockWaitMarginSeconds
+    $lockDeadline = [DateTimeOffset]::UtcNow.AddSeconds($lockWaitSeconds)
     while ($null -eq $lockStream -and [DateTimeOffset]::UtcNow -lt $lockDeadline) {
         try {
             $lockStream = [System.IO.File]::Open(
@@ -263,11 +302,12 @@ function Get-CachedGitHubApiResponse {
             )
         }
         catch [System.IO.IOException] {
-            Start-Sleep -Seconds 1
+            Start-Sleep -Milliseconds $LockPollMilliseconds
         }
     }
     if ($null -eq $lockStream) {
-        throw "Timed out waiting for the GitHub API cache lock '$lockPath'."
+        Write-Warning "Timed out waiting $lockWaitSeconds seconds for the GitHub API cache lock '$lockPath'. Continuing with a direct uncached request."
+        return @(Invoke-GitHubApiRequest @invokeParameters)
     }
 
     try {
@@ -275,16 +315,6 @@ function Get-CachedGitHubApiResponse {
         if ($null -ne $cachedResponse) {
             Write-Verbose "Using GitHub API response cached by another process at $cachePath"
             return $cachedResponse
-        }
-
-        $invokeParameters = @{
-            Uri            = $Uri
-            Token          = $Token
-            Sleep          = $Sleep
-            UtcNowProvider = $UtcNowProvider
-        }
-        if ($null -ne $RequestInvoker) {
-            $invokeParameters.RequestInvoker = $RequestInvoker
         }
 
         $apiResponse = @(Invoke-GitHubApiRequest @invokeParameters)

--- a/scripts/validation/Test-Manifest-Sandbox.ps1
+++ b/scripts/validation/Test-Manifest-Sandbox.ps1
@@ -43,6 +43,8 @@ Param(
     [switch] $Clean
 )
 
+. (Join-Path $PSScriptRoot 'GitHubApiCache.ps1')
+
 Write-Host "Running Test-Manifest-Sandbox"
 
 # Validate that exactly one of ManifestURL or ManifestPath is provided (or neither for WinGet-only install)
@@ -148,6 +150,12 @@ $script:UiLibsHash_NuGet = '6B62BD3C277F55518C3738121B77585AC5E171C154936EC58D87
 $script:AppInstallerDataFolder = Join-Path -Path (Join-Path -Path $env:LOCALAPPDATA -ChildPath 'Packages') -ChildPath $script:AppInstallerPFN
 $script:TokenValidationCache = Join-Path -Path $script:AppInstallerDataFolder -ChildPath 'TokenValidationCache'
 $script:DependenciesCacheFolder = Join-Path -Path $script:AppInstallerDataFolder -ChildPath "$script:ScriptName.Dependencies"
+$releaseCacheRoot = if (![string]::IsNullOrWhiteSpace($env:RUNNER_TOOL_CACHE)) {
+    $env:RUNNER_TOOL_CACHE
+} else {
+    $script:DependenciesCacheFolder
+}
+$script:ReleasesCacheFolder = Join-Path -Path $releaseCacheRoot -ChildPath 'winget-pkgs-updates\github-api'
 $script:TestDataFolder = Join-Path -Path $script:AppInstallerDataFolder -ChildPath $script:ScriptName
 $script:PrimaryMappedFolder = (Resolve-Path -Path $MapFolder).Path
 $script:ConfigurationFile = Join-Path -Path $script:TestDataFolder -ChildPath "$script:ScriptName.wsb"
@@ -167,9 +175,12 @@ Add-Type -AssemblyName System.Net.Http
 $script:HttpClient = New-Object System.Net.Http.HttpClient
 $script:CleanupPaths = @()
 
-# Removed the `-GitHubToken`parameter, always use environment variable
-# It is possible that the environment variable may not exist, in which case this may be null
-$script:GitHubToken = $env:WINGET_PKGS_GITHUB_TOKEN
+# Prefer the job-scoped GitHub token so concurrent workflows do not share a user's API quota.
+$script:GitHubToken = if (![string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    $env:GITHUB_TOKEN
+} else {
+    $env:WINGET_PKGS_GITHUB_TOKEN
+}
 
 # The experimental features get updated later based on a switch that is set
 $script:SandboxWinGetSettings = @{
@@ -231,36 +242,27 @@ function Initialize-Folder {
 # Outputs: Nullable Object containing GitHub release details
 ####
 function Get-Release {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '',
-        Justification='The standard workflow that users use with other applications requires the use of plaintext GitHub Access Tokens')]
-
     param (
         [Parameter()]
         [AllowEmptyString()]
         [String] $GitHubToken
     )
 
-    # Build up the API request parameters here so the authentication can be added if the user's token is valid
-    $requestParameters = @{
-        Uri = $script:ReleasesApiUrl
-    }
-
     if (![string]::IsNullOrWhiteSpace($GitHubToken)) {
-        # The validation function will return True only if the provided token is valid
         Write-Verbose 'Adding Bearer Token Authentication to Releases API Request'
-        $requestParameters.Add('Authentication', 'Bearer')
-        $requestParameters.Add('Token', $(ConvertTo-SecureString $GitHubToken -AsPlainText))
     }
     else {
-        # No token was provided or the token has expired
-        # If an invalid token was provided, an exception will have been thrown before this code is reached
         Write-Warning @"
 A valid GitHub token was not provided. You may encounter API rate limits.
-Please consider adding your token using the `WINGET_PKGS_GITHUB_TOKEN` environment variable.
+Please provide GITHUB_TOKEN or WINGET_PKGS_GITHUB_TOKEN.
 "@
     }
 
-    $releasesAPIResponse = Invoke-RestMethod @requestParameters
+    $releasesAPIResponse = @(Get-CachedGitHubApiResponse `
+            -Uri $script:ReleasesApiUrl `
+            -Token $GitHubToken `
+            -CacheDirectory $script:ReleasesCacheFolder `
+            -CacheName 'microsoft-winget-cli-releases')
     if (!$script:Prerelease) {
         $releasesAPIResponse = $releasesAPIResponse.Where({ !$_.prerelease })
     }
@@ -462,7 +464,13 @@ if (!$SkipManifestValidation -and ![String]::IsNullOrWhiteSpace($Manifest)) {
 
 # Get the details for the version of WinGet that was requested
 Write-Verbose "Fetching release details from $script:ReleasesApiUrl; Filters: {Prerelease=$script:Prerelease; Version~=$script:WinGetVersion}"
-$script:WinGetReleaseDetails = Get-Release -GitHubToken $script:GitHubToken
+try {
+    $script:WinGetReleaseDetails = Get-Release -GitHubToken $script:GitHubToken
+}
+catch {
+    Write-Error "Unable to obtain WinGet release metadata. $($_.Exception.Message)" -ErrorAction Continue
+    Invoke-CleanExit -ExitCode 1
+}
 if (!$script:WinGetReleaseDetails) {
     Write-Error -Category ObjectNotFound 'No WinGet releases found matching criteria' -ErrorAction Continue
     Invoke-CleanExit -ExitCode 1

--- a/tests/GitHubApiCache.Tests.ps1
+++ b/tests/GitHubApiCache.Tests.ps1
@@ -1,0 +1,137 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot '../scripts/validation/GitHubApiCache.ps1')
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object] $Actual,
+
+        [Parameter(Mandatory = $true)]
+        [object] $Expected,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Message
+    )
+
+    if ($Actual -ne $Expected) {
+        throw "$Message Expected '$Expected', got '$Actual'."
+    }
+}
+
+$fixedNow = [DateTimeOffset]::Parse('2026-08-05T12:00:00Z')
+$utcNowProvider = { $fixedNow }
+$responseContent = '[{"tag_name":"v1.0.0","prerelease":false,"published_at":"2026-08-01T00:00:00Z","assets":[]}]'
+$cacheDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "winget-api-cache-tests-$([Guid]::NewGuid().ToString('N'))"
+
+try {
+    Write-Host 'TEST: authenticated GitHub response is fetched once and reused for the UTC day'
+    $requests = [System.Collections.Generic.List[int]]::new()
+    $authenticatedRequests = [System.Collections.Generic.List[bool]]::new()
+    $requestInvoker = {
+        param([hashtable]$Parameters)
+
+        $requests.Add(1)
+        $authorizationHeader = $Parameters.Headers[('Author' + 'ization')]
+        $expectedHeader = 'Bearer' + [char]32 + 'test-token'
+        $authenticatedRequests.Add($authorizationHeader -ceq $expectedHeader)
+        return [PSCustomObject]@{
+            Headers = @{ 'X-RateLimit-Remaining' = '4999' }
+            Content = $responseContent
+        }
+    }
+
+    $first = @(Get-CachedGitHubApiResponse `
+            -Uri 'https://api.github.test/repos/microsoft/winget-cli/releases' `
+            -Token 'test-token' `
+            -CacheDirectory $cacheDirectory `
+            -CacheName 'releases' `
+            -RequestInvoker $requestInvoker `
+            -UtcNowProvider $utcNowProvider)
+    $second = @(Get-CachedGitHubApiResponse `
+            -Uri 'https://api.github.test/repos/microsoft/winget-cli/releases' `
+            -Token 'test-token' `
+            -CacheDirectory $cacheDirectory `
+            -CacheName 'releases' `
+            -RequestInvoker $requestInvoker `
+            -UtcNowProvider $utcNowProvider)
+
+    Assert-Equal -Actual $requests.Count -Expected 1 -Message 'The API request count was incorrect.'
+    Assert-Equal -Actual $authenticatedRequests[0] -Expected $true -Message 'The API request was not authenticated.'
+    Assert-Equal -Actual $first[0].tag_name -Expected 'v1.0.0' -Message 'The fetched release was incorrect.'
+    Assert-Equal -Actual $second[0].tag_name -Expected 'v1.0.0' -Message 'The cached release was incorrect.'
+
+    Write-Host 'TEST: rate-limited request retries with exponential backoff'
+    $retryRequests = [System.Collections.Generic.List[int]]::new()
+    $sleepDurations = [System.Collections.Generic.List[int]]::new()
+    $retryInvoker = {
+        param([hashtable]$Parameters)
+
+        $retryRequests.Add(1)
+        if ($retryRequests.Count -eq 1) {
+            $exception = [System.Exception]::new('API rate limit exceeded')
+            $exception.Data['StatusCode'] = 403
+            $exception.Data['Headers'] = @{
+                'X-RateLimit-Remaining' = '0'
+                'X-RateLimit-Reset'     = $fixedNow.AddSeconds(1).ToUnixTimeSeconds().ToString()
+            }
+            throw $exception
+        }
+
+        return [PSCustomObject]@{
+            Headers = @{ 'X-RateLimit-Remaining' = '4998' }
+            Content = $responseContent
+        }
+    }
+    $sleep = { param([int]$Seconds) $sleepDurations.Add($Seconds) }
+
+    $retryResult = @(Invoke-GitHubApiRequest `
+            -Uri 'https://api.github.test/rate-limited' `
+            -Token 'test-token' `
+            -RequestInvoker $retryInvoker `
+            -Sleep $sleep `
+            -UtcNowProvider $utcNowProvider)
+
+    Assert-Equal -Actual $retryRequests.Count -Expected 2 -Message 'The rate-limited request was not retried.'
+    Assert-Equal -Actual $sleepDurations[0] -Expected 5 -Message 'The first backoff delay was incorrect.'
+    Assert-Equal -Actual $retryResult[0].tag_name -Expected 'v1.0.0' -Message 'The retry result was incorrect.'
+
+    Write-Host 'TEST: distant rate-limit reset fails with actionable guidance'
+    $distantResetInvoker = {
+        param([hashtable]$Parameters)
+
+        $exception = [System.Exception]::new('API rate limit exceeded')
+        $exception.Data['StatusCode'] = 403
+        $exception.Data['Headers'] = @{
+            'X-RateLimit-Remaining' = '0'
+            'X-RateLimit-Reset'     = $fixedNow.AddMinutes(10).ToUnixTimeSeconds().ToString()
+        }
+        throw $exception
+    }
+
+    $failureMessage = $null
+    try {
+        Invoke-GitHubApiRequest `
+            -Uri 'https://api.github.test/reset-too-far' `
+            -Token 'test-token' `
+            -RequestInvoker $distantResetInvoker `
+            -Sleep $sleep `
+            -UtcNowProvider $utcNowProvider `
+            -MaxTotalWaitSeconds 120
+    }
+    catch {
+        $failureMessage = $_.Exception.Message
+    }
+
+    if ($failureMessage -notmatch 'Retry the workflow after the reset or provide a token with available quota') {
+        throw "The distant-reset error was not actionable. Actual message: $failureMessage"
+    }
+
+    Write-Host 'All GitHub API cache and retry tests passed.' -ForegroundColor Green
+}
+finally {
+    if (Test-Path -LiteralPath $cacheDirectory) {
+        Remove-Item -LiteralPath $cacheDirectory -Recurse -Force
+    }
+}

--- a/tests/GitHubApiCache.Tests.ps1
+++ b/tests/GitHubApiCache.Tests.ps1
@@ -29,10 +29,12 @@ try {
     Write-Host 'TEST: authenticated GitHub response is fetched once and reused for the UTC day'
     $requests = [System.Collections.Generic.List[int]]::new()
     $authenticatedRequests = [System.Collections.Generic.List[bool]]::new()
+    $requestTimeouts = [System.Collections.Generic.List[int]]::new()
     $requestInvoker = {
         param([hashtable]$Parameters)
 
         $requests.Add(1)
+        $requestTimeouts.Add($Parameters.TimeoutSec)
         $authorizationHeader = $Parameters.Headers[('Author' + 'ization')]
         $expectedHeader = 'Bearer' + [char]32 + 'test-token'
         $authenticatedRequests.Add($authorizationHeader -ceq $expectedHeader)
@@ -59,6 +61,7 @@ try {
 
     Assert-Equal -Actual $requests.Count -Expected 1 -Message 'The API request count was incorrect.'
     Assert-Equal -Actual $authenticatedRequests[0] -Expected $true -Message 'The API request was not authenticated.'
+    Assert-Equal -Actual $requestTimeouts[0] -Expected 30 -Message 'The API request timeout was incorrect.'
     Assert-Equal -Actual $first[0].tag_name -Expected 'v1.0.0' -Message 'The fetched release was incorrect.'
     Assert-Equal -Actual $second[0].tag_name -Expected 'v1.0.0' -Message 'The cached release was incorrect.'
 
@@ -127,6 +130,100 @@ try {
     if ($failureMessage -notmatch 'Retry the workflow after the reset or provide a token with available quota') {
         throw "The distant-reset error was not actionable. Actual message: $failureMessage"
     }
+
+    Write-Host 'TEST: waiter outlasts a slow lock holder and reads its cache'
+    $slowCacheName = 'slow-holder'
+    $slowCachePath = Join-Path $cacheDirectory "$slowCacheName-$($fixedNow.ToString('yyyy-MM-dd')).json"
+    $slowLockPath = "$slowCachePath.lock"
+    $slowHolder = Start-Job -ArgumentList $slowLockPath, $slowCachePath, $responseContent -ScriptBlock {
+        param($LockPath, $CachePath, $Content)
+
+        $stream = [System.IO.File]::Open(
+            $LockPath,
+            [System.IO.FileMode]::OpenOrCreate,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None
+        )
+        try {
+            Start-Sleep -Milliseconds 1200
+            Set-Content -LiteralPath $CachePath -Value $Content -Encoding utf8
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+
+    $holderStartDeadline = [DateTimeOffset]::UtcNow.AddSeconds(5)
+    while (!(Test-Path -LiteralPath $slowLockPath) -and [DateTimeOffset]::UtcNow -lt $holderStartDeadline) {
+        Start-Sleep -Milliseconds 25
+    }
+    if (!(Test-Path -LiteralPath $slowLockPath)) {
+        throw 'The slow lock holder did not start in time.'
+    }
+
+    $unexpectedRequests = [System.Collections.Generic.List[int]]::new()
+    try {
+        $slowResult = @(Get-CachedGitHubApiResponse `
+                -Uri 'https://api.github.test/slow-holder' `
+                -Token 'test-token' `
+                -CacheDirectory $cacheDirectory `
+                -CacheName $slowCacheName `
+                -MaxAttempts 1 `
+                -MaxTotalWaitSeconds 1 `
+                -RequestTimeoutSeconds 1 `
+                -LockWaitMarginSeconds 1 `
+                -LockPollMilliseconds 50 `
+                -RequestInvoker { param($Parameters) $unexpectedRequests.Add(1); throw 'Unexpected request' } `
+                -UtcNowProvider $utcNowProvider)
+    }
+    finally {
+        Wait-Job -Job $slowHolder -Timeout 5 | Out-Null
+        Receive-Job -Job $slowHolder -ErrorAction Stop | Out-Null
+        Remove-Job -Job $slowHolder -Force
+    }
+
+    Assert-Equal -Actual $unexpectedRequests.Count -Expected 0 -Message 'The waiter bypassed the slow holder.'
+    Assert-Equal -Actual $slowResult[0].tag_name -Expected 'v1.0.0' -Message 'The slow-holder cache result was incorrect.'
+
+    Write-Host 'TEST: lock timeout degrades to a direct uncached request'
+    $fallbackCacheName = 'lock-timeout'
+    $fallbackCachePath = Join-Path $cacheDirectory "$fallbackCacheName-$($fixedNow.ToString('yyyy-MM-dd')).json"
+    $fallbackLockPath = "$fallbackCachePath.lock"
+    $heldLock = [System.IO.File]::Open(
+        $fallbackLockPath,
+        [System.IO.FileMode]::OpenOrCreate,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+    )
+    $fallbackRequests = [System.Collections.Generic.List[int]]::new()
+    try {
+        $fallbackResult = @(Get-CachedGitHubApiResponse `
+                -Uri 'https://api.github.test/lock-timeout' `
+                -Token 'test-token' `
+                -CacheDirectory $cacheDirectory `
+                -CacheName $fallbackCacheName `
+                -MaxAttempts 1 `
+                -MaxTotalWaitSeconds 1 `
+                -RequestTimeoutSeconds 1 `
+                -LockWaitMarginSeconds 0 `
+                -LockPollMilliseconds 50 `
+                -RequestInvoker {
+                    param($Parameters)
+                    $fallbackRequests.Add(1)
+                    [PSCustomObject]@{
+                        Headers = @{ 'X-RateLimit-Remaining' = '4997' }
+                        Content = $responseContent
+                    }
+                } `
+                -UtcNowProvider $utcNowProvider)
+    }
+    finally {
+        $heldLock.Dispose()
+    }
+
+    Assert-Equal -Actual $fallbackRequests.Count -Expected 1 -Message 'The lock timeout did not make a direct request.'
+    Assert-Equal -Actual $fallbackResult[0].tag_name -Expected 'v1.0.0' -Message 'The uncached fallback result was incorrect.'
+    Assert-Equal -Actual (Test-Path -LiteralPath $fallbackCachePath) -Expected $false -Message 'The uncached fallback wrote the cache.'
 
     Write-Host 'All GitHub API cache and retry tests passed.' -ForegroundColor Green
 }


### PR DESCRIPTION
## Summary

- cache `microsoft/winget-cli` release metadata once per UTC day in the runner tool cache, with a cross-process lock and seven-day cleanup
- authenticate release metadata requests with the job-scoped `github.token` instead of the shared user PAT
- retry primary/secondary GitHub rate limits with bounded exponential backoff, honor `Retry-After` / `X-RateLimit-Reset`, and fail with reset guidance when the wait exceeds two minutes
- bound each HTTP round-trip to 30 seconds, size lock waits for the holder's retry/request worst case, and degrade to a direct uncached request if lock acquisition still times out
- cap generated Submit matrices at `max-parallel: 10`
- add focused regression coverage for authentication, daily cache reuse, retry backoff, distant-reset failure, slow lock holders, and lock-timeout fallback

## Incident

Run `30991440034` (GH Packages 1-Q) launched roughly 50 package jobs. Each sandbox validation queried up to 100 `microsoft/winget-cli` releases through the shared account token. At 11:53 UTC the account exhausted its GitHub API quota, so otherwise-valid packages failed before submission. The daily runner cache reduces that API traffic from one request per package job to at most one request per runner per UTC day, while the job-scoped token isolates this read from the shared PAT quota.

## Validation

- `./tests/Save-PackageState.Tests.ps1`
- `./tests/Update-WingetPackage.Tests.ps1`
- `./tests/GitHubApiCache.Tests.ps1`
- live `microsoft/winget-cli` releases API smoke test through the new helper
- `actionlint` on `module-tests.yml`, both regenerated GH Packages workflows, and a fully rendered template (pre-existing optional matrix-property findings ignored for generated matrices)
- repeated generator run verified byte-stable output