### PR TITLE
Restore WinMatsch installer source URL arguments

### DIFF
--- a/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
@@ -55,13 +55,12 @@ function Get-WinMatschInstallerUrlArguments {
     )
 
     foreach ($installerEntry in $InstallerEntries) {
+        '--urls'
+        $installerEntry.InstallerUrl
+
         if ($installerEntry.ArchitectureHint) {
             '--url'
             $installerEntry.OriginalValue
-        }
-        else {
-            '--urls'
-            $installerEntry.InstallerUrl
         }
     }
 }

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -100,28 +100,47 @@ Assert-SequenceEqual `
     -Expected @('--urls', $plainUrls[0], '--urls', $plainUrls[1]) `
     -Message 'Multiple plain URL arguments were incorrect.'
 
-Write-Host 'TEST: architecture-qualified URL is passed only through --url'
+Write-Host 'TEST: architecture-qualified URL is passed through --urls and --url'
 $architectureUrl = 'https://github.com/sunfish-shogi/shogihome/releases/download/v1.0.0/release-v1.0.0-win.zip|x86'
+$architectureInstallerUrl = $architectureUrl.Split('|')[0]
 Assert-SequenceEqual `
     -Actual (Get-TestWinMatschUrlArguments -InstallerValues $architectureUrl) `
-    -Expected @('--url', $architectureUrl) `
+    -Expected @('--urls', $architectureInstallerUrl, '--url', $architectureUrl) `
     -Message 'Architecture-qualified URL arguments were incorrect.'
 
-Write-Host 'TEST: F95Checker neutral URL is not passed a second time as a plain URL'
-$f95CheckerUrl = 'https://github.com/Willy-JL/F95Checker/releases/download/12.0.0/F95Checker-Windows.zip|neutral'
+Write-Host 'TEST: F95Checker neutral URL is passed through --urls and --url'
+$f95CheckerUrl = 'https://github.com/Willy-JL/F95Checker/releases/download/11.1.3/F95Checker-Windows.zip|neutral'
+$f95CheckerInstallerUrl = $f95CheckerUrl.Split('|')[0]
 Assert-SequenceEqual `
     -Actual (Get-TestWinMatschUrlArguments -InstallerValues $f95CheckerUrl) `
-    -Expected @('--url', $f95CheckerUrl) `
+    -Expected @('--urls', $f95CheckerInstallerUrl, '--url', $f95CheckerUrl) `
     -Message 'F95Checker URL arguments were incorrect.'
 
-Write-Host 'TEST: scoped URL is passed only through --url'
+Write-Host 'TEST: scoped URL is passed through --urls and --url'
 $scopedUrl = 'https://example.invalid/app.zip|neutral|machine'
+$scopedInstallerUrl = $scopedUrl.Split('|')[0]
 Assert-SequenceEqual `
     -Actual (Get-TestWinMatschUrlArguments -InstallerValues $scopedUrl) `
-    -Expected @('--url', $scopedUrl) `
+    -Expected @('--urls', $scopedInstallerUrl, '--url', $scopedUrl) `
     -Message 'Scoped URL arguments were incorrect.'
 
-Write-Host 'TEST: mixed URL list passes every installer exactly once'
+Write-Host 'TEST: same-URL dual-scope entries preserve both source and override representations'
+$zeroInstallUrl = 'https://github.com/0install/0install-win/releases/download/2.29.2/zero-install.exe'
+$zeroInstallUrls = @(
+    "$zeroInstallUrl|x86|user"
+    "$zeroInstallUrl|x86|machine"
+)
+Assert-SequenceEqual `
+    -Actual (Get-TestWinMatschUrlArguments -InstallerValues $zeroInstallUrls) `
+    -Expected @(
+        '--urls', $zeroInstallUrl
+        '--url', $zeroInstallUrls[0]
+        '--urls', $zeroInstallUrl
+        '--url', $zeroInstallUrls[1]
+    ) `
+    -Message 'Same-URL dual-scope arguments were incorrect.'
+
+Write-Host 'TEST: mixed URL list preserves source entries and qualified overrides'
 $mixedUrls = @(
     'https://example.invalid/plain-x64.zip'
     'https://example.invalid/qualified-x86.zip|x86'
@@ -132,13 +151,15 @@ Assert-SequenceEqual `
     -Actual (Get-TestWinMatschUrlArguments -InstallerValues $mixedUrls) `
     -Expected @(
         '--urls', $mixedUrls[0]
+        '--urls', $mixedUrls[1].Split('|')[0]
         '--url', $mixedUrls[1]
         '--urls', $mixedUrls[2]
+        '--urls', $mixedUrls[3].Split('|')[0]
         '--url', $mixedUrls[3]
     ) `
     -Message 'Mixed URL arguments were incorrect.'
 
