### PR TITLE
Exclude unchanged SVGExplorerExtension release artifacts

### DIFF
--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -166,9 +166,6 @@ jobs:
           - id: SUSE.RancherDesktop
             repo: rancher-sandbox/rancher-desktop
             url: https://github.com/rancher-sandbox/rancher-desktop/releases/download/v{VERSION}/Rancher.Desktop.Setup.{VERSION}.msi
-          - id: SVGExplorerExtension.SVGExplorerExtension
-            repo: tibold/svg-explorer-extension
-            url: https://github.com/tibold/svg-explorer-extension/releases/download/v{VERSION}/svg_see_x64.exe https://github.com/tibold/svg-explorer-extension/releases/download/v{VERSION}/svg_see_x86.exe
           - id: Syncplay.Syncplay
             repo: Syncplay/syncplay
             url: https://github.com/Syncplay/syncplay/releases/download/v{VERSION}/Syncplay-{VERSION}-Setup.exe

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -930,9 +930,6 @@
           - id: "SUSE.RancherDesktop"
             repo: "rancher-sandbox/rancher-desktop"
             url: "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v{VERSION}/Rancher.Desktop.Setup.{VERSION}.msi"
-          - id: "SVGExplorerExtension.SVGExplorerExtension"
-            repo: "tibold/svg-explorer-extension"
-            url: "https://github.com/tibold/svg-explorer-extension/releases/download/v{VERSION}/svg_see_x64.exe https://github.com/tibold/svg-explorer-extension/releases/download/v{VERSION}/svg_see_x86.exe"
           - id: "Syncplay.Syncplay"
             repo: "Syncplay/syncplay"
             url: "https://github.com/Syncplay/syncplay/releases/download/v{VERSION}/Syncplay-{VERSION}-Setup.exe"
@@ -1363,7 +1360,6 @@
 #          - id: "Jellyfin.Server"
 #            repo: "jellyfin/jellyfin-server-windows"
 #            url: "https://github.com/jellyfin/jellyfin-server-windows/releases/download/{VERSION}/jellyfin_{VERSION}_windows-x64.exe"
-
 
 
 

--- a/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
+++ b/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
@@ -21,17 +21,25 @@ function Assert-NotMatch {
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
 $configurationPaths = @(
     'github-releases-monitored.yml',
-    '.github/workflows/update-github-packages-1-q.yml'
+    '.github/workflows/update-github-packages-1-q.yml',
+    '.github/workflows/update-github-packages-r-z.yml'
+)
+
+$excludedPackageIds = @(
+    'benaclejames.VRCFaceTracking',
+    'SVGExplorerExtension.SVGExplorerExtension'
 )
 
 foreach ($configurationRelativePath in $configurationPaths) {
     $configurationPath = Join-Path $repositoryRoot $configurationRelativePath
     $configuration = Get-Content -LiteralPath $configurationPath -Raw
 
-    Assert-NotMatch `
-        -Actual $configuration `
-        -Pattern '^\s*-\s+id:\s*"?benaclejames\.VRCFaceTracking"?\s*$' `
-        -Message "$configurationRelativePath must not monitor benaclejames.VRCFaceTracking until its release installer can be analyzed."
+    foreach ($packageId in $excludedPackageIds) {
+        Assert-NotMatch `
+            -Actual $configuration `
+            -Pattern "^\s*-\s+id:\s*`"?$([regex]::Escape($packageId))`"?\s*$" `
+            -Message "$configurationRelativePath must not monitor $packageId until its upstream release artifacts change."
+    }
 }
 
 Write-Host 'GitHub release monitoring configuration regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Exclude `SVGExplorerExtension.SVGExplorerExtension` from both mirrored GitHub release monitoring configurations.
- Extend the monitored-release configuration regression coverage for the new exclusion and ensure the r-z workflow mirror is checked.

## Rationale
Fork-only run `31047205813` confirmed the version `1.0.0` installers are unchanged artifacts already published in winget: x64 SHA256 `69F972...FCA6DB` and x86 SHA256 `64962D...D0FA9`. This is an upstream publisher issue, not a generator defect, so monitoring remains disabled until upstream ships changed artifacts.

## Validation
- `pwsh -NoProfile -File .\\tests\\GitHubReleaseMonitoringConfiguration.Tests.ps1`
- Module-tests workflow test sequence (with Pester `5.7.1`): all 8 Pester tests passed and all script regressions passed.