### PR TITLE
Fix upstream ForkBranch preflight reads

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -686,7 +686,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: Fork
+          WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -686,7 +686,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
+          WINGET_PKGS_SUBMISSION_TARGET: Fork
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -45,7 +45,8 @@ jobs:
           $pesterConfig = New-PesterConfiguration
           $pesterConfig.Run.Path = @(
             './tests/Submit-WingetPackage.Tests.ps1',
-            './tests/ForkBranchSubmission.Tests.ps1'
+            './tests/ForkBranchSubmission.Tests.ps1',
+            './tests/Test-ExistingPRs.Tests.ps1'
           )
           $pesterConfig.Run.Exit = $true
           Invoke-Pester -Configuration $pesterConfig

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1412,7 +1412,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: Fork
+          WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1412,7 +1412,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
+          WINGET_PKGS_SUBMISSION_TARGET: Fork
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -1013,7 +1013,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
+          WINGET_PKGS_SUBMISSION_TARGET: Fork
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -1013,7 +1013,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: Fork
+          WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -725,7 +725,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: Fork
+          WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -725,7 +725,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
-          WINGET_PKGS_SUBMISSION_TARGET: ${{ github.ref == 'refs/heads/main' && 'Upstream' || 'Fork' }}
+          WINGET_PKGS_SUBMISSION_TARGET: Fork
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -801,4 +801,3 @@ jobs:
         env:
           VARS_NTFY_TOPIC: ${{ vars.NTFY_TOPIC }}
           VARS_NTFY_URL: ${{ vars.NTFY_URL }}
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # winget-pkgs-updates
-**PR repo:** [winget-pkgs](https://github.com/microsoft/winget-pkgs.git)  
-**Fork repo:** [damn-good-b0t/winget-pkgs](https://github.com/damn-good-b0t/winget-pkgs)
+**Submission repo:** [Utesgui/winget-pkgs](https://github.com/Utesgui/winget-pkgs)
 
-### PRs:
-- [**all open PRs**](https://github.com/microsoft/winget-pkgs/pulls/damn-good-b0t)
-- [**need attention**](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3Adamn-good-b0t+-label%3AAzure-Pipeline-Passed+)
+### Fork submissions:
+- [**all open PRs**](https://github.com/Utesgui/winget-pkgs/pulls)
+- [**need attention**](https://github.com/Utesgui/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3AUtesgui)
 
 | Package Version Handling| Count|
 |----------------------------|---------------------------------------------------------------|
@@ -18,17 +17,16 @@
 ## Scheduled submission topology
 
 Validated scheduled manifests use `ForkBranch` submission rather than
-`wingetcreate submit`. The module verifies `WINGET_PKGS_FORK_REPO` is a fork
-of `microsoft/winget-pkgs`, creates a disposable branch directly from the
-selected base commit, and commits only the manifest files to that branch. It
-never syncs or writes the fork default branch.
+`wingetcreate submit`. `WINGET_PKGS_FORK_REPO` must be configured as
+`Utesgui/winget-pkgs`; the module verifies that exact repository is a fork of
+`microsoft/winget-pkgs`, creates a disposable branch directly from its default
+branch, and commits only the manifest files to that branch. It never syncs or
+writes the fork default branch.
 
-Main-branch runs open the normal pull request from that user-owned fork branch
-to `microsoft/winget-pkgs`. Non-main test runs instead open the pull request
-inside the configured fork, so test submissions make no write to the Microsoft
-repository. A fine-grained PAT needs Contents write on the configured fork and
-Pull requests write on the selected PR target; it does not need GitHub Actions
-workflow scope.
+Every trigger, including scheduled main-branch runs, opens the pull request
+inside `Utesgui/winget-pkgs`. Submissions to `microsoft/winget-pkgs` are
+disabled. A fine-grained PAT needs Contents write and Pull requests write on
+`Utesgui/winget-pkgs`; it does not need GitHub Actions workflow scope.
 
 ## Package-specific WinMatsch overrides
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # winget-pkgs-updates
-**Submission repo:** [Utesgui/winget-pkgs](https://github.com/Utesgui/winget-pkgs)
+**Submission repo:** [damn-good-b0t/winget-pkgs](https://github.com/damn-good-b0t/winget-pkgs)
 
 ### Fork submissions:
-- [**all open PRs**](https://github.com/Utesgui/winget-pkgs/pulls)
-- [**need attention**](https://github.com/Utesgui/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3AUtesgui)
+- [**all open PRs**](https://github.com/damn-good-b0t/winget-pkgs/pulls)
+- [**need attention**](https://github.com/damn-good-b0t/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3Adamn-good-b0t)
 
 | Package Version Handling| Count|
 |----------------------------|---------------------------------------------------------------|
@@ -17,16 +17,16 @@
 ## Scheduled submission topology
 
 Validated scheduled manifests use `ForkBranch` submission rather than
-`wingetcreate submit`. `WINGET_PKGS_FORK_REPO` must be configured as
-`Utesgui/winget-pkgs`; the module verifies that exact repository is a fork of
-`microsoft/winget-pkgs`, creates a disposable branch directly from its default
-branch, and commits only the manifest files to that branch. It never syncs or
-writes the fork default branch.
+`wingetcreate submit`. `WINGET_PKGS_FORK_REPO` must name a user-owned fork;
+the module verifies that repository is a fork of `microsoft/winget-pkgs`,
+creates a disposable branch directly from its default branch, and commits only
+the manifest files to that branch. It never syncs or writes the fork default
+branch.
 
 Every trigger, including scheduled main-branch runs, opens the pull request
-inside `Utesgui/winget-pkgs`. Submissions to `microsoft/winget-pkgs` are
+inside the configured fork. Submissions to `microsoft/winget-pkgs` are
 disabled. A fine-grained PAT needs Contents write and Pull requests write on
-`Utesgui/winget-pkgs`; it does not need GitHub Actions workflow scope.
+the configured fork; it does not need GitHub Actions workflow scope.
 
 ## Package-specific WinMatsch overrides
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ the manifest files to that branch. It never syncs or writes the fork default
 branch.
 
 Every trigger, including scheduled main-branch runs, opens the pull request
-inside the configured fork. Submissions to `microsoft/winget-pkgs` are
-disabled. A fine-grained PAT needs Contents write and Pull requests write on
-the configured fork; it does not need GitHub Actions workflow scope.
+from the configured fork branch to `microsoft/winget-pkgs`. The submission
+flow never directly pushes or commits content to `microsoft/winget-pkgs`.
+Public upstream duplicate and base reads are unauthenticated so a
+fork-scoped fine-grained token cannot block them. A fine-grained PAT needs
+Contents write on the configured fork and Pull requests write on the upstream
+target; it does not need GitHub Actions workflow scope.
 
 ## Package-specific WinMatsch overrides
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # winget-pkgs-updates
-**Submission repo:** [damn-good-b0t/winget-pkgs](https://github.com/damn-good-b0t/winget-pkgs)
+**PR repo:** [winget-pkgs](https://github.com/microsoft/winget-pkgs.git)
+**Fork repo:** [damn-good-b0t/winget-pkgs](https://github.com/damn-good-b0t/winget-pkgs)
 
-### Fork submissions:
-- [**all open PRs**](https://github.com/damn-good-b0t/winget-pkgs/pulls)
-- [**need attention**](https://github.com/damn-good-b0t/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3Adamn-good-b0t)
+### Pull requests:
+- [**all open PRs**](https://github.com/microsoft/winget-pkgs/pulls/damn-good-b0t)
+- [**need attention**](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Aopen+is%3Apr+author%3Adamn-good-b0t)
 
 | Package Version Handling| Count|
 |----------------------------|---------------------------------------------------------------|

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -84,6 +84,22 @@ function Get-ForkBranchSubmissionFiles {
     )
 }
 
+function Assert-SafeWingetPkgsForkRepository {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ForkRepository
+    )
+
+    $approvedForkRepository = 'Utesgui/winget-pkgs'
+    if ($ForkRepository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+        throw "WINGET_PKGS_FORK_REPO must be an owner/repository name, not '$ForkRepository'."
+    }
+    if ($ForkRepository -ine $approvedForkRepository) {
+        throw "WINGET_PKGS_FORK_REPO must be configured as $approvedForkRepository for ForkBranch submissions; received '$ForkRepository'."
+    }
+}
+
 function Invoke-ForkBranchSubmission {
     <#
     .SYNOPSIS
@@ -110,34 +126,20 @@ function Invoke-ForkBranchSubmission {
         [string] $ForkRepository,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Upstream', 'Fork')]
-        [string] $SubmissionTarget = 'Upstream',
-
-        [Parameter(Mandatory = $false)]
         [string] $Resolves
     )
 
     $upstreamRepository = 'microsoft/winget-pkgs'
-    if ($ForkRepository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
-        throw "WINGET_PKGS_FORK_REPO must be an owner/repository name, not '$ForkRepository'."
-    }
-    if ($ForkRepository -ieq $upstreamRepository) {
-        throw 'WINGET_PKGS_FORK_REPO must name a user-owned fork, never microsoft/winget-pkgs.'
-    }
+    Assert-SafeWingetPkgsForkRepository -ForkRepository $ForkRepository
 
     $fork = Invoke-WingetPkgsGitHubApi -Method Get -Path "repos/$ForkRepository" -Token $Token
     if (-not $fork.fork -or "$($fork.parent.full_name)" -ine $upstreamRepository) {
         throw "Configured repository '$ForkRepository' is not a fork of $upstreamRepository."
     }
 
-    $targetRepository = if ($SubmissionTarget -eq 'Fork') { $ForkRepository } else { $upstreamRepository }
+    $targetRepository = $ForkRepository
     $targetDefaultBranch = "$($fork.default_branch)"
     $baseRepository = $targetRepository
-
-    if ($SubmissionTarget -eq 'Upstream') {
-        $upstream = Invoke-WingetPkgsGitHubApi -Method Get -Path "repos/$upstreamRepository" -Token $Token
-        $targetDefaultBranch = "$($upstream.default_branch)"
-    }
 
     $baseReference = Invoke-WingetPkgsGitHubApi `
         -Method Get `

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -18,14 +18,18 @@ function Invoke-WingetPkgsGitHubApi {
         [string] $Token,
 
         [Parameter(Mandatory = $false)]
+        [switch] $Unauthenticated,
+
+        [Parameter(Mandatory = $false)]
         [object] $Body
     )
-
     $headers = @{
         Accept                 = 'application/vnd.github+json'
-        Authorization          = "Bearer $Token"
         'X-GitHub-Api-Version' = '2022-11-28'
         'User-Agent'           = 'winget-pkgs-updates'
+    }
+    if (-not $Unauthenticated) {
+        $headers.Authorization = "Bearer $Token"
     }
     $request = @{
         Uri         = "https://api.github.com/$($Path.TrimStart('/'))"
@@ -137,14 +141,22 @@ function Invoke-ForkBranchSubmission {
         throw "Configured repository '$ForkRepository' is not a fork of $upstreamRepository."
     }
 
-    $targetRepository = $ForkRepository
-    $targetDefaultBranch = "$($fork.default_branch)"
+    # The fine-grained fork token cannot necessarily read the public upstream.
+    # Keep its use to fork writes and the final cross-repository PR creation.
+    $targetRepository = $upstreamRepository
+    $upstream = Invoke-WingetPkgsGitHubApi `
+        -Method Get `
+        -Path "repos/$upstreamRepository" `
+        -Token $Token `
+        -Unauthenticated
+    $targetDefaultBranch = "$($upstream.default_branch)"
     $baseRepository = $targetRepository
 
     $baseReference = Invoke-WingetPkgsGitHubApi `
         -Method Get `
         -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch" `
-        -Token $Token
+        -Token $Token `
+        -Unauthenticated
     $baseSha = "$($baseReference.object.sha)"
     if ([string]::IsNullOrWhiteSpace($baseSha)) {
         throw "Could not resolve the $baseRepository/$targetDefaultBranch commit SHA."
@@ -152,7 +164,8 @@ function Invoke-ForkBranchSubmission {
     $baseCommit = Invoke-WingetPkgsGitHubApi `
         -Method Get `
         -Path "repos/$baseRepository/git/commits/$baseSha" `
-        -Token $Token
+        -Token $Token `
+        -Unauthenticated
     $baseTreeSha = "$($baseCommit.tree.sha)"
     if ([string]::IsNullOrWhiteSpace($baseTreeSha)) {
         throw "Could not resolve the base tree for $baseRepository/$targetDefaultBranch."

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -91,12 +91,12 @@ function Assert-SafeWingetPkgsForkRepository {
         [string] $ForkRepository
     )
 
-    $approvedForkRepository = 'Utesgui/winget-pkgs'
+    $upstreamRepository = 'microsoft/winget-pkgs'
     if ($ForkRepository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
         throw "WINGET_PKGS_FORK_REPO must be an owner/repository name, not '$ForkRepository'."
     }
-    if ($ForkRepository -ine $approvedForkRepository) {
-        throw "WINGET_PKGS_FORK_REPO must be configured as $approvedForkRepository for ForkBranch submissions; received '$ForkRepository'."
+    if ($ForkRepository -ieq $upstreamRepository) {
+        throw 'WINGET_PKGS_FORK_REPO must name a user-owned fork, never microsoft/winget-pkgs.'
     }
 }
 

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -30,8 +30,9 @@
     fork's default branch.
 
     .PARAMETER SubmissionTarget
-    ForkBranch target: "Upstream" opens the normal PR against
-    microsoft/winget-pkgs; "Fork" opens a fork-only PR for test runs.
+    ForkBranch is restricted to "Fork" and opens the pull request inside the
+    verified Utesgui/winget-pkgs fork. Submissions to microsoft/winget-pkgs
+    are disabled.
 
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses
@@ -97,7 +98,7 @@ function Submit-WingetPackage {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet('Upstream', 'Fork')]
-        [string] $SubmissionTarget = 'Upstream'
+        [string] $SubmissionTarget = 'Fork'
     )
 
     # Get GitHub token
@@ -249,6 +250,15 @@ function Submit-WingetPackage {
             }
 
             "ForkBranch" {
+                if ($SubmissionTarget -ne 'Fork') {
+                    return @{
+                        Success  = $false
+                        Error    = 'ForkBranch submissions are restricted to the Fork target; submissions to microsoft/winget-pkgs are disabled.'
+                        PrUrl    = $null
+                        PrNumber = $null
+                    }
+                }
+
                 $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
                 if ([string]::IsNullOrWhiteSpace($forkRepository)) {
                     return @{
@@ -259,12 +269,8 @@ function Submit-WingetPackage {
                     }
                 }
 
-                $targetRepository = if ($SubmissionTarget -eq 'Fork') {
-                    $forkRepository
-                }
-                else {
-                    'microsoft/winget-pkgs'
-                }
+                Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
+                $targetRepository = $forkRepository
 
                 if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
                     $existingPrUrl = Get-WingetPkgsPrUrl `
@@ -294,7 +300,6 @@ function Submit-WingetPackage {
                     -PrTitle $PrTitle `
                     -Token $Token `
                     -ForkRepository $forkRepository `
-                    -SubmissionTarget $SubmissionTarget `
                     -Resolves $Resolves
 
                 if (-not $forkSubmission.Created) {

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -30,9 +30,10 @@
     fork's default branch.
 
     .PARAMETER SubmissionTarget
-    ForkBranch is restricted to "Fork" and opens the pull request inside the
-    configured, topology-verified user-owned fork. Submissions to
-    microsoft/winget-pkgs are disabled.
+    ForkBranch is restricted to "Upstream". It creates the branch and manifest
+    commit in the configured, topology-verified user-owned fork, then opens a
+    pull request against microsoft/winget-pkgs. It never directly pushes or
+    commits content to microsoft/winget-pkgs.
 
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses
@@ -98,7 +99,7 @@ function Submit-WingetPackage {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet('Upstream', 'Fork')]
-        [string] $SubmissionTarget = 'Fork'
+        [string] $SubmissionTarget = 'Upstream'
     )
 
     # Get GitHub token
@@ -250,10 +251,10 @@ function Submit-WingetPackage {
             }
 
             "ForkBranch" {
-                if ($SubmissionTarget -ne 'Fork') {
+                if ($SubmissionTarget -ne 'Upstream') {
                     return @{
                         Success  = $false
-                        Error    = 'ForkBranch submissions are restricted to the Fork target; submissions to microsoft/winget-pkgs are disabled.'
+                        Error    = 'ForkBranch submissions are restricted to the Upstream target; manifest writes remain in the configured fork.'
                         PrUrl    = $null
                         PrNumber = $null
                     }
@@ -270,7 +271,7 @@ function Submit-WingetPackage {
                 }
 
                 Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
-                $targetRepository = $forkRepository
+                $targetRepository = 'microsoft/winget-pkgs'
 
                 if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
                     $existingPrUrl = Get-WingetPkgsPrUrl `

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -31,8 +31,8 @@
 
     .PARAMETER SubmissionTarget
     ForkBranch is restricted to "Fork" and opens the pull request inside the
-    verified Utesgui/winget-pkgs fork. Submissions to microsoft/winget-pkgs
-    are disabled.
+    configured, topology-verified user-owned fork. Submissions to
+    microsoft/winget-pkgs are disabled.
 
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -4,7 +4,10 @@
 
 .DESCRIPTION
     The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version. 
-    It uses the GitHub CLI (`gh`) to perform the search and returns `true` if any matching PRs are found, otherwise returns `false`.
+    It uses GitHub's public REST search endpoint without credentials so a
+    fine-grained submission token scoped only to the source fork cannot turn a
+    readable upstream lookup into a 404. It returns `true` if matching open or
+    merged PRs are found, otherwise returns `false`.
 
 .PARAMETER Version
     The version of the package to check for existing PRs. This parameter is mandatory.
@@ -24,8 +27,6 @@
     System.Boolean
     Returns `true` if any matching PRs are found, otherwise returns `false`.
 
-.NOTES
-    This function requires the GitHub CLI (`gh`) to be installed and authenticated.
 #>
 function Test-ExistingPRs {
     param(
@@ -35,22 +36,41 @@ function Test-ExistingPRs {
         [Parameter(Mandatory = $false)] [string] $Repository = 'microsoft/winget-pkgs'
     )
     Write-Host "Checking for existing PRs for $PackageIdentifier $Version in $Repository"
-    $ExistingOpenPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'open' --json 'title,url' --repo $Repository | ConvertFrom-Json
-    
-    $ExistingPRs = if ($OnlyOpen) {
-        @($ExistingOpenPRs)
-    } else {
-        $ExistingMergedPRs = gh pr list --search "$($PackageIdentifier) $($Version) in:title draft:false" --state 'merged' --json 'title,url' --repo $Repository | ConvertFrom-Json
-        @($ExistingOpenPRs) + @($ExistingMergedPRs)
+
+    if ($Repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+        throw "Repository must be an owner/repository name, not '$Repository'."
+    }
+    if ([string]::IsNullOrWhiteSpace($PackageIdentifier) -or [string]::IsNullOrWhiteSpace($Version)) {
+        throw 'PackageIdentifier and Version are required to search for existing pull requests.'
     }
 
-    if ($ExistingPRs.Count -gt 0) {
-        $ExistingPRs | ForEach-Object {
-            Write-Host "Found existing PR: $($_.title)"
-            Write-Host "-> $($_.url)"
-        }
-        return $true
-    } else {
-        return $false
+    $states = if ($OnlyOpen) { @('open') } else { @('open', 'merged') }
+    $headers = @{
+        Accept                 = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+        'User-Agent'           = 'winget-pkgs-updates'
     }
+    $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
+    $escapedVersion = $Version.Replace('"', '\"')
+
+    foreach ($state in $states) {
+        $query = "repo:$Repository is:pr is:$state in:title `"$escapedPackageIdentifier $escapedVersion`""
+        $encodedQuery = [uri]::EscapeDataString($query)
+        $response = Invoke-RestMethod `
+            -Method Get `
+            -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
+            -Headers $headers `
+            -ErrorAction Stop
+        $existingPrs = @($response.items)
+
+        if ($existingPrs.Count -gt 0) {
+            $existingPrs | ForEach-Object {
+                Write-Host "Found existing PR: $($_.title)"
+                Write-Host "-> $($_.html_url)"
+            }
+            return $true
+        }
+    }
+
+    return $false
 }

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -14,11 +14,17 @@ Describe 'Submit-WingetPackage ForkBranch' {
         ) | Set-Content -LiteralPath (Join-Path $global:ForkBranchSubmissionManifestPath 'Test.Package.yaml')
 
         $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
+        $global:ForkBranchDuplicateRepositories = [System.Collections.Generic.List[string]]::new()
         $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
-        $env:WINGET_PKGS_FORK_REPO = 'Utesgui/winget-pkgs'
+        $env:WINGET_PKGS_FORK_REPO = 'damn-good-b0t/winget-pkgs'
 
         InModuleScope WingetMaintainerModule {
-            Mock Test-ExistingPRs { $false }
+            Mock Test-ExistingPRs {
+                param($PackageIdentifier, $Version, $Repository)
+
+                $global:ForkBranchDuplicateRepositories.Add($Repository)
+                return $false
+            }
             Mock Get-WingetPkgsPrUrl { $null }
             Mock Invoke-WingetPkgsGitHubApi {
                 param($Method, $Path, $Token, $Body)
@@ -30,7 +36,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                 })
 
                 switch -Regex ($Path) {
-                    '^repos/Utesgui/winget-pkgs$' {
+                    '^repos/damn-good-b0t/winget-pkgs$' {
                         return [pscustomobject]@{
                             fork           = $true
                             default_branch = 'master'
@@ -54,7 +60,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     }
                     '/pulls$' {
                         return [pscustomobject]@{
-                            html_url = 'https://github.com/Utesgui/winget-pkgs/pull/12345'
+                            html_url = 'https://github.com/damn-good-b0t/winget-pkgs/pull/12345'
                             number   = 12345
                         }
                     }
@@ -71,6 +77,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         $env:WINGET_PKGS_FORK_REPO = $global:OriginalForkRepository
         Remove-Variable -Name ForkBranchSubmissionManifestPath -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchSubmissionRequests -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ForkBranchDuplicateRepositories -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
     }
 
@@ -94,7 +101,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
     }
 
-    It 'keeps Fork submissions entirely within the verified Utesgui fork' {
+    It 'keeps Fork submissions entirely within the configured verified fork' {
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
             -PackageId 'Test.Package' `
@@ -108,19 +115,22 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match 'microsoft/winget-pkgs' }).Count -ne 0) {
             throw 'Fork submission called the Microsoft repository API.'
         }
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'damn-good-b0t/winget-pkgs' }).Count -ne 0) {
+            throw "Fork submission did not perform duplicate checks against the configured fork: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        }
 
         $forkWrites = @(
             $global:ForkBranchSubmissionRequests |
                 Where-Object {
-                    $_.Path -match '^repos/Utesgui/winget-pkgs/' -and
+                    $_.Path -match '^repos/damn-good-b0t/winget-pkgs/' -and
                     $_.Method -in @('Post', 'Patch', 'Delete')
                 }
         )
         foreach ($expectedPath in @(
-            'repos/Utesgui/winget-pkgs/git/trees',
-            'repos/Utesgui/winget-pkgs/git/commits',
-            'repos/Utesgui/winget-pkgs/git/refs',
-            'repos/Utesgui/winget-pkgs/pulls'
+            'repos/damn-good-b0t/winget-pkgs/git/trees',
+            'repos/damn-good-b0t/winget-pkgs/git/commits',
+            'repos/damn-good-b0t/winget-pkgs/git/refs',
+            'repos/damn-good-b0t/winget-pkgs/pulls'
         )) {
             if ($forkWrites.Path -notcontains $expectedPath) {
                 throw "Expected fork write was not made: $expectedPath"
@@ -129,26 +139,31 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if (@($forkWrites | Where-Object { $_.Path -match 'merge-upstream|refs/heads/master' }).Count -ne 0) {
             throw 'ForkBranch wrote or synchronized the fork default branch.'
         }
-        $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/Utesgui/winget-pkgs/git/trees' }
+        $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/git/trees' }
         if ($treeRequest.Body.base_tree -cne 'base-tree-sha') {
             throw "ForkBranch did not base the manifest tree on the resolved base tree: $($treeRequest.Body.base_tree)"
         }
 
         $pullRequest = $global:ForkBranchSubmissionRequests |
-            Where-Object { $_.Path -eq 'repos/Utesgui/winget-pkgs/pulls' } |
+            Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/pulls' } |
             Select-Object -Last 1
         if ($pullRequest.Body.base -cne 'master') {
             throw "Fork test submission used an unexpected base branch: $($pullRequest.Body.base)"
         }
-        if ($pullRequest.Body.head -notmatch '^Utesgui:winget-autosubmit/') {
+        if ($pullRequest.Body.head -notmatch '^damn-good-b0t:winget-autosubmit/') {
             throw "Fork test submission used an unexpected PR head: $($pullRequest.Body.head)"
         }
     }
 
     It 'does not create a fork branch when the matching target PR already exists' {
         InModuleScope WingetMaintainerModule {
-            Mock Test-ExistingPRs { $true }
-            Mock Get-WingetPkgsPrUrl { 'https://github.com/Utesgui/winget-pkgs/pull/54321' }
+            Mock Test-ExistingPRs {
+                param($PackageIdentifier, $Version, $Repository)
+
+                $global:ForkBranchDuplicateRepositories.Add($Repository)
+                return $true
+            }
+            Mock Get-WingetPkgsPrUrl { 'https://github.com/damn-good-b0t/winget-pkgs/pull/54321' }
         }
 
         $result = Submit-WingetPackage `
@@ -158,16 +173,34 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -Token 'test-token' `
             -With ForkBranch
 
-        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/Utesgui/winget-pkgs/pull/54321') {
+        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/damn-good-b0t/winget-pkgs/pull/54321') {
             throw "Existing submission PR was not returned: $($result | ConvertTo-Json -Compress)"
+        }
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'damn-good-b0t/winget-pkgs') {
+            throw "Duplicate detection did not use the configured fork: $($global:ForkBranchDuplicateRepositories -join ', ')"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
             throw 'Duplicate detection attempted a fork API request.'
         }
     }
 
-    It 'rejects an unapproved fork configuration before querying GitHub' {
-        $env:WINGET_PKGS_FORK_REPO = 'damn-good-b0t/winget-pkgs'
+    It 'rejects a configured repository that is not a winget-pkgs fork before writing' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-WingetPkgsGitHubApi {
+                param($Method, $Path, $Token, $Body)
+
+                $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
+                    Method = $Method
+                    Path   = $Path
+                    Body   = $Body
+                })
+                return [pscustomobject]@{
+                    fork           = $false
+                    default_branch = 'master'
+                    parent         = [pscustomobject]@{ full_name = 'unrelated/repository' }
+                }
+            }
+        }
 
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
@@ -177,13 +210,37 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -With ForkBranch
 
         if ($result.Success -ne $false) {
-            throw 'An unapproved fork configuration unexpectedly succeeded.'
+            throw 'A repository that is not a fork unexpectedly succeeded.'
         }
-        if ($result.Error -notmatch 'must be configured as Utesgui/winget-pkgs') {
+        if ($result.Error -notmatch 'is not a fork of microsoft/winget-pkgs') {
+            throw "The invalid fork topology was not identified clearly: $($result.Error)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Method -in @('Post', 'Patch', 'Delete') }).Count -ne 0) {
+            throw 'An invalid fork topology attempted a GitHub write.'
+        }
+    }
+
+    It 'rejects microsoft/winget-pkgs as the configured fork before querying GitHub' {
+        $env:WINGET_PKGS_FORK_REPO = 'microsoft/winget-pkgs'
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $false) {
+            throw 'The Microsoft repository configuration unexpectedly succeeded.'
+        }
+        if ($result.Error -notmatch 'user-owned fork') {
             throw "The unsafe fork configuration was not identified clearly: $($result.Error)"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
-            throw 'An unapproved fork configuration queried or wrote a GitHub repository.'
+            throw 'The Microsoft repository configuration queried or wrote a GitHub repository.'
+        }
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 0) {
+            throw 'The Microsoft repository configuration performed duplicate detection.'
         }
     }
 

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -27,12 +27,13 @@ Describe 'Submit-WingetPackage ForkBranch' {
             }
             Mock Get-WingetPkgsPrUrl { $null }
             Mock Invoke-WingetPkgsGitHubApi {
-                param($Method, $Path, $Token, $Body)
+                param($Method, $Path, $Token, $Unauthenticated, $Body)
 
                 $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
-                    Method = $Method
-                    Path   = $Path
-                    Body   = $Body
+                    Method          = $Method
+                    Path            = $Path
+                    Unauthenticated = [bool] $Unauthenticated
+                    Body            = $Body
                 })
 
                 switch -Regex ($Path) {
@@ -42,6 +43,9 @@ Describe 'Submit-WingetPackage ForkBranch' {
                             default_branch = 'master'
                             parent         = [pscustomobject]@{ full_name = 'microsoft/winget-pkgs' }
                         }
+                    }
+                    '^repos/microsoft/winget-pkgs$' {
+                        return [pscustomobject]@{ default_branch = 'master' }
                     }
                     '/git/ref/heads/master$' {
                         return [pscustomobject]@{ object = [pscustomobject]@{ sha = 'base-sha' } }
@@ -60,7 +64,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     }
                     '/pulls$' {
                         return [pscustomobject]@{
-                            html_url = 'https://github.com/damn-good-b0t/winget-pkgs/pull/12345'
+                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
                             number   = 12345
                         }
                     }
@@ -81,27 +85,27 @@ Describe 'Submit-WingetPackage ForkBranch' {
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
     }
 
-    It 'rejects an upstream ForkBranch target before querying GitHub' {
+    It 'rejects a fork-only ForkBranch target before querying GitHub' {
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
             -PackageId 'Test.Package' `
             -Version '1.0.0' `
             -Token 'test-token' `
             -With ForkBranch `
-            -SubmissionTarget Upstream
+            -SubmissionTarget Fork
 
         if ($result.Success -ne $false) {
-            throw "Expected an upstream ForkBranch submission to fail, got: $($result | ConvertTo-Json -Compress)"
+            throw "Expected a fork-only ForkBranch submission to fail, got: $($result | ConvertTo-Json -Compress)"
         }
-        if ($result.Error -notmatch 'restricted to the Fork target') {
-            throw "The upstream rejection was not explained clearly: $($result.Error)"
+        if ($result.Error -notmatch 'restricted to the Upstream target') {
+            throw "The fork-only rejection was not explained clearly: $($result.Error)"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
-            throw 'An upstream ForkBranch target queried or wrote a GitHub repository.'
+            throw 'A fork-only ForkBranch target queried or wrote a GitHub repository.'
         }
     }
 
-    It 'keeps Fork submissions entirely within the configured verified fork' {
+    It 'creates cross-repository PRs from the configured verified fork' {
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
             -PackageId 'Test.Package' `
@@ -112,11 +116,15 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if ($result.Success -ne $true) {
             throw "Expected a successful fork-only ForkBranch submission, got: $($result.Error)"
         }
-        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match 'microsoft/winget-pkgs' }).Count -ne 0) {
-            throw 'Fork submission called the Microsoft repository API.'
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'microsoft/winget-pkgs' }).Count -ne 0) {
+            throw "Fork submission did not perform duplicate checks against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
         }
-        if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'damn-good-b0t/winget-pkgs' }).Count -ne 0) {
-            throw "Fork submission did not perform duplicate checks against the configured fork: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        $upstreamReads = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/microsoft/winget-pkgs($|/)' -and $_.Method -eq 'Get' }
+        )
+        if ($upstreamReads.Count -ne 3 -or @($upstreamReads | Where-Object { -not $_.Unauthenticated }).Count -ne 0) {
+            throw "Upstream base reads must be unauthenticated: $($upstreamReads | ConvertTo-Json -Compress)"
         }
 
         $forkWrites = @(
@@ -129,8 +137,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         foreach ($expectedPath in @(
             'repos/damn-good-b0t/winget-pkgs/git/trees',
             'repos/damn-good-b0t/winget-pkgs/git/commits',
-            'repos/damn-good-b0t/winget-pkgs/git/refs',
-            'repos/damn-good-b0t/winget-pkgs/pulls'
+            'repos/damn-good-b0t/winget-pkgs/git/refs'
         )) {
             if ($forkWrites.Path -notcontains $expectedPath) {
                 throw "Expected fork write was not made: $expectedPath"
@@ -145,13 +152,23 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
 
         $pullRequest = $global:ForkBranchSubmissionRequests |
-            Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/pulls' } |
+            Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' } |
             Select-Object -Last 1
+        if ($null -eq $pullRequest -or $pullRequest.Method -ne 'Post') {
+            throw 'ForkBranch did not create the expected upstream pull request.'
+        }
         if ($pullRequest.Body.base -cne 'master') {
-            throw "Fork test submission used an unexpected base branch: $($pullRequest.Body.base)"
+            throw "ForkBranch used an unexpected upstream base branch: $($pullRequest.Body.base)"
         }
         if ($pullRequest.Body.head -notmatch '^damn-good-b0t:winget-autosubmit/') {
-            throw "Fork test submission used an unexpected PR head: $($pullRequest.Body.head)"
+            throw "ForkBranch used an unexpected cross-repository PR head: $($pullRequest.Body.head)"
+        }
+        $upstreamWrites = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/microsoft/winget-pkgs/' -and $_.Method -in @('Post', 'Patch', 'Delete') }
+        )
+        if ($upstreamWrites.Count -ne 1 -or $upstreamWrites[0].Path -cne 'repos/microsoft/winget-pkgs/pulls') {
+            throw "Upstream write surface is not limited to creating the intended pull request: $($upstreamWrites.Path -join ', ')"
         }
     }
 
@@ -163,7 +180,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                 $global:ForkBranchDuplicateRepositories.Add($Repository)
                 return $true
             }
-            Mock Get-WingetPkgsPrUrl { 'https://github.com/damn-good-b0t/winget-pkgs/pull/54321' }
+            Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
         }
 
         $result = Submit-WingetPackage `
@@ -173,11 +190,11 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -Token 'test-token' `
             -With ForkBranch
 
-        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/damn-good-b0t/winget-pkgs/pull/54321') {
+        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/54321') {
             throw "Existing submission PR was not returned: $($result | ConvertTo-Json -Compress)"
         }
-        if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'damn-good-b0t/winget-pkgs') {
-            throw "Duplicate detection did not use the configured fork: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
+            throw "Duplicate detection did not use the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
             throw 'Duplicate detection attempted a fork API request.'
@@ -187,12 +204,13 @@ Describe 'Submit-WingetPackage ForkBranch' {
     It 'rejects a configured repository that is not a winget-pkgs fork before writing' {
         InModuleScope WingetMaintainerModule {
             Mock Invoke-WingetPkgsGitHubApi {
-                param($Method, $Path, $Token, $Body)
+                param($Method, $Path, $Token, $Unauthenticated, $Body)
 
                 $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
-                    Method = $Method
-                    Path   = $Path
-                    Body   = $Body
+                    Method          = $Method
+                    Path            = $Path
+                    Unauthenticated = [bool] $Unauthenticated
+                    Body            = $Body
                 })
                 return [pscustomobject]@{
                     fork           = $false

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
 
         $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
         $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
-        $env:WINGET_PKGS_FORK_REPO = 'test-owner/winget-pkgs'
+        $env:WINGET_PKGS_FORK_REPO = 'Utesgui/winget-pkgs'
 
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs { $false }
@@ -30,15 +30,12 @@ Describe 'Submit-WingetPackage ForkBranch' {
                 })
 
                 switch -Regex ($Path) {
-                    '^repos/test-owner/winget-pkgs$' {
+                    '^repos/Utesgui/winget-pkgs$' {
                         return [pscustomobject]@{
                             fork           = $true
                             default_branch = 'master'
                             parent         = [pscustomobject]@{ full_name = 'microsoft/winget-pkgs' }
                         }
-                    }
-                    '^repos/microsoft/winget-pkgs$' {
-                        return [pscustomobject]@{ default_branch = 'master' }
                     }
                     '/git/ref/heads/master$' {
                         return [pscustomobject]@{ object = [pscustomobject]@{ sha = 'base-sha' } }
@@ -57,7 +54,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     }
                     '/pulls$' {
                         return [pscustomobject]@{
-                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            html_url = 'https://github.com/Utesgui/winget-pkgs/pull/12345'
                             number   = 12345
                         }
                     }
@@ -77,7 +74,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
     }
 
-    It 'creates an upstream PR from a fork branch without writing the fork default branch' {
+    It 'rejects an upstream ForkBranch target before querying GitHub' {
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
             -PackageId 'Test.Package' `
@@ -86,27 +83,44 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -With ForkBranch `
             -SubmissionTarget Upstream
 
+        if ($result.Success -ne $false) {
+            throw "Expected an upstream ForkBranch submission to fail, got: $($result | ConvertTo-Json -Compress)"
+        }
+        if ($result.Error -notmatch 'restricted to the Fork target') {
+            throw "The upstream rejection was not explained clearly: $($result.Error)"
+        }
+        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
+            throw 'An upstream ForkBranch target queried or wrote a GitHub repository.'
+        }
+    }
+
+    It 'keeps Fork submissions entirely within the verified Utesgui fork' {
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch
+
         if ($result.Success -ne $true) {
-            throw "Expected a successful upstream ForkBranch submission, got: $($result.Error)"
+            throw "Expected a successful fork-only ForkBranch submission, got: $($result.Error)"
         }
-        if ($result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/12345') {
-            throw "Unexpected upstream PR URL: $($result.PrUrl)"
-        }
-        if ($result.PrNumber -cne '12345') {
-            throw "Unexpected upstream PR number: $($result.PrNumber)"
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match 'microsoft/winget-pkgs' }).Count -ne 0) {
+            throw 'Fork submission called the Microsoft repository API.'
         }
 
         $forkWrites = @(
             $global:ForkBranchSubmissionRequests |
                 Where-Object {
-                    $_.Path -match '^repos/test-owner/winget-pkgs/' -and
+                    $_.Path -match '^repos/Utesgui/winget-pkgs/' -and
                     $_.Method -in @('Post', 'Patch', 'Delete')
                 }
         )
         foreach ($expectedPath in @(
-            'repos/test-owner/winget-pkgs/git/trees',
-            'repos/test-owner/winget-pkgs/git/commits',
-            'repos/test-owner/winget-pkgs/git/refs'
+            'repos/Utesgui/winget-pkgs/git/trees',
+            'repos/Utesgui/winget-pkgs/git/commits',
+            'repos/Utesgui/winget-pkgs/git/refs',
+            'repos/Utesgui/winget-pkgs/pulls'
         )) {
             if ($forkWrites.Path -notcontains $expectedPath) {
                 throw "Expected fork write was not made: $expectedPath"
@@ -115,46 +129,18 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if (@($forkWrites | Where-Object { $_.Path -match 'merge-upstream|refs/heads/master' }).Count -ne 0) {
             throw 'ForkBranch wrote or synchronized the fork default branch.'
         }
-        $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/test-owner/winget-pkgs/git/trees' }
+        $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/Utesgui/winget-pkgs/git/trees' }
         if ($treeRequest.Body.base_tree -cne 'base-tree-sha') {
             throw "ForkBranch did not base the manifest tree on the resolved base tree: $($treeRequest.Body.base_tree)"
         }
 
-        $upstreamWrites = @(
-            $global:ForkBranchSubmissionRequests |
-                Where-Object {
-                    $_.Path -match '^repos/microsoft/winget-pkgs/' -and
-                    $_.Method -in @('Post', 'Patch', 'Delete')
-                }
-        )
-        if ($upstreamWrites.Count -ne 1 -or $upstreamWrites[0].Path -cne 'repos/microsoft/winget-pkgs/pulls') {
-            throw "Upstream write surface is not limited to creating the intended PR: $($upstreamWrites.Path -join ', ')"
-        }
-    }
-
-    It 'keeps Fork test submissions entirely within the verified user fork' {
-        $result = Submit-WingetPackage `
-            -ManifestPath $global:ForkBranchSubmissionManifestPath `
-            -PackageId 'Test.Package' `
-            -Version '1.0.0' `
-            -Token 'test-token' `
-            -With ForkBranch `
-            -SubmissionTarget Fork
-
-        if ($result.Success -ne $true) {
-            throw "Expected a successful fork-only ForkBranch submission, got: $($result.Error)"
-        }
-        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match 'microsoft/winget-pkgs' }).Count -ne 0) {
-            throw 'Fork test submission called the Microsoft repository API.'
-        }
-
         $pullRequest = $global:ForkBranchSubmissionRequests |
-            Where-Object { $_.Path -eq 'repos/test-owner/winget-pkgs/pulls' } |
+            Where-Object { $_.Path -eq 'repos/Utesgui/winget-pkgs/pulls' } |
             Select-Object -Last 1
         if ($pullRequest.Body.base -cne 'master') {
             throw "Fork test submission used an unexpected base branch: $($pullRequest.Body.base)"
         }
-        if ($pullRequest.Body.head -notmatch '^test-owner:winget-autosubmit/') {
+        if ($pullRequest.Body.head -notmatch '^Utesgui:winget-autosubmit/') {
             throw "Fork test submission used an unexpected PR head: $($pullRequest.Body.head)"
         }
     }
@@ -162,7 +148,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
     It 'does not create a fork branch when the matching target PR already exists' {
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs { $true }
-            Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
+            Mock Get-WingetPkgsPrUrl { 'https://github.com/Utesgui/winget-pkgs/pull/54321' }
         }
 
         $result = Submit-WingetPackage `
@@ -172,19 +158,16 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -Token 'test-token' `
             -With ForkBranch
 
-        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/microsoft/winget-pkgs/pull/54321') {
+        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/Utesgui/winget-pkgs/pull/54321') {
             throw "Existing submission PR was not returned: $($result | ConvertTo-Json -Compress)"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
             throw 'Duplicate detection attempted a fork API request.'
         }
-        InModuleScope WingetMaintainerModule {
-            Assert-MockCalled Invoke-WingetPkgsGitHubApi -Times 0 -Exactly -Scope It
-        }
     }
 
-    It 'rejects microsoft/winget-pkgs as the configured fork before writing a branch' {
-        $env:WINGET_PKGS_FORK_REPO = 'microsoft/winget-pkgs'
+    It 'rejects an unapproved fork configuration before querying GitHub' {
+        $env:WINGET_PKGS_FORK_REPO = 'damn-good-b0t/winget-pkgs'
 
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
@@ -194,13 +177,34 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -With ForkBranch
 
         if ($result.Success -ne $false) {
-            throw 'A microsoft/winget-pkgs fork configuration unexpectedly succeeded.'
+            throw 'An unapproved fork configuration unexpectedly succeeded.'
         }
-        if ($result.Error -notmatch 'user-owned fork') {
+        if ($result.Error -notmatch 'must be configured as Utesgui/winget-pkgs') {
             throw "The unsafe fork configuration was not identified clearly: $($result.Error)"
         }
-        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Method -in @('Post', 'Patch', 'Delete') }).Count -ne 0) {
-            throw 'An unsafe fork configuration attempted a GitHub write.'
+        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
+            throw 'An unapproved fork configuration queried or wrote a GitHub repository.'
+        }
+    }
+
+    It 'fails closed when the required safe fork configuration is absent' {
+        $env:WINGET_PKGS_FORK_REPO = ''
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $false) {
+            throw 'A missing fork configuration unexpectedly succeeded.'
+        }
+        if ($result.Error -notmatch 'WINGET_PKGS_FORK_REPO is required') {
+            throw "The missing fork configuration was not identified clearly: $($result.Error)"
+        }
+        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
+            throw 'A missing fork configuration queried or wrote a GitHub repository.'
         }
     }
 }

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
     }
 
-    It 'rejects a fork-only ForkBranch target before querying GitHub' {
+    It 'rejects a pull request target in the source fork before querying GitHub' {
         $result = Submit-WingetPackage `
             -ManifestPath $global:ForkBranchSubmissionManifestPath `
             -PackageId 'Test.Package' `
@@ -95,13 +95,13 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -SubmissionTarget Fork
 
         if ($result.Success -ne $false) {
-            throw "Expected a fork-only ForkBranch submission to fail, got: $($result | ConvertTo-Json -Compress)"
+            throw "Expected a source-fork PR target to fail, got: $($result | ConvertTo-Json -Compress)"
         }
         if ($result.Error -notmatch 'restricted to the Upstream target') {
             throw "The fork-only rejection was not explained clearly: $($result.Error)"
         }
         if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
-            throw 'A fork-only ForkBranch target queried or wrote a GitHub repository.'
+            throw 'A source-fork PR target queried or wrote a GitHub repository.'
         }
     }
 
@@ -114,7 +114,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
             -With ForkBranch
 
         if ($result.Success -ne $true) {
-            throw "Expected a successful fork-only ForkBranch submission, got: $($result.Error)"
+            throw "Expected a successful cross-repository ForkBranch submission, got: $($result.Error)"
         }
         if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'microsoft/winget-pkgs' }).Count -ne 0) {
             throw "Fork submission did not perform duplicate checks against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -58,8 +58,11 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Message "$workflowName does not provide the configured user-owned fork." | Out-Null
     Assert-Match `
         -Actual $submitJob `
-        -Pattern "(?m)^          WINGET_PKGS_SUBMISSION_TARGET: \$\{\{\s*github\.ref == 'refs/heads/main' && 'Upstream' \|\| 'Fork'\s*\}\}\s*$" `
-        -Message "$workflowName does not isolate non-main test submissions to the user-owned fork." | Out-Null
+        -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_TARGET: Fork\s*$' `
+        -Message "$workflowName must use the fork-only submission target for every trigger." | Out-Null
+    if ([regex]::IsMatch($submitJob, '(?i)microsoft/winget-pkgs|SubmissionTarget:\s*Upstream')) {
+        throw "$workflowName submit-pr job may not target microsoft/winget-pkgs."
+    }
 }
 
 Write-Host 'All submission workflow authorization regression tests passed.' -ForegroundColor Green

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -58,10 +58,10 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Message "$workflowName does not provide the configured user-owned fork." | Out-Null
     Assert-Match `
         -Actual $submitJob `
-        -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_TARGET: Fork\s*$' `
-        -Message "$workflowName must use the fork-only submission target for every trigger." | Out-Null
-    if ([regex]::IsMatch($submitJob, '(?i)microsoft/winget-pkgs|SubmissionTarget:\s*Upstream')) {
-        throw "$workflowName submit-pr job may not target microsoft/winget-pkgs."
+        -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_TARGET: Upstream\s*$' `
+        -Message "$workflowName must use the upstream pull request target for every trigger." | Out-Null
+    if ([regex]::IsMatch($submitJob, '(?i)WINGET_PKGS_SUBMISSION_TARGET:\s*Fork')) {
+        throw "$workflowName may not create fork-only pull requests."
     }
 }
 

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -1,0 +1,95 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
+
+Describe 'Test-ExistingPRs' {
+    BeforeEach {
+        $global:ExistingPrSearchRequests = [System.Collections.Generic.List[object]]::new()
+
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                return [pscustomobject]@{
+                    items = @(
+                        [pscustomobject]@{
+                            title    = 'Update version: Test.Package version 1.0.0'
+                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    AfterEach {
+        Remove-Variable -Name ExistingPrSearchRequests -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'searches the public upstream REST API without the fork-scoped token' {
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $true) {
+            throw 'A matching upstream pull request was not found.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "Expected the open PR search to stop after one match, got $($global:ExistingPrSearchRequests.Count) request(s)."
+        }
+
+        $request = $global:ExistingPrSearchRequests[0]
+        if ($request.Method -cne 'Get' -or $request.Uri -notmatch '^https://api\.github\.com/search/issues\?') {
+            throw "Unexpected upstream PR search request: $($request | ConvertTo-Json -Compress)"
+        }
+        if ($request.Headers.ContainsKey('Authorization')) {
+            throw 'The public upstream PR search must not send the fork-scoped token.'
+        }
+
+        $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
+        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch 'is:open' -or $query -notmatch 'Test.Package 1.0.0') {
+            throw "The public upstream PR search used an unexpected query: $query"
+        }
+    }
+
+    It 'searches only open pull requests when requested' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                return [pscustomobject]@{ items = @() }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs' `
+            -OnlyOpen
+
+        if ($result -ne $false) {
+            throw 'An empty upstream PR search unexpectedly found a match.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "OnlyOpen performed $($global:ExistingPrSearchRequests.Count) search requests instead of one."
+        }
+
+        $query = [uri]::UnescapeDataString(([uri] $global:ExistingPrSearchRequests[0].Uri).Query)
+        if ($query -notmatch 'is:open' -or $query -match 'is:merged') {
+            throw "OnlyOpen used an unexpected query: $query"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- restore the intended cross-repository `ForkBranch` topology: disposable manifest tree/commit/branch in `WINGET_PKGS_FORK_REPO`, pull request targeting `microsoft/winget-pkgs`
- replace authenticated `gh pr list` preflight calls with unauthenticated GitHub public REST search, avoiding 404s from a fine-grained token scoped to the source fork
- make read-only upstream repository/base/ref/commit API calls unauthenticated; retain the authenticated upstream PR creation as the only Microsoft write
- keep generated workflows aligned with the template and add routing and anonymous-search regressions

## Required configuration
`WINGET_PKGS_FORK_REPO` must be the runtime user's fork (`damn-good-b0t/winget-pkgs` for this deployment). The flow verifies it is a fork of `microsoft/winget-pkgs` and rejects Microsoft itself as the source repository.

## Tests
- `./tests/SubmissionWorkflowAuthorization.Tests.ps1`
- Pester 5.7.1: `Submit-WingetPackage.Tests.ps1`, `ForkBranchSubmission.Tests.ps1`, `Test-ExistingPRs.Tests.ps1` (12 passed)
- Pester 6: `ForkBranchSubmission.Tests.ps1`, `Test-ExistingPRs.Tests.ps1` (8 passed)
- live unauthenticated public GitHub search for `ChiaNetwork.GUIforChiaBlockchain 2.7.3` succeeded without an Authorization header

No external repositories were mutated.