### PR TITLE
Honor structural rewrite approval during content validation

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -320,10 +320,11 @@ jobs:
         shell: pwsh
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
+          $allowStructuralRewrite = "$env:MATRIX_ALLOW_STRUCTURAL_REWRITE" -eq 'true'
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {
@@ -334,6 +335,7 @@ jobs:
           }
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
+          MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -83,6 +83,22 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record structural rewrite approval
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ./structural-rewrite-approval | Out-Null
+          Set-Content -Path ./structural-rewrite-approval/approved -Value 'true' -NoNewline
+
+      - name: Upload structural rewrite approval marker
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: structural-rewrite__${{ matrix.id }}__${{ steps.generate.outputs.version }}
+          path: ./structural-rewrite-approval
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Record generation failure
         if: failure()
         shell: pwsh
@@ -145,20 +161,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $packages = @()
+          $artifacts = @()
           $page = 1
           do {
             $response = gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100&page=$page" | ConvertFrom-Json
-            foreach ($artifact in $response.artifacts) {
-              if ($artifact.name -match '^manifest__(.+)__(.+)$') {
-                $packageName = $Matches[1]
-                $version = $Matches[2]
-                $packages += @{ PackageName = $packageName; version = $version }
-                Write-Host "Found: $packageName @ $version"
-              }
-            }
+            $artifacts += $response.artifacts
             $page++
           } while ($response.artifacts.Count -eq 100)
+
+          $structuralRewriteApprovals = @{}
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^structural-rewrite__(.+)__(.+)$') {
+              $structuralRewriteApprovals["$($Matches[1])__$($Matches[2])"] = $true
+            }
+          }
+
+          $packages = @()
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^manifest__(.+)__(.+)$') {
+              $packageName = $Matches[1]
+              $version = $Matches[2]
+              $approvalKey = "$packageName__$version"
+              $packages += @{
+                PackageName = $packageName
+                version = $version
+                allowStructuralRewrite = $structuralRewriteApprovals.ContainsKey($approvalKey)
+              }
+              Write-Host "Found: $packageName @ $version (structural rewrite: $($structuralRewriteApprovals.ContainsKey($approvalKey)))"
+            }
+          }
 
           $hasPackages = ($packages.Count -gt 0).ToString().ToLower()
           $matrix = @{ include = @($packages) } | ConvertTo-Json -Compress -Depth 3
@@ -324,7 +355,7 @@ jobs:
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite:$allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -42,6 +42,7 @@ jobs:
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1
           ./tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
+          ./tests/Test-ManifestContent.Tests.ps1
           $pesterConfig = New-PesterConfiguration
           $pesterConfig.Run.Path = @(
             './tests/Submit-WingetPackage.Tests.ps1',

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -812,6 +812,22 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record structural rewrite approval
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ./structural-rewrite-approval | Out-Null
+          Set-Content -Path ./structural-rewrite-approval/approved -Value 'true' -NoNewline
+
+      - name: Upload structural rewrite approval marker
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: structural-rewrite__${{ matrix.id }}__${{ steps.generate.outputs.version }}
+          path: ./structural-rewrite-approval
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Record generation failure
         if: failure()
         shell: pwsh
@@ -874,20 +890,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $packages = @()
+          $artifacts = @()
           $page = 1
           do {
             $response = gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100&page=$page" | ConvertFrom-Json
-            foreach ($artifact in $response.artifacts) {
-              if ($artifact.name -match '^manifest__(.+)__(.+)$') {
-                $packageName = $Matches[1]
-                $version = $Matches[2]
-                $packages += @{ PackageName = $packageName; version = $version }
-                Write-Host "Found: $packageName @ $version"
-              }
-            }
+            $artifacts += $response.artifacts
             $page++
           } while ($response.artifacts.Count -eq 100)
+
+          $structuralRewriteApprovals = @{}
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^structural-rewrite__(.+)__(.+)$') {
+              $structuralRewriteApprovals["$($Matches[1])__$($Matches[2])"] = $true
+            }
+          }
+
+          $packages = @()
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^manifest__(.+)__(.+)$') {
+              $packageName = $Matches[1]
+              $version = $Matches[2]
+              $approvalKey = "$packageName__$version"
+              $packages += @{
+                PackageName = $packageName
+                version = $version
+                allowStructuralRewrite = $structuralRewriteApprovals.ContainsKey($approvalKey)
+              }
+              Write-Host "Found: $packageName @ $version (structural rewrite: $($structuralRewriteApprovals.ContainsKey($approvalKey)))"
+            }
+          }
 
           $hasPackages = ($packages.Count -gt 0).ToString().ToLower()
           $matrix = @{ include = @($packages) } | ConvertTo-Json -Compress -Depth 3
