### PR TITLE
Avoid fork default-branch sync during scheduled submissions

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -612,6 +612,10 @@ jobs:
     runs-on: windows-2025
     if: always() && needs.collect-validated.result == 'success' && needs.collect-validated.outputs.has_packages == 'true'
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Test' }}
+    # Serialize submissions for the same package across scheduled runs.
+    concurrency:
+      group: winget-pkgs-submit-${{ matrix.PackageName }}
+      cancel-in-progress: false
 
     strategy:
       fail-fast: false
@@ -681,6 +685,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -690,7 +696,9 @@ jobs:
           $result = Submit-WingetPackage `
             -ManifestPath "$env:STEPS_MANIFEST_OUTPUTS_PATH" `
             -PackageId "$env:MATRIX_PACKAGENAME" `
-            -Version "$env:MATRIX_VERSION"
+            -Version "$env:MATRIX_VERSION" `
+            -With "ForkBranch" `
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -42,6 +42,9 @@ jobs:
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1
           $pesterConfig = New-PesterConfiguration
-          $pesterConfig.Run.Path = './tests/Submit-WingetPackage.Tests.ps1'
+          $pesterConfig.Run.Path = @(
+            './tests/Submit-WingetPackage.Tests.ps1',
+            './tests/ForkBranchSubmission.Tests.ps1'
+          )
           $pesterConfig.Run.Exit = $true
           Invoke-Pester -Configuration $pesterConfig

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1417,6 +1417,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -1427,7 +1429,8 @@ jobs:
             -ManifestPath "$env:STEPS_MANIFEST_OUTPUTS_PATH" `
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
-            -With "WinGetCreate"
+            -With "ForkBranch" `
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -1015,6 +1015,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -1025,7 +1027,8 @@ jobs:
             -ManifestPath "$env:STEPS_MANIFEST_OUTPUTS_PATH" `
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
-            -With "WinGetCreate"
+            -With "ForkBranch" `
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -652,6 +652,10 @@ jobs:
     runs-on: windows-2025
     if: always() && needs.collect-validated.result == 'success' && needs.collect-validated.outputs.has_packages == 'true'
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Test' }}
+    # Serialize submissions for the same package across scheduled runs.
+    concurrency:
+      group: winget-pkgs-submit-${{ matrix.PackageName }}
+      cancel-in-progress: false
     
     strategy:
       fail-fast: false
@@ -720,6 +724,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -729,7 +735,9 @@ jobs:
           $result = Submit-WingetPackage `
             -ManifestPath "$env:STEPS_MANIFEST_OUTPUTS_PATH" `
             -PackageId "$env:MATRIX_PACKAGENAME" `
-            -Version "$env:MATRIX_VERSION"
+            -Version "$env:MATRIX_VERSION" `
+            -With "ForkBranch" `
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
           
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green
@@ -793,5 +801,4 @@ jobs:
         env:
           VARS_NTFY_TOPIC: ${{ vars.NTFY_TOPIC }}
           VARS_NTFY_URL: ${{ vars.NTFY_URL }}
