### PR TITLE
Exclude VRCFaceTracking from GitHub release updates

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -41,6 +41,7 @@ jobs:
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1
+          ./tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
           $pesterConfig = New-PesterConfiguration
           $pesterConfig.Run.Path = @(
             './tests/Submit-WingetPackage.Tests.ps1',

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -121,9 +121,6 @@ jobs:
           - id: bcssov.IronyModManager
             repo: bcssov/IronyModManager
             url: https://github.com/bcssov/IronyModManager/releases/download/v{VERSION}/win-x64-setup.zip https://github.com/bcssov/IronyModManager/releases/download/v{VERSION}/win-x64-setup.zip
-          - id: benaclejames.VRCFaceTracking
-            repo: benaclejames/VRCFaceTracking
-            url: https://github.com/benaclejames/VRCFaceTracking/releases/download/{VERSION}/VRCFaceTracking_{VERSION}_x64.zip
           - id: Benbuck.Finestray
             repo: benbuck/finestray
             url: https://github.com/benbuck/finestray/releases/download/v{VERSION}/Finestray-{VERSION}-win64.exe

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -98,9 +98,6 @@
           - id: "bcssov.IronyModManager"
             repo: "bcssov/IronyModManager"
             url: "https://github.com/bcssov/IronyModManager/releases/download/v{VERSION}/win-x64-setup.zip https://github.com/bcssov/IronyModManager/releases/download/v{VERSION}/win-x64-setup.zip"
-          - id: "benaclejames.VRCFaceTracking"
-            repo: "benaclejames/VRCFaceTracking"
-            url: "https://github.com/benaclejames/VRCFaceTracking/releases/download/{VERSION}/VRCFaceTracking_{VERSION}_x64.zip"
           - id: "Benbuck.Finestray"
             repo: "benbuck/finestray"
             url: "https://github.com/benbuck/finestray/releases/download/v{VERSION}/Finestray-{VERSION}-win64.exe"
@@ -1366,7 +1363,6 @@
 #          - id: "Jellyfin.Server"
 #            repo: "jellyfin/jellyfin-server-windows"
 #            url: "https://github.com/jellyfin/jellyfin-server-windows/releases/download/{VERSION}/jellyfin_{VERSION}_windows-x64.exe"
-
 
 
 

--- a/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
+++ b/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-NotMatch {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Actual,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Pattern,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Message
+    )
+
+    if ([regex]::IsMatch($Actual, $Pattern, [Text.RegularExpressions.RegexOptions]::Multiline)) {
+        throw $Message
+    }
+}
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$configurationPaths = @(
+    'github-releases-monitored.yml',
+    '.github/workflows/update-github-packages-1-q.yml'
+)
+
+foreach ($configurationRelativePath in $configurationPaths) {
+    $configurationPath = Join-Path $repositoryRoot $configurationRelativePath
+    $configuration = Get-Content -LiteralPath $configurationPath -Raw
+
+    Assert-NotMatch `
+        -Actual $configuration `
+        -Pattern '^\s*-\s+id:\s*"?benaclejames\.VRCFaceTracking"?\s*$' `
+        -Message "$configurationRelativePath must not monitor benaclejames.VRCFaceTracking until its release installer can be analyzed."
+}
+
+Write-Host 'GitHub release monitoring configuration regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Exclude `benaclejames.VRCFaceTracking` from both mirrored automated GitHub-release mappings.
- Add and run a regression check that prevents either configuration surface from re-enabling the package.

## Rationale
Release `5.2.3.0` packages the required `AppxManifest.xml`, `AppxSignature.p7x`, and `VRCFaceTracking.exe` in a traditionally encrypted ZIP. Processing that installer would violate the fail-closed ZIP004 policy until upstream provides an analyzable, non-encrypted installer.

## Validation
- Ran the complete `module-tests` workflow command locally, including the new regression test and 8 Pester tests.