@@ -1053,7 +1084,7 @@ jobs:
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite:$allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1049,10 +1049,11 @@ jobs:
         shell: pwsh
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
+          $allowStructuralRewrite = "$env:MATRIX_ALLOW_STRUCTURAL_REWRITE" -eq 'true'
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {
@@ -1063,6 +1064,7 @@ jobs:
           }
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
+          MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -647,10 +647,11 @@ jobs:
         shell: pwsh
         run: |
           $manifestPath = "$env:STEPS_MANIFEST_OUTPUTS_PATH"
+          $allowStructuralRewrite = "$env:MATRIX_ALLOW_STRUCTURAL_REWRITE" -eq 'true'
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {
@@ -661,6 +662,7 @@ jobs:
           }
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
+          MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -410,6 +410,22 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record structural rewrite approval
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ./structural-rewrite-approval | Out-Null
+          Set-Content -Path ./structural-rewrite-approval/approved -Value 'true' -NoNewline
+
+      - name: Upload structural rewrite approval marker
+        if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: structural-rewrite__${{ matrix.id }}__${{ steps.generate.outputs.version }}
+          path: ./structural-rewrite-approval
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Record generation failure
         if: failure()
         shell: pwsh
@@ -472,20 +488,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $packages = @()
+          $artifacts = @()
           $page = 1
           do {
             $response = gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100&page=$page" | ConvertFrom-Json
-            foreach ($artifact in $response.artifacts) {
-              if ($artifact.name -match '^manifest__(.+)__(.+)$') {
-                $packageName = $Matches[1]
-                $version = $Matches[2]
-                $packages += @{ PackageName = $packageName; version = $version }
-                Write-Host "Found: $packageName @ $version"
-              }
-            }
+            $artifacts += $response.artifacts
             $page++
           } while ($response.artifacts.Count -eq 100)
+
+          $structuralRewriteApprovals = @{}
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^structural-rewrite__(.+)__(.+)$') {
+              $structuralRewriteApprovals["$($Matches[1])__$($Matches[2])"] = $true
+            }
+          }
+
+          $packages = @()
+          foreach ($artifact in $artifacts) {
+            if ($artifact.name -match '^manifest__(.+)__(.+)$') {
+              $packageName = $Matches[1]
+              $version = $Matches[2]
+              $approvalKey = "$packageName__$version"
+              $packages += @{
+                PackageName = $packageName
+                version = $version
+                allowStructuralRewrite = $structuralRewriteApprovals.ContainsKey($approvalKey)
+              }
+              Write-Host "Found: $packageName @ $version (structural rewrite: $($structuralRewriteApprovals.ContainsKey($approvalKey)))"
+            }
+          }
 
           $hasPackages = ($packages.Count -gt 0).ToString().ToLower()
           $matrix = @{ include = @($packages) } | ConvertTo-Json -Compress -Depth 3
@@ -651,7 +682,7 @@ jobs:
 
           Write-Host "Running content validation for: $manifestPath"
 
-          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite $allowStructuralRewrite
+          & .\Scripts\validation\Test-ManifestContent.ps1 -ManifestPath $manifestPath -AllowStructuralRewrite:$allowStructuralRewrite
           $exitCode = $LASTEXITCODE
 
           if ($exitCode -eq 0) {

--- a/scripts/validation/Test-ManifestContent.ps1
+++ b/scripts/validation/Test-ManifestContent.ps1
@@ -54,7 +54,7 @@ param(
     [string] $PublishedPackageRoot,
 
     [Parameter(Mandatory = $false, HelpMessage = 'Allow an explicitly approved generator structural rewrite to remove inherited installer metadata.')]
-    [bool] $AllowStructuralRewrite = $false
+    [switch] $AllowStructuralRewrite
 )
 
 #region Helper Functions

--- a/scripts/validation/Test-ManifestContent.ps1
+++ b/scripts/validation/Test-ManifestContent.ps1
@@ -51,7 +51,10 @@ param(
         }
         return $true
     })]