-
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@
 ## Tools:
 **[Orca](https://learn.microsoft.com/de-de/windows/win32/msi/orca-exe)**: database table editor for creating and editing Windows Installer packages
 
+## Scheduled submission topology
+
+Validated scheduled manifests use `ForkBranch` submission rather than
+`wingetcreate submit`. The module verifies `WINGET_PKGS_FORK_REPO` is a fork
+of `microsoft/winget-pkgs`, creates a disposable branch directly from the
+selected base commit, and commits only the manifest files to that branch. It
+never syncs or writes the fork default branch.
+
+Main-branch runs open the normal pull request from that user-owned fork branch
+to `microsoft/winget-pkgs`. Non-main test runs instead open the pull request
+inside the configured fork, so test submissions make no write to the Microsoft
+repository. The PAT needs repository contents and pull-request access to the
+user-owned fork; it does not need GitHub Actions workflow scope.
+
 ## Package-specific WinMatsch overrides
 
 Keep safety questions enabled by default. When a package has reviewed, stable

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ never syncs or writes the fork default branch.
 Main-branch runs open the normal pull request from that user-owned fork branch
 to `microsoft/winget-pkgs`. Non-main test runs instead open the pull request
 inside the configured fork, so test submissions make no write to the Microsoft
-repository. The PAT needs repository contents and pull-request access to the
-user-owned fork; it does not need GitHub Actions workflow scope.
+repository. A fine-grained PAT needs Contents write on the configured fork and
+Pull requests write on the selected PR target; it does not need GitHub Actions
+workflow scope.
 
 ## Package-specific WinMatsch overrides
 

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -1,0 +1,236 @@
+function Invoke-WingetPkgsGitHubApi {
+    <#
+    .SYNOPSIS
+        Calls the GitHub REST API without placing a token in a process argument.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Get', 'Post', 'Patch', 'Delete')]
+        [string] $Method,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Path,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Token,
+
+        [Parameter(Mandatory = $false)]
+        [object] $Body
+    )
+
+    $headers = @{
+        Accept                 = 'application/vnd.github+json'
+        Authorization          = "Bearer $Token"
+        'X-GitHub-Api-Version' = '2022-11-28'
+        'User-Agent'           = 'winget-pkgs-updates'
+    }
+    $request = @{
+        Uri         = "https://api.github.com/$($Path.TrimStart('/'))"
+        Method      = $Method
+        Headers     = $headers
+        ErrorAction = 'Stop'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Body')) {
+        $request.ContentType = 'application/json'
+        $request.Body = $Body | ConvertTo-Json -Depth 20 -Compress
+    }
+
+    return Invoke-RestMethod @request
+}
+
+function Get-ForkBranchSubmissionFiles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ManifestPath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    if ($PackageId -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]*$') {
+        throw "Package ID '$PackageId' is not safe for a winget manifest path."
+    }
+    if ($Version -match '[\\/]' -or $Version -match '^\.+$') {
+        throw "Version '$Version' is not safe for a winget manifest path."
+    }
+
+    $files = @(Get-ChildItem -LiteralPath $ManifestPath -File -ErrorAction Stop)
+    if ($files.Count -eq 0) {
+        throw "Manifest path '$ManifestPath' does not contain any files."
+    }
+
+    $unexpectedFiles = @($files | Where-Object { $_.Extension -notin @('.yaml', '.yml') })
+    if ($unexpectedFiles.Count -gt 0) {
+        $unexpectedNames = $unexpectedFiles.Name -join ', '
+        throw "Manifest path '$ManifestPath' contains non-manifest files: $unexpectedNames"
+    }
+
+    $manifestDirectory = "manifests/$($PackageId[0].ToString().ToLowerInvariant())/$($PackageId.Replace('.', '/'))/$Version"
+    return @(
+        $files | ForEach-Object {
+            [pscustomobject]@{
+                Path    = "$manifestDirectory/$($_.Name)"
+                Content = Get-Content -LiteralPath $_.FullName -Raw -ErrorAction Stop
+            }
+        }
+    )
+}
+
+function Invoke-ForkBranchSubmission {
+    <#
+    .SYNOPSIS
+        Creates a submission branch in a verified user fork without syncing its default branch.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ManifestPath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PrTitle,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Token,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ForkRepository,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Upstream', 'Fork')]
+        [string] $SubmissionTarget = 'Upstream',
+
+        [Parameter(Mandatory = $false)]
+        [string] $Resolves
+    )
+
+    $upstreamRepository = 'microsoft/winget-pkgs'
+    if ($ForkRepository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+        throw "WINGET_PKGS_FORK_REPO must be an owner/repository name, not '$ForkRepository'."
+    }
+    if ($ForkRepository -ieq $upstreamRepository) {
+        throw 'WINGET_PKGS_FORK_REPO must name a user-owned fork, never microsoft/winget-pkgs.'
+    }
+
+    $fork = Invoke-WingetPkgsGitHubApi -Method Get -Path "repos/$ForkRepository" -Token $Token
+    if (-not $fork.fork -or "$($fork.parent.full_name)" -ine $upstreamRepository) {
+        throw "Configured repository '$ForkRepository' is not a fork of $upstreamRepository."
+    }
+
+    $targetRepository = if ($SubmissionTarget -eq 'Fork') { $ForkRepository } else { $upstreamRepository }
+    $targetDefaultBranch = "$($fork.default_branch)"
+    $baseRepository = $targetRepository
+
+    if ($SubmissionTarget -eq 'Upstream') {
+        $upstream = Invoke-WingetPkgsGitHubApi -Method Get -Path "repos/$upstreamRepository" -Token $Token
+        $targetDefaultBranch = "$($upstream.default_branch)"
+    }
+
+    $baseReference = Invoke-WingetPkgsGitHubApi `
+        -Method Get `
+        -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch" `
+        -Token $Token
+    $baseSha = "$($baseReference.object.sha)"
+    if ([string]::IsNullOrWhiteSpace($baseSha)) {
+        throw "Could not resolve the $baseRepository/$targetDefaultBranch commit SHA."
+    }
+    $baseCommit = Invoke-WingetPkgsGitHubApi `
+        -Method Get `
+        -Path "repos/$baseRepository/git/commits/$baseSha" `
+        -Token $Token
+    $baseTreeSha = "$($baseCommit.tree.sha)"
+    if ([string]::IsNullOrWhiteSpace($baseTreeSha)) {
+        throw "Could not resolve the base tree for $baseRepository/$targetDefaultBranch."
+    }
+
+    $treeItems = Get-ForkBranchSubmissionFiles `
+        -ManifestPath $ManifestPath `
+        -PackageId $PackageId `
+        -Version $Version |
+        ForEach-Object {
+            @{
+                path    = $_.Path
+                mode    = '100644'
+                type    = 'blob'
+                content = $_.Content
+            }
+        }
+
+    # A branch is created directly from the selected base commit; the fork's
+    # default branch is read-only throughout this flow.
+    $tree = Invoke-WingetPkgsGitHubApi `
+        -Method Post `
+        -Path "repos/$ForkRepository/git/trees" `
+        -Token $Token `
+        -Body @{
+            base_tree = $baseTreeSha
+            tree      = @($treeItems)
+        }
+    $commit = Invoke-WingetPkgsGitHubApi `
+        -Method Post `
+        -Path "repos/$ForkRepository/git/commits" `
+        -Token $Token `
+        -Body @{
+            message = $PrTitle
+            tree    = "$($tree.sha)"
+            parents = @($baseSha)
+        }
+
+    $branchSuffix = "$PackageId-$Version" -replace '[^A-Za-z0-9._-]', '-'
+    $branchName = "winget-autosubmit/$branchSuffix-$([guid]::NewGuid().ToString('N'))"
+    Invoke-WingetPkgsGitHubApi `
+        -Method Post `
+        -Path "repos/$ForkRepository/git/refs" `
+        -Token $Token `
+        -Body @{
+            ref = "refs/heads/$branchName"
+            sha = "$($commit.sha)"
+        } | Out-Null
+
+    # Recheck immediately before the external write. Workflow concurrency handles
+    # scheduled workers; this closes the remaining generate-to-submit window.
+    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
+        Invoke-WingetPkgsGitHubApi `
+            -Method Delete `
+            -Path "repos/$ForkRepository/git/refs/heads/$branchName" `
+            -Token $Token | Out-Null
+
+        return [pscustomobject]@{
+            Created    = $false
+            BranchName = $branchName
+            PullRequest = $null
+        }
+    }
+
+    $forkOwner = $ForkRepository.Split('/')[0]
+    $body = if ([string]::IsNullOrWhiteSpace($Resolves)) { $null } else { "Resolves #$Resolves" }
+    $pullRequest = Invoke-WingetPkgsGitHubApi `
+        -Method Post `
+        -Path "repos/$targetRepository/pulls" `
+        -Token $Token `
+        -Body @{
+            title = $PrTitle
+            head  = "${forkOwner}:$branchName"
+            base  = $targetDefaultBranch
+            body  = $body
+        }
+
+    return [pscustomobject]@{
+        Created     = $true
+        BranchName  = $branchName
+        PullRequest = $pullRequest
+    }
+}

--- a/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
+++ b/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
@@ -34,7 +34,10 @@ function Get-WingetPkgsPrUrl {
         [string] $PackageId,
 
         [Parameter(Mandatory = $false)]
-        [string] $Version
+        [string] $Version,
+
+        [Parameter(Mandatory = $false)]
+        [string] $Repository = 'microsoft/winget-pkgs'
     )
 
     # Preferred source: the submission tool printed the URL itself.
@@ -71,7 +74,7 @@ function Get-WingetPkgsPrUrl {
             --state 'open' `
             --limit 10 `
             --json 'url,createdAt' `
