### PR TITLE
Retry safe WinMatsch branch-moved submissions

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -41,4 +41,7 @@ jobs:
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1
-          Invoke-Pester ./tests/Submit-WingetPackage.Tests.ps1 -EnableExit
+          $pesterConfig = New-PesterConfiguration
+          $pesterConfig.Run.Path = './tests/Submit-WingetPackage.Tests.ps1'
+          $pesterConfig.Run.Exit = $true
+          Invoke-Pester -Configuration $pesterConfig

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -41,3 +41,4 @@ jobs:
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1
+          Invoke-Pester ./tests/Submit-WingetPackage.Tests.ps1 -EnableExit

--- a/modules/WingetMaintainerModule/Private/WinMatschSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/WinMatschSubmission.ps1
@@ -1,0 +1,96 @@
+function Invoke-WinMatschSubmitAttempt {
+    <#
+    .SYNOPSIS
+        Submits one freshly validated WinMatsch pull request attempt.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ManifestPath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PrTitle,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Token,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Resolves
+    )
+
+    $winmatschArgs = @(
+        'submit'
+        $ManifestPath
+        '--submit'
+        '--yes'
+        '--prtitle', $PrTitle
+        '--token', $Token
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($Resolves)) {
+        $winmatschArgs += '--resolves'
+        $winmatschArgs += $Resolves
+    }
+
+    # Each attempt receives a new result file so retry decisions are based on
+    # that attempt's remote preflight and not on stale structured output.
+    $resultJsonPath = $null
+    if (Test-WinMatschSupportsResultJson -Command 'submit') {
+        $resultJsonPath = New-WinMatschResultJsonPath -Label 'submit'
+        $winmatschArgs += '--result-json'
+        $winmatschArgs += $resultJsonPath
+    }
+
+    $displayArgs = $winmatschArgs | ForEach-Object {
+        if ($_ -eq $Token) { '***' } else { $_ }
+    }
+    Write-Host "--> Running: winmatsch $($displayArgs -join ' ')" -ForegroundColor White
+
+    $output = @(& winmatsch @winmatschArgs 2>&1)
+    $exitCode = $LASTEXITCODE
+    Write-Host $output
+
+    $result = Read-WinMatschResult -Path $resultJsonPath
+    if ($resultJsonPath) {
+        Remove-Item -LiteralPath $resultJsonPath -Force -ErrorAction SilentlyContinue
+    }
+
+    return [pscustomobject]@{
+        ExitCode  = $exitCode
+        Output    = $output
+        Result    = $result
+        ErrorCode = if ($result -and $result.error) { "$($result.error.code)".Trim() } else { $null }
+        Error     = Get-WinMatschResultError -Result $result
+    }
+}
+
+function Test-WinMatschBranchMovedRetryable {
+    <#
+    .SYNOPSIS
+        Returns true only for WinMatsch's known-safe GH2020 retry condition.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object] $Attempt
+    )
+
+    if ($Attempt.ExitCode -eq 0) {
+        return $false
+    }
+
+    $details = @(
+        "$($Attempt.ErrorCode)"
+        "$($Attempt.Error)"
+        ($Attempt.Output | Out-String)
+    ) -join "`n"
+
+    if ($details -notmatch '(?i)\bGH2020\b') {
+        return $false
+    }
+
+    # A retry is unsafe when WinMatsch cannot determine whether a remote write
+    # succeeded. Let the run fail instead of risking a duplicate submission.
+    return $details -notmatch '(?i)remote outcome uncertain:\s*true|recovery required:\s*true'
+}

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -30,6 +30,10 @@
     GitHub Personal Access Token with repo scope. If not provided, uses
     GITHUB_TOKEN or WINGET_PAT environment variables.
 