-    [string] $PublishedPackageRoot
+    [string] $PublishedPackageRoot,
+
+    [Parameter(Mandatory = $false, HelpMessage = 'Allow an explicitly approved generator structural rewrite to remove inherited installer metadata.')]
+    [bool] $AllowStructuralRewrite = $false
 )
 
 #region Helper Functions
@@ -820,9 +823,14 @@ if ($errors.Count -eq 0) {
                     Select-Object -First 1
 
                 if ($baselinePublishedManifest) {
-                    $consistencyErrors = @(Test-InstallerMetadataConsistency -CurrentManifestSet $localManifestSet -PreviousManifestSet $baselinePublishedManifest)
-                    foreach ($consistencyError in $consistencyErrors) {
-                        $errors += $consistencyError
+                    if ($AllowStructuralRewrite) {
+                        $warnings += "Skipping installer metadata consistency comparison against published version $($baselinePublishedManifest.PackageVersion) because structural rewrite approval was explicitly provided."
+                    }
+                    else {
+                        $consistencyErrors = @(Test-InstallerMetadataConsistency -CurrentManifestSet $localManifestSet -PreviousManifestSet $baselinePublishedManifest)
+                        foreach ($consistencyError in $consistencyErrors) {
+                            $errors += $consistencyError
+                        }
                     }
                 }
             }

--- a/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
+++ b/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
@@ -18,6 +18,23 @@ function Assert-NotMatch {
     }
 }
 
+function Assert-Match {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Actual,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Pattern,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Message
+    )
+
+    if (-not [regex]::IsMatch($Actual, $Pattern, [Text.RegularExpressions.RegexOptions]::Multiline)) {
+        throw $Message
+    }
+}
+
 $repositoryRoot = Split-Path -Parent $PSScriptRoot
 $configurationPaths = @(
     'github-releases-monitored.yml',
@@ -40,6 +57,42 @@ foreach ($configurationRelativePath in $configurationPaths) {
             -Pattern "^\s*-\s+id:\s*`"?$([regex]::Escape($packageId))`"?\s*$" `
             -Message "$configurationRelativePath must not monitor $packageId until its upstream release artifacts change."
     }
+}
+
+$workflowPaths = @(
+    '.github/workflows-templates/github-releases.yml',
+    '.github/workflows/update-github-packages-1-q.yml',
+    '.github/workflows/update-github-packages-r-z.yml'
+)
+
+foreach ($workflowRelativePath in $workflowPaths) {
+    $workflowPath = Join-Path $repositoryRoot $workflowRelativePath
+    $workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape("name: structural-rewrite__`${{ matrix.id }}__`${{ steps.generate.outputs.version }}")) `
+        -Message "$workflowRelativePath must publish an approval marker for each approved structural rewrite."
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape("if: steps.generate.outputs.generated == 'true' && fromJSON(toJSON(matrix)).allowStructuralRewrite == true")) `
+        -Message "$workflowRelativePath must publish approval markers only for explicitly approved packages."
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape("if (`$artifact.name -match '^structural-rewrite__(.+)__(.+)`$')")) `
+        -Message "$workflowRelativePath must read structural rewrite approval markers before building its validation matrix."
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape('allowStructuralRewrite = $structuralRewriteApprovals.ContainsKey($approvalKey)')) `
+        -Message "$workflowRelativePath must preserve structural rewrite approval in its dynamic validation matrix."
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape('MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}')) `
+        -Message "$workflowRelativePath must pass dynamic approval metadata to content validation."
+    Assert-Match `
+        -Actual $workflow `
+        -Pattern ([regex]::Escape('-AllowStructuralRewrite:$allowStructuralRewrite')) `
+        -Message "$workflowRelativePath must explicitly bind the structural rewrite approval switch."
 }
 
 Write-Host 'GitHub release monitoring configuration regression tests passed.' -ForegroundColor Green