-Write-Host 'TEST: Update-WingetPackage sends the production-shaped URL only once'
+Write-Host 'TEST: Update-WingetPackage sends both representations for a qualified URL'
 $updateArguments = Invoke-TestUpdateWingetPackage -InstallerValue $f95CheckerUrl
 $updateUrlArguments = [System.Collections.Generic.List[string]]::new()
 for ($index = 0; $index -lt $updateArguments.Count; $index++) {
@@ -150,8 +171,28 @@ for ($index = 0; $index -lt $updateArguments.Count; $index++) {
 }
 Assert-SequenceEqual `
     -Actual $updateUrlArguments `
-    -Expected @('--url', $f95CheckerUrl) `
-    -Message 'Update-WingetPackage duplicated the F95Checker URL.'
+    -Expected @('--urls', $f95CheckerInstallerUrl, '--url', $f95CheckerUrl) `
+    -Message 'Update-WingetPackage did not preserve the F95Checker source and override.'
+
+Write-Host 'TEST: Update-WingetPackage preserves same-URL dual-scope entries'
+$zeroInstallUpdateArguments = Invoke-TestUpdateWingetPackage -InstallerValue ($zeroInstallUrls -join ' ')
+$zeroInstallUpdateUrlArguments = [System.Collections.Generic.List[string]]::new()
+for ($index = 0; $index -lt $zeroInstallUpdateArguments.Count; $index++) {
+    if ($zeroInstallUpdateArguments[$index] -in @('--url', '--urls')) {
+        $zeroInstallUpdateUrlArguments.Add($zeroInstallUpdateArguments[$index])
+        $zeroInstallUpdateUrlArguments.Add($zeroInstallUpdateArguments[$index + 1])
+        $index++
+    }
+}
+Assert-SequenceEqual `
+    -Actual $zeroInstallUpdateUrlArguments `
+    -Expected @(
+        '--urls', $zeroInstallUrl
+        '--url', $zeroInstallUrls[0]
+        '--urls', $zeroInstallUrl
+        '--url', $zeroInstallUrls[1]
+    ) `
+    -Message 'Update-WingetPackage did not preserve the same-URL dual-scope entries.'
 
 Write-Host 'TEST: structural rewrite approval is opt-in'
 $defaultUpdateArguments = Invoke-TestUpdateWingetPackage -InstallerValue $plainUrl


### PR DESCRIPTION
## Summary

- restore WinMatsch's required dual representation for qualified installer entries: `--urls <source>` plus `--url <qualified spec>`
- keep plain entries unchanged as a single `--urls <source>` pair
- preserve same-URL user/machine entries independently, including both source occurrences and both qualified overrides
- update the PR #150 regression tests for sunfish, F95Checker, mixed inputs, and ZeroInstall's production dual-scope layout

## Regression

[Run 31018793841](https://github.com/b0t-at/winget-pkgs-updates/actions/runs/31018793841) was the first production run on WinMatsch 0.8.13. Deckboard, F95Checker, and ZeroInstall reached WinMatsch with qualified `--url` arguments but no source `--urls` arguments, then failed with `WF_INVALID: No Windows release assets were supplied or discovered`.

[PR #150](https://github.com/b0t-at/winget-pkgs-updates/pull/150) suppressed `--urls` for qualified entries to work around duplicate-key failures in WinMatsch 0.8.11/0.8.12. WinMatsch's command reference defines `--urls` as the installer source list and `--url` as a qualifier override. WinMatsch 0.8.13's changelog and [PR #36](https://github.com/b0t-at/winmatsch/pull/36) document same-URL multi-scope support and qualified-override absorption, so callers must again supply both representations.

## Validation

- complete module regression suite passed: `Save-PackageState.Tests.ps1`, `Update-WingetPackage.Tests.ps1`, and `GitHubApiCache.Tests.ps1`
- all 40 module/test PowerShell files parse successfully
- `git diff --check` passed

### Live WinMatsch v0.8.13 dry runs

Downloaded `https://winmatsch.oneinfra.de/latest/winmatsch-win-x64.exe` and verified:

- version: `0.8.13+db0384078740be47d88bedbd34125e8997f54f0f`
- SHA-256: `492e5efcb316434a8368662486afbd85758e1036789c8586f26bc741baeed207` (matches the v0.8.13 release digest)

ZeroInstall succeeds with the restored composition:

```text
winmatsch update ZeroInstall.ZeroInstall --version 2.29.2 \
  --urls <zero-install.exe> --url <zero-install.exe>|x86|user \
  --urls <zero-install.exe> --url <zero-install.exe>|x86|machine \
  --dry-run --interaction never
```

Result: exit `0`, `success=true`; the preview contains separate x86/user and x86/machine entries sharing the URL with their inherited scope-specific switches.

F95Checker exposed a remaining WinMatsch 0.8.13 absorption gap with the real 11.1.3 archive:

```text
winmatsch update WillyJL.F95Checker --version 11.1.3 \
  --urls <F95Checker-Windows.zip> --url <F95Checker-Windows.zip>|neutral \
  --dry-run --interaction never
```

Result: exit `4`, `MAP_AMBIGUOUS` plus `MAP_DUPLICATE_INSTALLER_KEY (Neutral|Zip||)`. The exact `winmatsch analyze` installer-shape evidence from the real 11.1.3 ZIP is:

```json
[
  {
    "architecture": "x64",
    "installerType": "zip",
    "nestedInstallerType": "portable"
  },
  {
    "architecture": "arm64",
    "installerType": "zip",
    "nestedInstallerType": "portable"
  }
]
```

The `|neutral` override forces both candidates to the same effective key, and v0.8.13 `CollapseQualifiedVariants` does not absorb them. A plain-source control fails `MAP_REMOVED`. This is an upstream v0.8.13 issue rather than a caller argument-composition failure; it has been reported for the next WinMatsch release.

No submissions or GitHub mutations were performed by either live generation command.