### PR TITLE
Fix GH package config failures from run 30991440034

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -39,9 +39,10 @@ jobs:
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
-          GHTagPattern: ${{ matrix.tagPattern }}
-          GHVersionSource: ${{ matrix.versionSource }}
-          WinMatschOverridePack: ${{ matrix.overridePack }}
+          GHTagPattern: ${{ fromJSON(toJSON(matrix)).tagPattern }}
+          GHVersionSource: ${{ fromJSON(toJSON(matrix)).versionSource }}
+          WinMatschOverridePack: ${{ fromJSON(toJSON(matrix)).overridePack }}
+          AllowStructuralRewrite: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           PackageName: ${{ matrix.id }}
           With: ${{ matrix.With }}
           Submit: "false"

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -450,7 +450,7 @@ jobs:
             url: https://github.com/4thOffice/loopinupdater/releases/download/v{VERSION}/Loop-Email-Setup-{VERSION}.exe https://github.com/4thOffice/loopinupdater/releases/download/v{VERSION}/Loop-Email-Setup-{VERSION}.exe
           - id: IPEP.Scantailor-Experimental
             repo: ImageProcessing-ElectronicPublications/scantailor-experimental
-            url: https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-32-install.exe https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-64-install.exe https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-ARM64-Qt6-install.exe
+            url: https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-64-install.exe
           - id: Istio.Istio
             repo: istio/istio
             url: https://github.com/istio/istio/releases/download/{VERSION}/istio-{VERSION}-win.zip
@@ -463,9 +463,6 @@ jobs:
           - id: JackieLiu.NotepadsApp
             repo: 0x7c13/Notepads
             url: https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle
-          - id: jadquir.MRA
-            repo: Jadquir/mra-files
-            url: https://github.com/Jadquir/mra-files/releases/download/0.111/MRA_Setup_x64.msi
           - id: jaegertracing.jaeger
             repo: jaegertracing/jaeger
             url: https://github.com/jaegertracing/jaeger/releases/download/v{VERSION}/jaeger-{VERSION}-windows-amd64.zip
@@ -685,6 +682,7 @@ jobs:
           - id: OpenTelemetry.Weaver
             repo: open-telemetry/weaver
             url: https://github.com/open-telemetry/weaver/releases/download/v{VERSION}/weaver-x86_64-pc-windows-msvc.zip
+            allowStructuralRewrite: true
           - id: OpenTofu.Tofu
             repo: opentofu/opentofu
             url: https://github.com/opentofu/opentofu/releases/download/v{VERSION}/tofu_{VERSION}_windows_386.zip https://github.com/opentofu/opentofu/releases/download/v{VERSION}/tofu_{VERSION}_windows_amd64.zip
@@ -780,9 +778,10 @@ jobs:
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
-          GHTagPattern: ${{ matrix.tagPattern }}
-          GHVersionSource: ${{ matrix.versionSource }}
-          WinMatschOverridePack: ${{ matrix.overridePack }}
+          GHTagPattern: ${{ fromJSON(toJSON(matrix)).tagPattern }}
+          GHVersionSource: ${{ fromJSON(toJSON(matrix)).versionSource }}
+          WinMatschOverridePack: ${{ fromJSON(toJSON(matrix)).overridePack }}
+          AllowStructuralRewrite: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           PackageName: ${{ matrix.id }}
           With: ${{ matrix.With }}
           Submit: "false"

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -369,9 +369,10 @@ jobs:
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
-          GHTagPattern: ${{ matrix.tagPattern }}
-          GHVersionSource: ${{ matrix.versionSource }}
-          WinMatschOverridePack: ${{ matrix.overridePack }}
+          GHTagPattern: ${{ fromJSON(toJSON(matrix)).tagPattern }}
+          GHVersionSource: ${{ fromJSON(toJSON(matrix)).versionSource }}
+          WinMatschOverridePack: ${{ fromJSON(toJSON(matrix)).overridePack }}
+          AllowStructuralRewrite: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           PackageName: ${{ matrix.id }}
           With: ${{ matrix.With }}
           Submit: "false"

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ its matrix entry's `overridePack` field to that repository-relative path:
 The single-package workflow exposes the same path as `overridePack`. The wrapper
 rejects missing files and rejects override packs with Komac or WinGetCreate, so
 an override cannot be silently ignored.