--- a/tests/Test-ManifestContent.Tests.ps1
+++ b/tests/Test-ManifestContent.Tests.ps1
@@ -62,13 +62,13 @@ try {
         -IncludeNestedInstallerMetadata $false
 
     Write-Host 'TEST: structural metadata removal fails without explicit approval'
-    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite $false
+    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite:$false
     if ($LASTEXITCODE -ne 4) {
         throw "Expected metadata consistency validation to fail with exit code 4, got $LASTEXITCODE."
     }
 
     Write-Host 'TEST: structural metadata removal passes with explicit approval'
-    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite $true
+    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite:$true
     if ($LASTEXITCODE -ne 0) {
         throw "Expected approved structural rewrite validation to pass, got exit code $LASTEXITCODE."
     }

--- a/tests/Test-ManifestContent.Tests.ps1
+++ b/tests/Test-ManifestContent.Tests.ps1
@@ -1,0 +1,82 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$validationScript = Join-Path $repositoryRoot 'scripts/validation/Test-ManifestContent.ps1'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("winget-manifest-content-test-$([guid]::NewGuid().ToString('N'))")
+$publishedVersionPath = Join-Path $testRoot 'published/1.0.0'
+$generatedManifestPath = Join-Path $testRoot 'generated'
+
+function Write-TestManifest {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Path,
+        [Parameter(Mandatory = $true)] [string] $Version,
+        [Parameter(Mandatory = $true)] [string] $Hash,
+        [Parameter(Mandatory = $true)] [bool] $IncludeNestedInstallerMetadata
+    )
+
+    $nestedInstallerMetadata = if ($IncludeNestedInstallerMetadata) {
+        @"
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: Pinokio Setup.exe
+"@
+    }
+    else {
+        ''
+    }
+
+    @"
+PackageIdentifier: Test.StructuralRewrite
+PackageVersion: $Version
+InstallerType: nullsoft
+$nestedInstallerMetadata
+Installers:
+- Architecture: x64
+  InstallerUrl: https://example.invalid/test-$Version.exe
+  InstallerSha256: $Hash
+ManifestType: installer
+ManifestVersion: 1.12.0
+"@ | Set-Content -LiteralPath (Join-Path $Path 'Test.StructuralRewrite.installer.yaml') -NoNewline
+
+    @"
+PackageIdentifier: Test.StructuralRewrite
+PackageVersion: $Version
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+"@ | Set-Content -LiteralPath (Join-Path $Path 'Test.StructuralRewrite.yaml') -NoNewline
+}
+
+try {
+    New-Item -ItemType Directory -Path $publishedVersionPath, $generatedManifestPath -Force | Out-Null
+    Write-TestManifest `
+        -Path $publishedVersionPath `
+        -Version '1.0.0' `
+        -Hash ('A' * 64) `
+        -IncludeNestedInstallerMetadata $true
+    Write-TestManifest `
+        -Path $generatedManifestPath `
+        -Version '1.1.0' `
+        -Hash ('B' * 64) `
+        -IncludeNestedInstallerMetadata $false
+
+    Write-Host 'TEST: structural metadata removal fails without explicit approval'
+    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite $false
+    if ($LASTEXITCODE -ne 4) {
+        throw "Expected metadata consistency validation to fail with exit code 4, got $LASTEXITCODE."
+    }
+
+    Write-Host 'TEST: structural metadata removal passes with explicit approval'
+    $null = & $validationScript -ManifestPath $generatedManifestPath -PublishedPackageRoot (Split-Path -Parent $publishedVersionPath) -AllowStructuralRewrite $true
+    if ($LASTEXITCODE -ne 0) {
+        throw "Expected approved structural rewrite validation to pass, got exit code $LASTEXITCODE."
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Test-ManifestContent regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Root cause\nThe Pinokio 8.0.40 generator output correctly changes from the published 8.0.35 nested NSIS layout to a direct NSIS installer. llowStructuralRewrite reached WinMatsch but not content validation, which rejected the intentionally removed NestedInstallerType and NestedInstallerFiles metadata.\n\n## Change\n- pass the existing per-package structural-rewrite approval into content validation in the template and both rendered workflows\n- skip only inherited installer metadata consistency checks when that opt-in is present; all YAML, package-version, hash, and duplicate-installer validation remains active\n- add focused regression coverage, including the unapproved failure case\n\nNo manifests or branches in microsoft/winget-pkgs are modified.