-            --repo 'microsoft/winget-pkgs' 2>$null
+            --repo $Repository 2>$null
 
         if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
             return $null

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -4,7 +4,8 @@
 
 .DESCRIPTION
     Takes a pre-generated and validated manifest folder and submits it as a PR
-    to the winget-pkgs repository using either Komac or WinGetCreate.
+    to the winget-pkgs repository using WinMatsch, Komac, WinGetCreate, or
+    a server-side branch in a verified user-owned fork.
     This function should only be called after manifest validation and sandbox
     testing have passed.
 
@@ -24,7 +25,13 @@
     Optional GitHub issue number that this PR resolves.
 
 .PARAMETER With
-    The tool to use for submission: "WinMatsch" (default), "Komac" or "WinGetCreate".
+    The tool to use for submission: "WinMatsch" (default), "Komac",
+    "WinGetCreate", or "ForkBranch". ForkBranch never synchronizes the
+    fork's default branch.
+
+    .PARAMETER SubmissionTarget
+    ForkBranch target: "Upstream" opens the normal PR against
+    microsoft/winget-pkgs; "Fork" opens a fork-only PR for test runs.
 
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses
@@ -78,7 +85,7 @@ function Submit-WingetPackage {
         [string] $Resolves,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("WinMatsch", "Komac", "WinGetCreate")]
