### PR TITLE
Exclude Terragrunt validation regression

### DIFF
--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -395,10 +395,7 @@ jobs:
           - id: Gruntwork.cloud-nuke
             repo: gruntwork-io/cloud-nuke
             url: https://github.com/gruntwork-io/cloud-nuke/releases/download/v{VERSION}/cloud-nuke_windows_386.exe https://github.com/gruntwork-io/cloud-nuke/releases/download/v{VERSION}/cloud-nuke_windows_amd64.exe
-          - id: Gruntwork.Terragrunt
-            repo: gruntwork-io/terragrunt
-            url: https://github.com/gruntwork-io/terragrunt/releases/download/v{VERSION}/terragrunt_windows_386.exe https://github.com/gruntwork-io/terragrunt/releases/download/v{VERSION}/terragrunt_windows_amd64.exe
-            allowStructuralRewrite: true
+          # Gruntwork.Terragrunt is excluded: WinMatsch drops the published portable nested-installer metadata.
           # gurnec.HashCheckShellExtension is excluded: its current installer SHA256 is already published.
           # Gyan.FFmpeg.Essentials is excluded: 9.0 removed the prior release asset layout, which requires a reviewed WinMatsch mapping override.
           - id: h3poteto.fedistar

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -387,10 +387,7 @@
           - id: "Gruntwork.cloud-nuke"
             repo: "gruntwork-io/cloud-nuke"
             url: "https://github.com/gruntwork-io/cloud-nuke/releases/download/v{VERSION}/cloud-nuke_windows_386.exe https://github.com/gruntwork-io/cloud-nuke/releases/download/v{VERSION}/cloud-nuke_windows_amd64.exe"
-          - id: "Gruntwork.Terragrunt"
-            repo: "gruntwork-io/terragrunt"
-            url: "https://github.com/gruntwork-io/terragrunt/releases/download/v{VERSION}/terragrunt_windows_386.exe https://github.com/gruntwork-io/terragrunt/releases/download/v{VERSION}/terragrunt_windows_amd64.exe"
-            allowStructuralRewrite: true
+          # Gruntwork.Terragrunt is excluded: WinMatsch drops the published portable nested-installer metadata.
           # gurnec.HashCheckShellExtension is excluded: its current installer SHA256 is already published.
           # Gyan.FFmpeg.Essentials is excluded: 9.0 removed the prior release asset layout, which requires a reviewed WinMatsch mapping override.
           - id: "h3poteto.fedistar"

--- a/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
+++ b/tests/GitHubReleaseMonitoringConfiguration.Tests.ps1
@@ -27,7 +27,8 @@ $configurationPaths = @(
 
 $excludedPackageIds = @(
     'benaclejames.VRCFaceTracking',
-    'SVGExplorerExtension.SVGExplorerExtension'
+    'SVGExplorerExtension.SVGExplorerExtension',
+    'Gruntwork.Terragrunt'
 )
 
 foreach ($configurationRelativePath in $configurationPaths) {
@@ -38,7 +39,7 @@ foreach ($configurationRelativePath in $configurationPaths) {
         Assert-NotMatch `
             -Actual $configuration `
             -Pattern "^\s*-\s+id:\s*`"?$([regex]::Escape($packageId))`"?\s*$" `
-            -Message "$configurationRelativePath must not monitor $packageId until its upstream release artifacts change."
+            -Message "$configurationRelativePath must not monitor $packageId while its documented validation exclusion applies."
     }
 }
 


### PR DESCRIPTION
## Summary
- exclude `Gruntwork.Terragrunt` from the mirrored GitHub release monitoring matrices
- document that WinMatsch 1.1.2 output removes the published portable nested-installer metadata
- prevent accidental re-enablement with the release-monitoring configuration regression test

## Root cause
The generated 1.1.2 manifest has valid Windows release URLs and SHA256 hashes, but omits `NestedInstallerType` and `NestedInstallerFiles` present in the published 1.1.1 manifest. Integrated content validation rejects that metadata loss.

## Validation
- `pwsh -NoProfile -File .\tests\GitHubReleaseMonitoringConfiguration.Tests.ps1`
- parsed both updated YAML configurations with `ConvertFrom-Yaml`