+.PARAMETER MaxBranchMovedRetries
+    Maximum retries after WinMatsch reports its safe GH2020 branch-moved
+    conflict. Each retry runs a fresh WinMatsch validation/submission attempt.
+
 .EXAMPLE
     Submit-WingetPackage -ManifestPath "./manifests/f/Fork/Fork/1.85.0" `
         -PackageId "Fork.Fork" -Version "1.85.0"
@@ -78,7 +82,11 @@ function Submit-WingetPackage {
         [string] $With = "WinMatsch",
 
         [Parameter(Mandatory = $false)]
-        [string] $Token
+        [string] $Token,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 3)]
+        [int] $MaxBranchMovedRetries = 1
     )
 
     # Get GitHub token
@@ -121,50 +129,52 @@ function Submit-WingetPackage {
                 # Ensure WinMatsch is installed
                 Install-WinMatsch
 
-                # Build winmatsch submit command arguments
-                # --submit pushes the PR through the GitHub lifecycle; --yes approves non-interactively
-                $winmatschArgs = @(
-                    "submit"
-                    $fullManifestPath
-                    "--submit"
-                    "--yes"
-                    "--prtitle", $PrTitle
-                    "--token", $Token
-                )
+                $maxAttempts = $MaxBranchMovedRetries + 1
+                for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+                    # This is a read-only check against microsoft/winget-pkgs.
+                    # WinMatsch remains the only component that creates the PR.
+                    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version) {
+                        $existingPrUrl = Get-WingetPkgsPrUrl -PackageId $PackageId -Version $Version
+                        $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
+                            $Matches['Number']
+                        }
+                        else {
+                            $null
+                        }
 
-                # Add resolves if provided
-                if (-not [string]::IsNullOrWhiteSpace($Resolves)) {
-                    $winmatschArgs += "--resolves"
-                    $winmatschArgs += $Resolves
-                }
+                        Write-Host 'A matching winget-pkgs PR already exists; skipping submission.' -ForegroundColor Yellow
+                        return @{
+                            Success  = $true
+                            Error    = $null
+                            PrUrl    = $existingPrUrl
+                            PrNumber = $existingPrNumber
+                        }
+                    }
 
-                # Only newer builds understand --result-json; older ones reject the flag outright.
-                $resultJsonPath = $null
-                if (Test-WinMatschSupportsResultJson -Command 'submit') {
-                    $resultJsonPath = New-WinMatschResultJsonPath -Label 'submit'
-                    $winmatschArgs += "--result-json"
-                    $winmatschArgs += $resultJsonPath
-                }
+                    $attemptResult = Invoke-WinMatschSubmitAttempt `
+                        -ManifestPath $fullManifestPath `
+                        -PrTitle $PrTitle `
+                        -Token $Token `
+                        -Resolves $Resolves
+                    $output = $attemptResult.Output
+                    $exitCode = $attemptResult.ExitCode
+                    $winmatschResult = $attemptResult.Result
 
-                Write-Host "--> Running: winmatsch $($winmatschArgs -replace $Token, '***' -join ' ')" -ForegroundColor White
+                    if ($exitCode -eq 0) {
+                        break
+                    }
 
-                $output = & winmatsch @winmatschArgs 2>&1
-                $exitCode = $LASTEXITCODE
-
-                Write-Host $output
-
-                $winmatschResult = Read-WinMatschResult -Path $resultJsonPath
-                if ($resultJsonPath) {
-                    Remove-Item -LiteralPath $resultJsonPath -Force -ErrorAction SilentlyContinue
-                }
-
-                if ($exitCode -ne 0) {
-                    $reportedError = Get-WinMatschResultError -Result $winmatschResult
+                    $reportedError = $attemptResult.Error
                     if (-not $reportedError) { $reportedError = "Output: $output" }
+
+                    if ((Test-WinMatschBranchMovedRetryable -Attempt $attemptResult) -and $attempt -lt $maxAttempts) {
+                        Write-Warning "WinMatsch validated branch moved before PR creation (GH2020); retrying fresh validation ($($attempt + 1) of $maxAttempts)."
+                        continue
+                    }
 
                     return @{
                         Success  = $false
-                        Error    = "WinMatsch submit failed with exit code $exitCode. $reportedError"
+                        Error    = "WinMatsch submit failed with exit code $exitCode after $attempt attempt(s). $reportedError"
                         PrUrl    = $null
                         PrNumber = $null
                     }

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -1,57 +1,60 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-Import-Module Pester -MinimumVersion 3.4
-
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
 Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
-$global:SubmitWingetPackageTestManifestPath = Join-Path ([IO.Path]::GetTempPath()) "winget-submit-tests-$([guid]::NewGuid().ToString('N'))"
-New-Item -ItemType Directory -Path $global:SubmitWingetPackageTestManifestPath -Force | Out-Null
 
-$global:NewTestSubmissionAttempt = {
-    param(
-        [int] $ExitCode,
-        [string] $ErrorCode,
-        [string] $ErrorMessage,
-        [string] $PrUrl
-    )
+Describe 'Submit-WingetPackage branch-moved retry' {
+    BeforeEach {
+        $global:SubmitWingetPackageTestManifestPath = Join-Path ([IO.Path]::GetTempPath()) "winget-submit-tests-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $global:SubmitWingetPackageTestManifestPath -Force | Out-Null
+        $global:NewTestSubmissionAttempt = {
+            param(
+                [int] $ExitCode,
+                [string] $ErrorCode,
+                [string] $ErrorMessage,
+                [string] $PrUrl
+            )
 
-    $result = if ($ErrorCode) {
-        [pscustomobject]@{
-            error = [pscustomobject]@{
-                code    = $ErrorCode
-                message = $ErrorMessage
+            if ($ErrorCode) {
+                $result = [pscustomobject]@{
+                    error = [pscustomobject]@{
+                        code    = $ErrorCode
+                        message = $ErrorMessage
+                    }
+                }
+            }
+            else {
+                $result = [pscustomobject]@{
+                    pullRequest = [pscustomobject]@{
+                        url    = $PrUrl
+                        number = '12345'
+                    }
+                }
+            }
+
+            return [pscustomobject]@{
+                ExitCode  = $ExitCode
+                Output    = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { "Created $PrUrl" }
+                Result    = $result
+                ErrorCode = $ErrorCode
+                Error     = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { $null }
             }
         }
-    }
-    else {
-        [pscustomobject]@{
-            pullRequest = [pscustomobject]@{
-                url    = $PrUrl
-                number = '12345'
-            }
+
+        InModuleScope WingetMaintainerModule {
+            $script:submissionAttempts = 0
+            Mock Install-WinMatsch {}
+            Mock Test-ExistingPRs { $false }
+            Mock Get-WingetPkgsPrUrl { $null }
         }
     }
 
-    return [pscustomobject]@{
-        ExitCode  = $ExitCode
-        Output    = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { "Created $PrUrl" }
-        Result    = $result
-        ErrorCode = $ErrorCode
-        Error     = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { $null }
+    AfterEach {
+        Remove-Item -LiteralPath $global:SubmitWingetPackageTestManifestPath -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Variable -Name SubmitWingetPackageTestManifestPath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name NewTestSubmissionAttempt -Scope Global -ErrorAction SilentlyContinue
     }
-}
-
-try {
-    Describe 'Submit-WingetPackage branch-moved retry' {
-        BeforeEach {
-            InModuleScope WingetMaintainerModule {
-                $script:submissionAttempts = 0
-                Mock Install-WinMatsch {}
-                Mock Test-ExistingPRs { $false }
-                Mock Get-WingetPkgsPrUrl { $null }
-            }
-        }
 
         It 'revalidates and submits once after a safe GH2020 branch movement' {
             InModuleScope WingetMaintainerModule {
@@ -160,9 +163,3 @@ try {
             }
         }
     }
-}
-finally {
-    Remove-Item -LiteralPath $global:SubmitWingetPackageTestManifestPath -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Variable -Name SubmitWingetPackageTestManifestPath -Scope Global -ErrorAction SilentlyContinue
-    Remove-Variable -Name NewTestSubmissionAttempt -Scope Global -ErrorAction SilentlyContinue
-}

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -4,7 +4,7 @@ Set-StrictMode -Version Latest
 Import-Module Pester -MinimumVersion 3.4
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
-$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
 $global:SubmitWingetPackageTestManifestPath = Join-Path ([IO.Path]::GetTempPath()) "winget-submit-tests-$([guid]::NewGuid().ToString('N'))"
 New-Item -ItemType Directory -Path $global:SubmitWingetPackageTestManifestPath -Force | Out-Null
 
@@ -45,7 +45,7 @@ $global:NewTestSubmissionAttempt = {
 try {
     Describe 'Submit-WingetPackage branch-moved retry' {
         BeforeEach {
-            InModuleScope $module.Name {
+            InModuleScope WingetMaintainerModule {
                 $script:submissionAttempts = 0
                 Mock Install-WinMatsch {}
                 Mock Test-ExistingPRs { $false }
@@ -54,7 +54,7 @@ try {
         }
 
         It 'revalidates and submits once after a safe GH2020 branch movement' {
-            InModuleScope $module.Name {
+            InModuleScope WingetMaintainerModule {
                 Mock Invoke-WinMatschSubmitAttempt {
                     $script:submissionAttempts++
                     if ($script:submissionAttempts -eq 1) {
@@ -83,7 +83,7 @@ try {
         }
 
         It 'fails closed when the bounded GH2020 retry is exhausted' {
-            InModuleScope $module.Name {
+            InModuleScope WingetMaintainerModule {
                 Mock Invoke-WinMatschSubmitAttempt {
                     & $global:NewTestSubmissionAttempt -ExitCode 5 -ErrorCode 'GH2020' -ErrorMessage 'The validated branch moved immediately before pull request creation.'
                 }
@@ -107,7 +107,7 @@ try {
         }
 
         It 'does not submit again when another worker created the matching PR' {
-            InModuleScope $module.Name {
+            InModuleScope WingetMaintainerModule {
                 $script:existingChecks = 0
                 Mock Test-ExistingPRs {
                     $script:existingChecks++
@@ -137,7 +137,7 @@ try {
         }
 
         It 'fails closed instead of retrying an uncertain GH2020 remote outcome' {
-            InModuleScope $module.Name {
+            InModuleScope WingetMaintainerModule {
                 Mock Invoke-WinMatschSubmitAttempt {
                     & $global:NewTestSubmissionAttempt `
                         -ExitCode 5 `

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -1,0 +1,168 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Import-Module Pester -MinimumVersion 3.4
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+$global:SubmitWingetPackageTestManifestPath = Join-Path ([IO.Path]::GetTempPath()) "winget-submit-tests-$([guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $global:SubmitWingetPackageTestManifestPath -Force | Out-Null
+
+$global:NewTestSubmissionAttempt = {
+    param(
+        [int] $ExitCode,
+        [string] $ErrorCode,
+        [string] $ErrorMessage,
+        [string] $PrUrl
+    )
+
+    $result = if ($ErrorCode) {
+        [pscustomobject]@{
+            error = [pscustomobject]@{
+                code    = $ErrorCode
+                message = $ErrorMessage
+            }
+        }
+    }
+    else {
+        [pscustomobject]@{
+            pullRequest = [pscustomobject]@{
+                url    = $PrUrl
+                number = '12345'
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        ExitCode  = $ExitCode
+        Output    = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { "Created $PrUrl" }
+        Result    = $result
+        ErrorCode = $ErrorCode
+        Error     = if ($ErrorCode) { "$ErrorCode : $ErrorMessage" } else { $null }
+    }
+}
+
+try {
+    Describe 'Submit-WingetPackage branch-moved retry' {
+        BeforeEach {
+            InModuleScope $module.Name {
+                $script:submissionAttempts = 0
+                Mock Install-WinMatsch {}
+                Mock Test-ExistingPRs { $false }
+                Mock Get-WingetPkgsPrUrl { $null }
+            }
+        }
+
+        It 'revalidates and submits once after a safe GH2020 branch movement' {
+            InModuleScope $module.Name {
+                Mock Invoke-WinMatschSubmitAttempt {
+                    $script:submissionAttempts++
+                    if ($script:submissionAttempts -eq 1) {
+                        return & $global:NewTestSubmissionAttempt -ExitCode 5 -ErrorCode 'GH2020' -ErrorMessage 'The validated branch moved immediately before pull request creation.'
+                    }
+
+                    return & $global:NewTestSubmissionAttempt -ExitCode 0 -PrUrl 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                }
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token' `
+                    -MaxBranchMovedRetries 1
+
+                if ($result.Success -ne $true) {
+                    throw "Expected a successful retry, got: $($result.Error)"
+                }
+                if ($result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/12345') {
+                    throw "The retry returned an unexpected PR URL: $($result.PrUrl)"
+                }
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 2 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+            }
+        }
+
+        It 'fails closed when the bounded GH2020 retry is exhausted' {
+            InModuleScope $module.Name {
+                Mock Invoke-WinMatschSubmitAttempt {
+                    & $global:NewTestSubmissionAttempt -ExitCode 5 -ErrorCode 'GH2020' -ErrorMessage 'The validated branch moved immediately before pull request creation.'
+                }
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token' `
+                    -MaxBranchMovedRetries 1
+
+                if ($result.Success -ne $false) {
+                    throw 'Retry exhaustion unexpectedly reported success.'
+                }
+                if ($result.Error -notmatch 'after 2 attempt\(s\)') {
+                    throw "Retry exhaustion did not report the bounded attempt count: $($result.Error)"
+                }
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 2 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+            }
+        }
+
+        It 'does not submit again when another worker created the matching PR' {
+            InModuleScope $module.Name {
+                $script:existingChecks = 0
+                Mock Test-ExistingPRs {
+                    $script:existingChecks++
+                    return $script:existingChecks -eq 2
+                }
+                Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
+                Mock Invoke-WinMatschSubmitAttempt {
+                    & $global:NewTestSubmissionAttempt -ExitCode 5 -ErrorCode 'GH2020' -ErrorMessage 'The validated branch moved immediately before pull request creation.'
+                }
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token' `
+                    -MaxBranchMovedRetries 1
+
+                if ($result.Success -ne $true) {
+                    throw "The existing PR result was not successful: $($result.Error)"
+                }
+                if ($result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/54321') {
+                    throw "The existing PR URL was not returned: $($result.PrUrl)"
+                }
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 1 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+            }
+        }
+
+        It 'fails closed instead of retrying an uncertain GH2020 remote outcome' {
+            InModuleScope $module.Name {
+                Mock Invoke-WinMatschSubmitAttempt {
+                    & $global:NewTestSubmissionAttempt `
+                        -ExitCode 5 `
+                        -ErrorCode 'GH2020' `
+                        -ErrorMessage 'The validated branch moved. Remote outcome uncertain: true.'
+                }
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token' `
+                    -MaxBranchMovedRetries 3
+
+                if ($result.Success -ne $false) {
+                    throw 'An uncertain remote outcome unexpectedly retried or reported success.'
+                }
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 1 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 1 -Exactly -Scope It
+            }
+        }
+    }
+}
+finally {
+    Remove-Item -LiteralPath $global:SubmitWingetPackageTestManifestPath -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Variable -Name SubmitWingetPackageTestManifestPath -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable -Name NewTestSubmissionAttempt -Scope Global -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
Fixes recoverable WinMatsch GH2020 branch-moved submission failures. Retries only safe, certain GH2020 failures with fresh WinMatsch validation; checks for an existing PR before every attempt; and fails closed on unknown, exhausted, or uncertain outcomes. Adds Pester coverage for success, exhaustion, duplicate avoidance, and uncertain remote outcomes.