### PR TITLE
Fix ForkBranch duplicate preflight rate limit

### DIFF
--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -271,28 +271,6 @@ function Submit-WingetPackage {
                 }
 
                 Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
-                $targetRepository = 'microsoft/winget-pkgs'
-
-                if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
-                    $existingPrUrl = Get-WingetPkgsPrUrl `
-                        -PackageId $PackageId `
-                        -Version $Version `
-                        -Repository $targetRepository
-                    $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
-                        $Matches['Number']
-                    }
-                    else {
-                        $null
-                    }
-
-                    Write-Host 'A matching submission PR already exists; skipping submission.' -ForegroundColor Yellow
-                    return @{
-                        Success  = $true
-                        Error    = $null
-                        PrUrl    = $existingPrUrl
-                        PrNumber = $existingPrNumber
-                    }
-                }
 
                 $forkSubmission = Invoke-ForkBranchSubmission `
                     -ManifestPath $fullManifestPath `

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -3,7 +3,7 @@
     Checks for existing pull requests (PRs) for a specified package identifier and version in the 'microsoft/winget-pkgs' repository.
 
 .DESCRIPTION
-    The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version. 
+    The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version.
     It uses GitHub's public REST search endpoint without credentials so a
     fine-grained submission token scoped only to the source fork cannot turn a
     readable upstream lookup into a 404. It returns `true` if matching open or
@@ -44,7 +44,6 @@ function Test-ExistingPRs {
         throw 'PackageIdentifier and Version are required to search for existing pull requests.'
     }
 
-    $states = if ($OnlyOpen) { @('open') } else { @('open', 'merged') }
     $headers = @{
         Accept                 = 'application/vnd.github+json'
         'X-GitHub-Api-Version' = '2022-11-28'
@@ -52,24 +51,22 @@ function Test-ExistingPRs {
     }
     $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
     $escapedVersion = $Version.Replace('"', '\"')
+    $stateQuery = if ($OnlyOpen) { 'is:open' } else { '(is:open OR is:merged)' }
+    $query = "repo:$Repository is:pr $stateQuery in:title `"$escapedPackageIdentifier $escapedVersion`""
+    $encodedQuery = [uri]::EscapeDataString($query)
+    $response = Invoke-RestMethod `
+        -Method Get `
+        -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
+        -Headers $headers `
+        -ErrorAction Stop
+    $existingPrs = @($response.items)
 
-    foreach ($state in $states) {
-        $query = "repo:$Repository is:pr is:$state in:title `"$escapedPackageIdentifier $escapedVersion`""
-        $encodedQuery = [uri]::EscapeDataString($query)
-        $response = Invoke-RestMethod `
-            -Method Get `
-            -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
-            -Headers $headers `
-            -ErrorAction Stop
-        $existingPrs = @($response.items)
-
-        if ($existingPrs.Count -gt 0) {
-            $existingPrs | ForEach-Object {
-                Write-Host "Found existing PR: $($_.title)"
-                Write-Host "-> $($_.html_url)"
-            }
-            return $true
+    if ($existingPrs.Count -gt 0) {
+        $existingPrs | ForEach-Object {
+            Write-Host "Found existing PR: $($_.title)"
+            Write-Host "-> $($_.html_url)"
         }
+        return $true
     }
 
     return $false

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -62,6 +62,11 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     '/git/refs$' {
                         return [pscustomobject]@{ ref = 'refs/heads/winget-autosubmit/test' }
                     }
+                    '/git/refs/heads/winget-autosubmit/' {
+                        if ($Method -eq 'Delete') {
+                            return $null
+                        }
+                    }
                     '/pulls$' {
                         return [pscustomobject]@{
                             html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
@@ -116,8 +121,11 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if ($result.Success -ne $true) {
             throw "Expected a successful cross-repository ForkBranch submission, got: $($result.Error)"
         }
-        if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'microsoft/winget-pkgs' }).Count -ne 0) {
-            throw "Fork submission did not perform duplicate checks against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
+            throw "Fork submission did not perform exactly one duplicate check against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        }
+        InModuleScope WingetMaintainerModule {
+            Assert-MockCalled Test-ExistingPRs -Times 1 -Exactly -Scope It
         }
         $upstreamReads = @(
             $global:ForkBranchSubmissionRequests |
@@ -172,7 +180,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
     }
 
-    It 'does not create a fork branch when the matching target PR already exists' {
+    It 'removes the temporary fork branch when the final duplicate preflight finds a target PR' {
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs {
                 param($PackageIdentifier, $Version, $Repository)
@@ -196,8 +204,18 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
             throw "Duplicate detection did not use the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
         }
-        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
-            throw 'Duplicate detection attempted a fork API request.'
+        $branchDeletes = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object {
+                    $_.Method -eq 'Delete' -and
+                    $_.Path -match '^repos/damn-good-b0t/winget-pkgs/git/refs/heads/winget-autosubmit/'
+                }
+        )
+        if ($branchDeletes.Count -ne 1) {
+            throw "The temporary fork branch was not removed after duplicate detection: $($global:ForkBranchSubmissionRequests | ConvertTo-Json -Compress)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' -and $_.Method -eq 'Post' }).Count -ne 0) {
+            throw 'Duplicate detection created an upstream pull request.'
         }
     }
 

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -55,8 +55,35 @@ Describe 'Test-ExistingPRs' {
         }
 
         $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
-        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch 'is:open' -or $query -notmatch 'Test.Package 1.0.0') {
+        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch '\(is:open OR is:merged\)' -or $query -notmatch 'Test.Package 1.0.0') {
             throw "The public upstream PR search used an unexpected query: $query"
+        }
+    }
+
+    It 'checks open and merged pull requests in one upstream request' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                return [pscustomobject]@{ items = @() }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $false) {
+            throw 'An empty upstream PR search unexpectedly found a match.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "Open and merged duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of one."
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the redundant ForkBranch duplicate preflight while retaining the final race-safe check immediately before PR creation
- consolidate open and merged duplicate matching into one anonymous upstream search request
- cover one-request duplicate detection, route safety, and temporary-branch cleanup

## Validation
- `Invoke-Pester` for `ForkBranchSubmission.Tests.ps1`, `Test-ExistingPRs.Tests.ps1`, and `Submit-WingetPackage.Tests.ps1`