+
+For a reviewed installer architecture, type, or scope transition, set
+`allowStructuralRewrite: true` on that package's matrix entry. This approval is
+disabled by default and maps only to WinMatsch's `--allow-structural-rewrite`
+option.

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -445,7 +445,7 @@
             url: "https://github.com/4thOffice/loopinupdater/releases/download/v{VERSION}/Loop-Email-Setup-{VERSION}.exe https://github.com/4thOffice/loopinupdater/releases/download/v{VERSION}/Loop-Email-Setup-{VERSION}.exe"
           - id: "IPEP.Scantailor-Experimental"
             repo: "ImageProcessing-ElectronicPublications/scantailor-experimental"
-            url: "https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-32-install.exe https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-64-install.exe https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-ARM64-Qt6-install.exe"
+            url: "https://github.com/ImageProcessing-ElectronicPublications/scantailor-experimental/releases/download/{VERSION}/scantailor-experimental-{VERSION}-X86-64-install.exe"
           - id: "Istio.Istio"
             repo: "istio/istio"
             url: "https://github.com/istio/istio/releases/download/{VERSION}/istio-{VERSION}-win.zip"
@@ -461,9 +461,7 @@
           - id: "JackieLiu.NotepadsApp"
             repo: "0x7c13/Notepads"
             url: "https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle https://github.com/0x7c13/Notepads/releases/download/v{VERSION}/Notepads_{VERSION}_x86_x64_arm64.msixbundle"
-          - id: "jadquir.MRA"
-            repo: "Jadquir/mra-files"
-            url: "https://github.com/Jadquir/mra-files/releases/download/0.111/MRA_Setup_x64.msi"
+          # jadquir.MRA is excluded: current releases redirect to versionless external downloads while the GitHub tag and asset versions are unrelated.
           - id: "jaegertracing.jaeger"
             repo: "jaegertracing/jaeger"
             url: "https://github.com/jaegertracing/jaeger/releases/download/v{VERSION}/jaeger-{VERSION}-windows-amd64.zip"
@@ -704,6 +702,7 @@
           - id: "OpenTelemetry.Weaver"
             repo: "open-telemetry/weaver"
             url: "https://github.com/open-telemetry/weaver/releases/download/v{VERSION}/weaver-x86_64-pc-windows-msvc.zip"
+            allowStructuralRewrite: true
           - id: "OpenTofu.Tofu"
             repo: "opentofu/opentofu"
             url: "https://github.com/opentofu/opentofu/releases/download/v{VERSION}/tofu_{VERSION}_windows_386.zip https://github.com/opentofu/opentofu/releases/download/v{VERSION}/tofu_{VERSION}_windows_amd64.zip"
@@ -1374,7 +1373,6 @@
 #          - id: "Jellyfin.Server"
 #            repo: "jellyfin/jellyfin-server-windows"
 #            url: "https://github.com/jellyfin/jellyfin-server-windows/releases/download/{VERSION}/jellyfin_{VERSION}_windows-x64.exe"
-
 
 
 

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -32,7 +32,8 @@ function Update-WingetPackage {
         [Parameter(Mandatory = $false)] [string] $GHURLs,
         [Parameter(Mandatory = $false)] [string] $GHTagPattern,
         [Parameter(Mandatory = $false)][ValidateSet('Tag', 'ReleaseName')] [string] $GHVersionSource = 'Tag',
-        [Parameter(Mandatory = $false)] [string] $WinMatschOverridePack
+        [Parameter(Mandatory = $false)] [string] $WinMatschOverridePack,
+        [Parameter(Mandatory = $false)] [bool] $AllowStructuralRewrite = $false
     )
 
     # Initialize result object