+        [ValidateSet("WinMatsch", "Komac", "WinGetCreate", "ForkBranch")]
         [string] $With = "WinMatsch",
 
         [Parameter(Mandatory = $false)]
@@ -86,7 +93,11 @@ function Submit-WingetPackage {
 
         [Parameter(Mandatory = $false)]
         [ValidateRange(0, 3)]
-        [int] $MaxBranchMovedRetries = 1
+        [int] $MaxBranchMovedRetries = 1,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Upstream', 'Fork')]
+        [string] $SubmissionTarget = 'Upstream'
     )
 
     # Get GitHub token
@@ -234,6 +245,85 @@ function Submit-WingetPackage {
                         PrUrl    = $null
                         PrNumber = $null
                     }
+                }
+            }
+
+            "ForkBranch" {
+                $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
+                if ([string]::IsNullOrWhiteSpace($forkRepository)) {
+                    return @{
+                        Success  = $false
+                        Error    = 'WINGET_PKGS_FORK_REPO is required for ForkBranch submissions.'
+                        PrUrl    = $null
+                        PrNumber = $null
+                    }
+                }
+
+                $targetRepository = if ($SubmissionTarget -eq 'Fork') {
+                    $forkRepository
+                }
+                else {
+                    'microsoft/winget-pkgs'
+                }
+
+                if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
+                    $existingPrUrl = Get-WingetPkgsPrUrl `
+                        -PackageId $PackageId `
+                        -Version $Version `
+                        -Repository $targetRepository
+                    $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
+                        $Matches['Number']
+                    }
+                    else {
+                        $null
+                    }
+
+                    Write-Host 'A matching submission PR already exists; skipping submission.' -ForegroundColor Yellow
+                    return @{
+                        Success  = $true
+                        Error    = $null
+                        PrUrl    = $existingPrUrl
+                        PrNumber = $existingPrNumber
+                    }
+                }
+
+                $forkSubmission = Invoke-ForkBranchSubmission `
+                    -ManifestPath $fullManifestPath `
+                    -PackageId $PackageId `
+                    -Version $Version `
+                    -PrTitle $PrTitle `
+                    -Token $Token `
+                    -ForkRepository $forkRepository `
+                    -SubmissionTarget $SubmissionTarget `
+                    -Resolves $Resolves
+
+                if (-not $forkSubmission.Created) {
+                    $existingPrUrl = Get-WingetPkgsPrUrl `
+                        -PackageId $PackageId `
+                        -Version $Version `
+                        -Repository $targetRepository
+                    $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
+                        $Matches['Number']
+                    }
+                    else {
+                        $null
+                    }
+
+                    return @{
+                        Success  = $true
+                        Error    = $null
+                        PrUrl    = $existingPrUrl
+                        PrNumber = $existingPrNumber
+                    }
+                }
+
+                $prUrl = "$($forkSubmission.PullRequest.html_url)".Trim()
+                $prNumber = "$($forkSubmission.PullRequest.number)".Trim()
+                return @{
+                    Success  = $true
+                    Error    = $null
+                    PrUrl    = $prUrl
+                    PrNumber = $prNumber
                 }
             }
         }

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -31,15 +31,16 @@ function Test-ExistingPRs {
     param(
         [Parameter(Mandatory = $true)] [string] $Version,
         [Parameter(Mandatory = $false)] [string] $PackageIdentifier = ${Env:PackageName},
-        [Parameter(Mandatory = $false)] [switch] $OnlyOpen
+        [Parameter(Mandatory = $false)] [switch] $OnlyOpen,
+        [Parameter(Mandatory = $false)] [string] $Repository = 'microsoft/winget-pkgs'
     )
-    Write-Host "Checking for existing PRs for $PackageIdentifier $Version"
-    $ExistingOpenPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'open' --json 'title,url' --repo 'microsoft/winget-pkgs' | ConvertFrom-Json
+    Write-Host "Checking for existing PRs for $PackageIdentifier $Version in $Repository"
+    $ExistingOpenPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'open' --json 'title,url' --repo $Repository | ConvertFrom-Json
     
     $ExistingPRs = if ($OnlyOpen) {
         @($ExistingOpenPRs)
     } else {
-        $ExistingMergedPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'merged' --json 'title,url' --repo 'microsoft/winget-pkgs' | ConvertFrom-Json
+        $ExistingMergedPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'merged' --json 'title,url' --repo $Repository | ConvertFrom-Json
         @($ExistingOpenPRs) + @($ExistingMergedPRs)
     }
 

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -1,0 +1,206 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
+
+Describe 'Submit-WingetPackage ForkBranch' {
+    BeforeEach {
+        $global:ForkBranchSubmissionManifestPath = Join-Path ([IO.Path]::GetTempPath()) "winget-fork-submit-tests-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $global:ForkBranchSubmissionManifestPath -Force | Out-Null
+        @(
+            'PackageIdentifier: Test.Package',
+            'PackageVersion: 1.0.0'
+        ) | Set-Content -LiteralPath (Join-Path $global:ForkBranchSubmissionManifestPath 'Test.Package.yaml')
+
+        $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
+        $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
+        $env:WINGET_PKGS_FORK_REPO = 'test-owner/winget-pkgs'
+
+        InModuleScope WingetMaintainerModule {
+            Mock Test-ExistingPRs { $false }
+            Mock Get-WingetPkgsPrUrl { $null }
+            Mock Invoke-WingetPkgsGitHubApi {
+                param($Method, $Path, $Token, $Body)
+
+                $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
+                    Method = $Method
+                    Path   = $Path
+                    Body   = $Body
+                })
+
+                switch -Regex ($Path) {
+                    '^repos/test-owner/winget-pkgs$' {
+                        return [pscustomobject]@{
+                            fork           = $true
+                            default_branch = 'master'
+                            parent         = [pscustomobject]@{ full_name = 'microsoft/winget-pkgs' }
+                        }
+                    }
+                    '^repos/microsoft/winget-pkgs$' {
+                        return [pscustomobject]@{ default_branch = 'master' }
+                    }
+                    '/git/ref/heads/master$' {
+                        return [pscustomobject]@{ object = [pscustomobject]@{ sha = 'base-sha' } }
+                    }
+                    '/git/commits/base-sha$' {
+                        return [pscustomobject]@{ tree = [pscustomobject]@{ sha = 'base-tree-sha' } }
+                    }
+                    '/git/trees$' {
+                        return [pscustomobject]@{ sha = 'tree-sha' }
+                    }
+                    '/git/commits$' {
+                        return [pscustomobject]@{ sha = 'commit-sha' }
+                    }
+                    '/git/refs$' {
+                        return [pscustomobject]@{ ref = 'refs/heads/winget-autosubmit/test' }
+                    }
+                    '/pulls$' {
+                        return [pscustomobject]@{
+                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            number   = 12345
+                        }
+                    }
+                    default {
+                        throw "Unexpected GitHub API request: $Method $Path"
+                    }
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $global:ForkBranchSubmissionManifestPath -Recurse -Force -ErrorAction SilentlyContinue
+        $env:WINGET_PKGS_FORK_REPO = $global:OriginalForkRepository
+        Remove-Variable -Name ForkBranchSubmissionManifestPath -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ForkBranchSubmissionRequests -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'creates an upstream PR from a fork branch without writing the fork default branch' {
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch `
+            -SubmissionTarget Upstream
+
+        if ($result.Success -ne $true) {
+            throw "Expected a successful upstream ForkBranch submission, got: $($result.Error)"
+        }
+        if ($result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/12345') {
+            throw "Unexpected upstream PR URL: $($result.PrUrl)"
+        }
+        if ($result.PrNumber -cne '12345') {
+            throw "Unexpected upstream PR number: $($result.PrNumber)"
+        }
+
+        $forkWrites = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object {
+                    $_.Path -match '^repos/test-owner/winget-pkgs/' -and
+                    $_.Method -in @('Post', 'Patch', 'Delete')
+                }
+        )
+        foreach ($expectedPath in @(
+            'repos/test-owner/winget-pkgs/git/trees',
+            'repos/test-owner/winget-pkgs/git/commits',
+            'repos/test-owner/winget-pkgs/git/refs'
+        )) {
+            if ($forkWrites.Path -notcontains $expectedPath) {
+                throw "Expected fork write was not made: $expectedPath"
+            }
+        }
+        if (@($forkWrites | Where-Object { $_.Path -match 'merge-upstream|refs/heads/master' }).Count -ne 0) {
+            throw 'ForkBranch wrote or synchronized the fork default branch.'
+        }
+        $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/test-owner/winget-pkgs/git/trees' }
+        if ($treeRequest.Body.base_tree -cne 'base-tree-sha') {
+            throw "ForkBranch did not base the manifest tree on the resolved base tree: $($treeRequest.Body.base_tree)"
+        }
+
+        $upstreamWrites = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object {
+                    $_.Path -match '^repos/microsoft/winget-pkgs/' -and
+                    $_.Method -in @('Post', 'Patch', 'Delete')
+                }
+        )
+        if ($upstreamWrites.Count -ne 1 -or $upstreamWrites[0].Path -cne 'repos/microsoft/winget-pkgs/pulls') {
+            throw "Upstream write surface is not limited to creating the intended PR: $($upstreamWrites.Path -join ', ')"
+        }
+    }
+
+    It 'keeps Fork test submissions entirely within the verified user fork' {
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch `
+            -SubmissionTarget Fork
+
+        if ($result.Success -ne $true) {
+            throw "Expected a successful fork-only ForkBranch submission, got: $($result.Error)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match 'microsoft/winget-pkgs' }).Count -ne 0) {
+            throw 'Fork test submission called the Microsoft repository API.'
+        }
+
+        $pullRequest = $global:ForkBranchSubmissionRequests |
+            Where-Object { $_.Path -eq 'repos/test-owner/winget-pkgs/pulls' } |
+            Select-Object -Last 1
+        if ($pullRequest.Body.base -cne 'master') {
+            throw "Fork test submission used an unexpected base branch: $($pullRequest.Body.base)"
+        }
+        if ($pullRequest.Body.head -notmatch '^test-owner:winget-autosubmit/') {
+            throw "Fork test submission used an unexpected PR head: $($pullRequest.Body.head)"
+        }
+    }
+
+    It 'does not create a fork branch when the matching target PR already exists' {
+        InModuleScope WingetMaintainerModule {
+            Mock Test-ExistingPRs { $true }
+            Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
+        }
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/54321') {
+            throw "Existing submission PR was not returned: $($result | ConvertTo-Json -Compress)"
+        }
+        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
+            throw 'Duplicate detection attempted a fork API request.'
+        }
+        InModuleScope WingetMaintainerModule {
+            Assert-MockCalled Invoke-WingetPkgsGitHubApi -Times 0 -Exactly -Scope It
+        }
+    }
+
+    It 'rejects microsoft/winget-pkgs as the configured fork before writing a branch' {
+        $env:WINGET_PKGS_FORK_REPO = 'microsoft/winget-pkgs'
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $false) {
+            throw 'A microsoft/winget-pkgs fork configuration unexpectedly succeeded.'
+        }
+        if ($result.Error -notmatch 'user-owned fork') {
+            throw "The unsafe fork configuration was not identified clearly: $($result.Error)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Method -in @('Post', 'Patch', 'Delete') }).Count -ne 0) {
+            throw 'An unsafe fork configuration attempted a GitHub write.'
+        }
+    }
+}

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -22,13 +22,16 @@ function Assert-Match {
 }
 
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
-$workflowNames = @(
-    'update-github-packages-1-q.yml',
-    'update-github-packages-r-z.yml'
+$workflowPaths = @(
+    '.github/workflows/update-github-packages-1-q.yml',
+    '.github/workflows/update-github-packages-r-z.yml',
+    '.github/workflows/update-script-packages.yml',
+    '.github/workflows-templates/github-releases.yml'
 )
 
-foreach ($workflowName in $workflowNames) {
-    $workflowPath = Join-Path $repositoryRoot ".github/workflows/$workflowName"
+foreach ($workflowRelativePath in $workflowPaths) {
+    $workflowPath = Join-Path $repositoryRoot $workflowRelativePath
+    $workflowName = Split-Path -Leaf $workflowPath
     $workflow = Get-Content -LiteralPath $workflowPath -Raw
 
     $submitMatch = Assert-Match `
@@ -47,8 +50,16 @@ foreach ($workflowName in $workflowNames) {
         -Message "$workflowName may cancel an in-progress same-package submission." | Out-Null
     Assert-Match `
         -Actual $submitJob `
-        -Pattern '(?s)\$result = Submit-WingetPackage.*?-With "WinGetCreate"' `
-        -Message "$workflowName must submit validated manifests with WinGetCreate instead of synchronizing the fork through WinMatsch." | Out-Null
+        -Pattern '(?s)\$result = Submit-WingetPackage.*?-With "ForkBranch".*?-SubmissionTarget "\$env:WINGET_PKGS_SUBMISSION_TARGET"' `
+        -Message "$workflowName must use the no-sync ForkBranch submission mode." | Out-Null
+    Assert-Match `
+        -Actual $submitJob `
+        -Pattern '(?m)^          WINGET_PKGS_FORK_REPO: \$\{\{\s*vars\.WINGET_PKGS_FORK_REPO\s*\}\}\s*$' `
+        -Message "$workflowName does not provide the configured user-owned fork." | Out-Null
+    Assert-Match `
+        -Actual $submitJob `
+        -Pattern "(?m)^          WINGET_PKGS_SUBMISSION_TARGET: \$\{\{\s*github\.ref == 'refs/heads/main' && 'Upstream' \|\| 'Fork'\s*\}\}\s*$" `
+        -Message "$workflowName does not isolate non-main test submissions to the user-owned fork." | Out-Null
 }
 
 Write-Host 'All submission workflow authorization regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Root cause
`wingetcreate submit` is not a fork-sync workaround: its upstream implementation unconditionally calls GitHub's `merge-upstream` endpoint on the authenticated user's fork default branch before it creates a submission branch. That call fails when the fork contains the workflow-only divergence, producing the observed “forked repository could not be synced” error. WinMatsch has the same default-branch synchronization dependency, so the remaining scheduled submitters were also vulnerable.

## Fix
- Add `ForkBranch`, a GitHub REST submission mode that verifies `WINGET_PKGS_FORK_REPO` is a user-owned fork of `microsoft/winget-pkgs`.
- Build a disposable fork branch directly from the selected base commit, write only the validated manifest tree to it, and open the PR from that branch. The fork default branch is never synchronized or written.
- Main runs target `microsoft/winget-pkgs`; non-main test runs create the PR entirely inside the configured fork.
- Move every scheduled submit path (GitHub package ranges, script packages, and the generated workflow template) to this mode while retaining same-package workflow concurrency and duplicate checks.

## Safety
The REST helper keeps the PAT in an HTTP authorization header, never in command arguments or logs. It rejects `microsoft/winget-pkgs` as the configured fork. The flow has no workflow-scope requirement; it uses repository contents/pull-request permissions only.

## Validation
- `tests/SubmissionWorkflowAuthorization.Tests.ps1`
- `tests/Submit-WingetPackage.Tests.ps1`
- `tests/ForkBranchSubmission.Tests.ps1`

The ForkBranch regression suite records the mocked REST surface and proves production writes only the intended upstream PR, fork tests make no Microsoft API request, no path invokes `merge-upstream`, and a pre-existing PR prevents any fork API write.