@@ -104,6 +105,9 @@ function Update-WingetPackage {
     if ($ContainsArchitectureHints -and $With -eq 'Komac') {
         Write-Warning 'Architecture suffixes detected in installer URLs. Switching from Komac to WinGetCreate so the hints are preserved.'
         $EffectiveWith = 'WinGetCreate'
+    }
+    if ($AllowStructuralRewrite -and $EffectiveWith -ne 'WinMatsch') {
+        throw 'AllowStructuralRewrite can only be used with the WinMatsch generator.'
     }
 
     $ResolvedWinMatschOverridePack = $null
@@ -189,6 +193,9 @@ function Update-WingetPackage {
                         "--version", $Latest.Version
                     )
                     $winmatschArgs += Get-WinMatschInstallerUrlArguments -InstallerEntries $RequestedInstallerEntries
+                    if ($AllowStructuralRewrite) {
+                        $winmatschArgs += "--allow-structural-rewrite"
+                    }
                     if ($resolves -match '^\d+$') {
                         $winmatschArgs += "--resolves"
                         $winmatschArgs += $resolves

--- a/scripts/Update-Package.ps1
+++ b/scripts/Update-Package.ps1
@@ -57,5 +57,8 @@ if ($Env:GHVersionSource) {
 if ($Env:WinMatschOverridePack) {
     $params.Add("WinMatschOverridePack", $Env:WinMatschOverridePack)
 }
+if ($Env:AllowStructuralRewrite -eq $true) {
+    $params.Add("AllowStructuralRewrite", $true)
+}
 
 Update-WingetPackage @params

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -40,11 +40,17 @@ function Get-TestWinMatschUrlArguments {
 function Invoke-TestUpdateWingetPackage {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$InstallerValue
+        [string]$InstallerValue,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$AllowStructuralRewrite = $false
     )
 
     return @(& $module {
-            param([string]$Value)
+            param(
+                [string]$Value,
+                [bool]$AllowRewrite
+            )
 
             function Test-GitHubToken { 'test-token' }
             function Test-PackageAndVersionInGithub {
@@ -70,10 +76,11 @@ function Invoke-TestUpdateWingetPackage {
                 -WingetPackage 'Test.Package' `
                 -With 'WinMatsch' `
                 -latestVersion '1.0.0' `
-                -latestVersionURL $Value | Out-Null
+                -latestVersionURL $Value `
+                -AllowStructuralRewrite $AllowRewrite | Out-Null
 
             $script:CapturedWinMatschArguments
-        } $InstallerValue)
+        } $InstallerValue $AllowStructuralRewrite)
 }
 
 Write-Host 'TEST: plain URL is passed only through --urls'
@@ -145,5 +152,15 @@ Assert-SequenceEqual `
     -Actual $updateUrlArguments `
     -Expected @('--url', $f95CheckerUrl) `
     -Message 'Update-WingetPackage duplicated the F95Checker URL.'
+
+Write-Host 'TEST: structural rewrite approval is opt-in'
+$defaultUpdateArguments = Invoke-TestUpdateWingetPackage -InstallerValue $plainUrl
+if ($defaultUpdateArguments -contains '--allow-structural-rewrite') {
+    throw 'Update-WingetPackage enabled structural rewrite approval by default.'
+}
+$rewriteUpdateArguments = Invoke-TestUpdateWingetPackage -InstallerValue $plainUrl -AllowStructuralRewrite $true
+if (@($rewriteUpdateArguments | Where-Object { $_ -eq '--allow-structural-rewrite' }).Count -ne 1) {
+    throw 'Update-WingetPackage did not pass structural rewrite approval exactly once.'
+}
 
 Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary

Fixes the three GitHub-package generation failures observed in production run [30991440034](https://github.com/b0t-at/winget-pkgs-updates/actions/runs/30991440034):

- **IPEP.Scantailor-Experimental:** keep only the `X86-64` installer URL published by release `1.2026.07.07`. The previous `1.2026.05.05` release had X86-32, X86-64, and ARM64 installers, but X86-32 and ARM64 are genuinely absent from the current release.
- **jadquir.MRA:** exclude automated GitHub-release monitoring. The latest tag `0.2` has no assets and redirects to versionless external downloads, while the old `0.111` GitHub asset is reused by winget manifests with unrelated package versions (`0.111` and `1.10.0`), so there is no reliable tag/asset-to-package-version mapping.
- **OpenTelemetry.Weaver:** add a package-scoped `allowStructuralRewrite: true` setting and flow it to WinMatsch as `--allow-structural-rewrite`, explicitly approving the MSI-to-portable-ZIP layout change without weakening the default for any other package.

The generated GH Packages workflows were regenerated from the template. Optional matrix properties now use a JSON round-trip so sparse package entries remain actionlint-valid.

## Validation

- Parsed `github-releases-monitored.yml`, the workflow template, and both generated workflows with PyYAML.
- `tests/Save-PackageState.Tests.ps1` passed.
- `tests/Update-WingetPackage.Tests.ps1` passed, including opt-in structural-rewrite coverage.
- `actionlint` passed for both generated GH Packages workflows.
- Current Scantailor X86-64 URL returned HTTP 206.
- Current Weaver ZIP URL returned HTTP 206.