### PR TITLE
Authenticated upstream reads with tiered failover; pre-generation guard regression

### DIFF
--- a/.github/actions/probe-winget-upstream-read/action.yml
+++ b/.github/actions/probe-winget-upstream-read/action.yml
@@ -1,0 +1,45 @@
+name: Probe winget upstream read access
+description: Check whether the current Actions token can read the public winget-pkgs repository.
+
+inputs:
+  github-token:
+    description: Actions token to probe for upstream read access.
+    required: true
+
+outputs:
+  available:
+    description: Whether the Actions token can read microsoft/winget-pkgs.
+    value: ${{ steps.probe.outputs.available }}
+
+runs:
+  using: composite
+  steps:
+    - id: probe
+      shell: pwsh
+      env:
+        WINGET_UPSTREAM_READ_PROBE_TOKEN: ${{ inputs.github-token }}
+      run: |
+        $headers = @{
+          Accept                 = 'application/vnd.github+json'
+          Authorization           = "Bearer $env:WINGET_UPSTREAM_READ_PROBE_TOKEN"
+          'X-GitHub-Api-Version' = '2022-11-28'
+          'User-Agent'           = 'winget-pkgs-updates'
+        }
+
+        try {
+          Invoke-RestMethod `
+            -Method Get `
+            -Uri 'https://api.github.com/repos/microsoft/winget-pkgs' `
+            -Headers $headers `
+            -ErrorAction Stop | Out-Null
+          'available=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host 'The Actions token can read microsoft/winget-pkgs.'
+        } catch {
+          $statusCode = if ($_.Exception.Response) {
+            [int] $_.Exception.Response.StatusCode
+          } else {
+            'unavailable'
+          }
+          'available=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Warning "The Actions token cannot read microsoft/winget-pkgs (HTTP $statusCode); using the configured fallback."
+        }

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -722,7 +722,7 @@ jobs:
 
       - name: Probe upstream read access
         if: steps.check-submit.outputs.skip != 'true'
-        id: upstream-read-probe
+        id: upstream-read-probe-submit
         uses: ./.github/actions/probe-winget-upstream-read
         with:
           github-token: ${{ github.token }}
@@ -732,7 +732,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -32,10 +32,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Probe upstream read access
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Generate manifest
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -713,11 +720,19 @@ jobs:
           Write-Host "Manifest path: $manifestPath"
           "path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Probe upstream read access
+        if: steps.check-submit.outputs.skip != 'true'
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Submit PR
         if: steps.check-submit.outputs.skip != 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -42,7 +42,8 @@ jobs:
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -732,7 +733,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -18,6 +18,60 @@ permissions:
   contents: read
 
 jobs:
+  upstream-read-capability:
+    name: Upstream read capability (diagnostic)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe upstream read endpoints
+        shell: pwsh
+        env:
+          ACTIONS_TOKEN_PROBE: ${{ github.token }}
+          WINGET_PAT_PROBE: ${{ secrets.WINGET_PAT }}
+        run: |
+          # Read-only diagnostic: reports HTTP status codes per credential for the
+          # exact upstream endpoints the submission flow reads. Never fails the
+          # workflow, performs no writes, and never prints token values.
+          $endpoints = @(
+            'https://api.github.com/repos/microsoft/winget-pkgs'
+            'https://api.github.com/repos/microsoft/winget-pkgs/git/ref/heads/master'
+            'https://api.github.com/search/issues?q=repo%3Amicrosoft%2Fwinget-pkgs+is%3Apr+capability+probe&per_page=1'
+          )
+          $credentials = [ordered]@{
+            'anonymous'    = $null
+            'github.token' = $env:ACTIONS_TOKEN_PROBE
+            'WINGET_PAT'   = $env:WINGET_PAT_PROBE
+          }
+          $lines = @('| Credential | Endpoint | Status |', '| --- | --- | --- |')
+          foreach ($credential in $credentials.GetEnumerator()) {
+            foreach ($endpoint in $endpoints) {
+              $shortEndpoint = $endpoint -replace '^https://api\.github\.com/', '' -replace '\?.*$', ''
+              if ($credential.Key -ne 'anonymous' -and [string]::IsNullOrWhiteSpace($credential.Value)) {
+                $lines += "| $($credential.Key) | $shortEndpoint | not configured |"
+                continue
+              }
+              $headers = @{
+                Accept                 = 'application/vnd.github+json'
+                'X-GitHub-Api-Version' = '2022-11-28'
+                'User-Agent'           = 'winget-pkgs-updates-capability-probe'
+              }
+              if ($credential.Key -ne 'anonymous') {
+                $headers.Authorization = "Bearer $($credential.Value)"
+              }
+              try {
+                $response = Invoke-WebRequest -Uri $endpoint -Headers $headers -SkipHttpErrorCheck -ErrorAction Stop
+                $status = [int]$response.StatusCode
+              }
+              catch {
+                $status = 'request error'
+              }
+              $lines += "| $($credential.Key) | $shortEndpoint | $status |"
+            }
+          }
+          $report = $lines -join "`n"
+          Write-Host $report
+          $report | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          exit 0
+
   package-state:
     name: Package state (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -768,7 +768,8 @@ jobs:
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -1458,7 +1459,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1448,7 +1448,7 @@ jobs:
 
       - name: Probe upstream read access
         if: steps.check-submit.outputs.skip != 'true'
-        id: upstream-read-probe
+        id: upstream-read-probe-submit
         uses: ./.github/actions/probe-winget-upstream-read
         with:
           github-token: ${{ github.token }}
@@ -1458,7 +1458,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -758,10 +758,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Probe upstream read access
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Generate manifest
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -1439,11 +1446,19 @@ jobs:
           Write-Host "Manifest path: $manifestPath"
           "path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Probe upstream read access
+        if: steps.check-submit.outputs.skip != 'true'
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Submit PR
         if: steps.check-submit.outputs.skip != 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -1049,7 +1049,7 @@ jobs:
 
       - name: Probe upstream read access
         if: steps.check-submit.outputs.skip != 'true'
-        id: upstream-read-probe
+        id: upstream-read-probe-submit
         uses: ./.github/actions/probe-winget-upstream-read
         with:
           github-token: ${{ github.token }}
@@ -1059,7 +1059,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -359,10 +359,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Probe upstream read access
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Generate manifest
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -1040,11 +1047,19 @@ jobs:
           Write-Host "Manifest path: $manifestPath"
           "path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+      - name: Probe upstream read access
+        if: steps.check-submit.outputs.skip != 'true'
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Submit PR
         if: steps.check-submit.outputs.skip != 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -369,7 +369,8 @@ jobs:
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
@@ -1059,7 +1060,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -75,11 +75,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      
+
+      - name: Probe upstream read access
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Generate manifest
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WebsiteURL: ${{ matrix.WebsiteURL }}
           PackageName: ${{ matrix.PackageName }}
@@ -718,12 +725,20 @@ jobs:
           $manifestPath = ($yamlFiles | Select-Object -First 1).DirectoryName
           Write-Host "Manifest path: $manifestPath"
           "path=$manifestPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-      
+
+      - name: Probe upstream read access
+        if: steps.check-submit.outputs.skip != 'true'
+        id: upstream-read-probe
+        uses: ./.github/actions/probe-winget-upstream-read
+        with:
+          github-token: ${{ github.token }}
+
       - name: Submit PR
         if: steps.check-submit.outputs.skip != 'true'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -86,7 +86,8 @@ jobs:
         id: generate
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WebsiteURL: ${{ matrix.WebsiteURL }}
           PackageName: ${{ matrix.PackageName }}
@@ -738,7 +739,8 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -728,7 +728,7 @@ jobs:
 
       - name: Probe upstream read access
         if: steps.check-submit.outputs.skip != 'true'
-        id: upstream-read-probe
+        id: upstream-read-probe-submit
         uses: ./.github/actions/probe-winget-upstream-read
         with:
           github-token: ${{ github.token }}
@@ -738,7 +738,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
-          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}

--- a/README.md
+++ b/README.md
@@ -28,19 +28,20 @@ Every trigger, including scheduled main-branch runs, opens the pull request
 from the configured fork branch to `microsoft/winget-pkgs`. The submission
 flow never directly pushes or commits content to `microsoft/winget-pkgs`.
 
-Each generation and submission job probes `${{ github.token }}` with one
-read-only `GET /repos/microsoft/winget-pkgs` request. When the probe succeeds,
-the token is passed only as `WINGET_UPSTREAM_READ_TOKEN` for upstream
-duplicate and base-ref reads; fork writes and the cross-repository PR POST
-continue to use `WINGET_PAT`. A failed probe leaves those reads anonymous.
-Optionally, administrators may configure `WINGET_PUBLIC_READ_TOKEN` as a
-separate public-read credential for that fallback. The repository does not
-create or require that secret, and it is never used for fork writes or PR
-creation.
-Public upstream duplicate and base reads are unauthenticated so a
-fork-scoped fine-grained token cannot block them. A fine-grained PAT needs
-Contents write on the configured fork and Pull requests write on the upstream
-target; it does not need GitHub Actions workflow scope.
+Upstream duplicate and base-ref reads use a tiered credential chain. The
+classic `WINGET_PAT` (`public_repo` scope, 5,000 requests/hour) is passed as
+`WINGET_UPSTREAM_READ_TOKEN` and used first. Each generation and submission
+job also probes `${{ github.token }}` with one read-only
+`GET /repos/microsoft/winget-pkgs` request; when the probe succeeds, that
+Actions token is passed as `WINGET_UPSTREAM_READ_FALLBACK_TOKEN` (1,000
+requests/hour). Administrators may optionally configure
+`WINGET_PUBLIC_READ_TOKEN` as a separate public-read credential for the
+fallback slot when the probe fails; the repository does not create or require
+that secret. If an upstream read fails with HTTP 401, 403, 404, or 429, the
+module retries the same request with the next tier, ending with anonymous
+public access, so a rate-limited or misbehaving credential can never block a
+submission. Read tokens are never used for fork writes or PR creation; fork
+writes and the cross-repository PR POST always use `WINGET_PAT`.
 
 ## Package-specific WinMatsch overrides
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ branch.
 Every trigger, including scheduled main-branch runs, opens the pull request
 from the configured fork branch to `microsoft/winget-pkgs`. The submission
 flow never directly pushes or commits content to `microsoft/winget-pkgs`.
+
+Each generation and submission job probes `${{ github.token }}` with one
+read-only `GET /repos/microsoft/winget-pkgs` request. When the probe succeeds,
+the token is passed only as `WINGET_UPSTREAM_READ_TOKEN` for upstream
+duplicate and base-ref reads; fork writes and the cross-repository PR POST
+continue to use `WINGET_PAT`. A failed probe leaves those reads anonymous.
+Optionally, administrators may configure `WINGET_PUBLIC_READ_TOKEN` as a
+separate public-read credential for that fallback. The repository does not
+create or require that secret, and it is never used for fork writes or PR
+creation.
 Public upstream duplicate and base reads are unauthenticated so a
 fork-scoped fine-grained token cannot block them. A fine-grained PAT needs
 Contents write on the configured fork and Pull requests write on the upstream

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -142,21 +142,25 @@ function Invoke-ForkBranchSubmission {
     }
 
     # The fine-grained fork token cannot necessarily read the public upstream.
-    # Keep its use to fork writes and the final cross-repository PR creation.
+    # A separately probed read token is restricted to the upstream GETs below;
+    # fork writes and the final cross-repository PR creation keep using $Token.
     $targetRepository = $upstreamRepository
+    $upstreamReadToken = "$env:WINGET_UPSTREAM_READ_TOKEN".Trim()
+    $useUnauthenticatedUpstreamReads = [string]::IsNullOrWhiteSpace($upstreamReadToken)
+    $upstreamRequestToken = if ($useUnauthenticatedUpstreamReads) { $Token } else { $upstreamReadToken }
     $upstream = Invoke-WingetPkgsGitHubApi `
         -Method Get `
         -Path "repos/$upstreamRepository" `
-        -Token $Token `
-        -Unauthenticated
+        -Token $upstreamRequestToken `
+        -Unauthenticated:$useUnauthenticatedUpstreamReads
     $targetDefaultBranch = "$($upstream.default_branch)"
     $baseRepository = $targetRepository
 
     $baseReference = Invoke-WingetPkgsGitHubApi `
         -Method Get `
         -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch" `
-        -Token $Token `
-        -Unauthenticated
+        -Token $upstreamRequestToken `
+        -Unauthenticated:$useUnauthenticatedUpstreamReads
     $baseSha = "$($baseReference.object.sha)"
     if ([string]::IsNullOrWhiteSpace($baseSha)) {
         throw "Could not resolve the $baseRepository/$targetDefaultBranch commit SHA."
@@ -164,8 +168,8 @@ function Invoke-ForkBranchSubmission {
     $baseCommit = Invoke-WingetPkgsGitHubApi `
         -Method Get `
         -Path "repos/$baseRepository/git/commits/$baseSha" `
-        -Token $Token `
-        -Unauthenticated
+        -Token $upstreamRequestToken `
+        -Unauthenticated:$useUnauthenticatedUpstreamReads
     $baseTreeSha = "$($baseCommit.tree.sha)"
     if ([string]::IsNullOrWhiteSpace($baseTreeSha)) {
         throw "Could not resolve the base tree for $baseRepository/$targetDefaultBranch."

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -46,6 +46,49 @@ function Invoke-WingetPkgsGitHubApi {
     return Invoke-RestMethod @request
 }
 
+function Invoke-WingetPkgsUpstreamReadApi {
+    <#
+    .SYNOPSIS
+        Performs a public upstream GET with tiered read credentials.
+    .DESCRIPTION
+        Attempts WINGET_UPSTREAM_READ_TOKEN first, then
+        WINGET_UPSTREAM_READ_FALLBACK_TOKEN, then anonymous access, failing
+        over only on authorization or rate-limit statuses (401/403/404/429).
+        The fork-scoped submission token is never used here.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Path
+    )
+
+    $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
+    for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
+        $tier = $credentialTiers[$tierIndex]
+        $isAnonymous = [string]::IsNullOrWhiteSpace($tier.Token)
+        # -Token is mandatory; the placeholder is never sent because
+        # -Unauthenticated omits the Authorization header entirely.
+        $requestToken = if ($isAnonymous) { 'unused-anonymous-read' } else { $tier.Token }
+        try {
+            return Invoke-WingetPkgsGitHubApi `
+                -Method Get `
+                -Path $Path `
+                -Token $requestToken `
+                -Unauthenticated:$isAnonymous
+        }
+        catch {
+            $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
+            $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
+            if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
+                throw
+            }
+            $nextTier = $credentialTiers[$tierIndex + 1]
+            Write-Warning "Upstream read '$Path' with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label)."
+        }
+    }
+}
+
 function Get-ForkBranchSubmissionFiles {
     [CmdletBinding()]
     param(
@@ -141,35 +184,20 @@ function Invoke-ForkBranchSubmission {
         throw "Configured repository '$ForkRepository' is not a fork of $upstreamRepository."
     }
 
-    # The fine-grained fork token cannot necessarily read the public upstream.
-    # A separately probed read token is restricted to the upstream GETs below;
-    # fork writes and the final cross-repository PR creation keep using $Token.
+    # Upstream reads use the tiered read credentials (WINGET_UPSTREAM_READ_TOKEN,
+    # then WINGET_UPSTREAM_READ_FALLBACK_TOKEN, then anonymous); fork writes and
+    # the final cross-repository PR creation keep using $Token.
     $targetRepository = $upstreamRepository
-    $upstreamReadToken = "$env:WINGET_UPSTREAM_READ_TOKEN".Trim()
-    $useUnauthenticatedUpstreamReads = [string]::IsNullOrWhiteSpace($upstreamReadToken)
-    $upstreamRequestToken = if ($useUnauthenticatedUpstreamReads) { $Token } else { $upstreamReadToken }
-    $upstream = Invoke-WingetPkgsGitHubApi `
-        -Method Get `
-        -Path "repos/$upstreamRepository" `
-        -Token $upstreamRequestToken `
-        -Unauthenticated:$useUnauthenticatedUpstreamReads
+    $upstream = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$upstreamRepository"
     $targetDefaultBranch = "$($upstream.default_branch)"
     $baseRepository = $targetRepository
 
-    $baseReference = Invoke-WingetPkgsGitHubApi `
-        -Method Get `
-        -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch" `
-        -Token $upstreamRequestToken `
-        -Unauthenticated:$useUnauthenticatedUpstreamReads
+    $baseReference = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch"
     $baseSha = "$($baseReference.object.sha)"
     if ([string]::IsNullOrWhiteSpace($baseSha)) {
         throw "Could not resolve the $baseRepository/$targetDefaultBranch commit SHA."
     }
-    $baseCommit = Invoke-WingetPkgsGitHubApi `
-        -Method Get `
-        -Path "repos/$baseRepository/git/commits/$baseSha" `
-        -Token $upstreamRequestToken `
-        -Unauthenticated:$useUnauthenticatedUpstreamReads
+    $baseCommit = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$baseRepository/git/commits/$baseSha"
     $baseTreeSha = "$($baseCommit.tree.sha)"
     if ([string]::IsNullOrWhiteSpace($baseTreeSha)) {
         throw "Could not resolve the base tree for $baseRepository/$targetDefaultBranch."

--- a/modules/WingetMaintainerModule/Private/UpstreamReadFailover.ps1
+++ b/modules/WingetMaintainerModule/Private/UpstreamReadFailover.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Shared credential-tier helpers for public upstream winget-pkgs reads.
+
+.DESCRIPTION
+    Upstream duplicate and base-ref reads authenticate with the credential in
+    WINGET_UPSTREAM_READ_TOKEN first (workflows pass the classic public-read
+    WINGET_PAT there, 5,000 core requests/hour). When GitHub rejects that
+    credential with an authorization or rate-limit status, the read retries
+    once with WINGET_UPSTREAM_READ_FALLBACK_TOKEN (the probed Actions token or
+    an optional WINGET_PUBLIC_READ_TOKEN) and finally falls back to anonymous
+    public access. These helpers only shape upstream read requests; fork
+    writes and the cross-repository PR creation never use them.
+#>
+
+function Get-WingetPkgsUpstreamReadCredentialTiers {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param()
+
+    $tiers = [System.Collections.Generic.List[object]]::new()
+
+    $primaryToken = "$env:WINGET_UPSTREAM_READ_TOKEN".Trim()
+    if (-not [string]::IsNullOrWhiteSpace($primaryToken)) {
+        $tiers.Add([pscustomobject]@{
+            Token = $primaryToken
+            Label = 'the primary upstream read token'
+        })
+    }
+
+    $fallbackToken = "$env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN".Trim()
+    if (-not [string]::IsNullOrWhiteSpace($fallbackToken) -and $fallbackToken -cne $primaryToken) {
+        $tiers.Add([pscustomobject]@{
+            Token = $fallbackToken
+            Label = 'the fallback upstream read token'
+        })
+    }
+
+    $tiers.Add([pscustomobject]@{
+        Token = $null
+        Label = 'anonymous public access'
+    })
+
+    return $tiers
+}
+
+function Get-WingetPkgsUpstreamReadFailureStatusCode {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    $exception = $ErrorRecord.Exception
+    if ($null -ne $exception -and
+        $null -ne $exception.PSObject.Properties['Response'] -and
+        $null -ne $exception.Response) {
+        return [int] $exception.Response.StatusCode
+    }
+
+    return 0
+}
+
+function Test-WingetPkgsUpstreamReadFailoverStatus {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int] $StatusCode
+    )
+
+    # 403/429 signal rate limiting; 401/404 defensively cover credential
+    # anomalies such as the transient upstream 404s previously observed for
+    # scoped tokens. Anything else is a real error and must surface.
+    return $StatusCode -in 401, 403, 404, 429
+}

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -4,10 +4,12 @@
 
 .DESCRIPTION
     The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version.
-    It uses GitHub's public REST search endpoint without credentials so a
-    fine-grained submission token scoped only to the source fork cannot turn a
-    readable upstream lookup into a 404. It returns `true` if matching open or
-    merged PRs are found, otherwise returns `false`.
+    It uses the dedicated `WINGET_UPSTREAM_READ_TOKEN` only when a workflow
+    capability probe has confirmed it can read the public upstream repository.
+    Without that token, it uses GitHub's public REST search endpoint without
+    credentials so a fine-grained submission token scoped only to the source
+    fork cannot turn a readable upstream lookup into a 404. It returns `true`
+    if matching open or merged PRs are found, otherwise returns `false`.
 
 .PARAMETER Version
     The version of the package to check for existing PRs. This parameter is mandatory.
@@ -48,6 +50,10 @@ function Test-ExistingPRs {
         Accept                 = 'application/vnd.github+json'
         'X-GitHub-Api-Version' = '2022-11-28'
         'User-Agent'           = 'winget-pkgs-updates'
+    }
+    $upstreamReadToken = "$env:WINGET_UPSTREAM_READ_TOKEN".Trim()
+    if (-not [string]::IsNullOrWhiteSpace($upstreamReadToken)) {
+        $headers.Authorization = "Bearer $upstreamReadToken"
     }
     $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
     $escapedVersion = $Version.Replace('"', '\"')

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -4,12 +4,15 @@
 
 .DESCRIPTION
     The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version.
-    It uses the dedicated `WINGET_UPSTREAM_READ_TOKEN` only when a workflow
-    capability probe has confirmed it can read the public upstream repository.
-    Without that token, it uses GitHub's public REST search endpoint without
-    credentials so a fine-grained submission token scoped only to the source
-    fork cannot turn a readable upstream lookup into a 404. It returns `true`
-    if matching open or merged PRs are found, otherwise returns `false`.
+    The search authenticates with the dedicated `WINGET_UPSTREAM_READ_TOKEN`
+    first (workflows pass the classic public-read WINGET_PAT there). When
+    GitHub rejects that credential with an authorization or rate-limit status
+    (401/403/404/429), the search retries once with
+    `WINGET_UPSTREAM_READ_FALLBACK_TOKEN` and finally falls back to the
+    anonymous public REST search endpoint, so a degraded credential can never
+    block duplicate detection. The fork-scoped submission token is never used
+    for this search. It returns `true` if matching open or merged PRs are
+    found, otherwise returns `false`.
 
 .PARAMETER Version
     The version of the package to check for existing PRs. This parameter is mandatory.
@@ -46,25 +49,42 @@ function Test-ExistingPRs {
         throw 'PackageIdentifier and Version are required to search for existing pull requests.'
     }
 
-    $headers = @{
-        Accept                 = 'application/vnd.github+json'
-        'X-GitHub-Api-Version' = '2022-11-28'
-        'User-Agent'           = 'winget-pkgs-updates'
-    }
-    $upstreamReadToken = "$env:WINGET_UPSTREAM_READ_TOKEN".Trim()
-    if (-not [string]::IsNullOrWhiteSpace($upstreamReadToken)) {
-        $headers.Authorization = "Bearer $upstreamReadToken"
-    }
     $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
     $escapedVersion = $Version.Replace('"', '\"')
     $stateQuery = if ($OnlyOpen) { 'is:open' } else { '(is:open OR is:merged)' }
     $query = "repo:$Repository is:pr $stateQuery in:title `"$escapedPackageIdentifier $escapedVersion`""
     $encodedQuery = [uri]::EscapeDataString($query)
-    $response = Invoke-RestMethod `
-        -Method Get `
-        -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
-        -Headers $headers `
-        -ErrorAction Stop
+
+    $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
+    $response = $null
+    for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
+        $tier = $credentialTiers[$tierIndex]
+        $headers = @{
+            Accept                 = 'application/vnd.github+json'
+            'X-GitHub-Api-Version' = '2022-11-28'
+            'User-Agent'           = 'winget-pkgs-updates'
+        }
+        if (-not [string]::IsNullOrWhiteSpace($tier.Token)) {
+            $headers.Authorization = "Bearer $($tier.Token)"
+        }
+        try {
+            $response = Invoke-RestMethod `
+                -Method Get `
+                -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
+                -Headers $headers `
+                -ErrorAction Stop
+            break
+        }
+        catch {
+            $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
+            $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
+            if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
+                throw
+            }
+            $nextTier = $credentialTiers[$tierIndex + 1]
+            Write-Warning "Existing-PR search with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label)."
+        }
+    }
     $existingPrs = @($response.items)
 
     if ($existingPrs.Count -gt 0) {

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -15,10 +15,13 @@ Describe 'Submit-WingetPackage ForkBranch' {
 
         $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
         $global:ForkBranchDuplicateRepositories = [System.Collections.Generic.List[string]]::new()
+        $global:ForkBranchUpstreamReadFailTokens = @()
         $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
         $global:OriginalUpstreamReadToken = $env:WINGET_UPSTREAM_READ_TOKEN
+        $global:OriginalUpstreamReadFallbackToken = $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN
         $env:WINGET_PKGS_FORK_REPO = 'damn-good-b0t/winget-pkgs'
         $env:WINGET_UPSTREAM_READ_TOKEN = ''
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = ''
 
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs {
@@ -38,6 +41,13 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     Unauthenticated = [bool] $Unauthenticated
                     Body            = $Body
                 })
+
+                if ($Method -eq 'Get' -and
+                    $Path -match '^repos/microsoft/winget-pkgs($|/)' -and
+                    $global:ForkBranchUpstreamReadFailTokens -ccontains $Token) {
+                    $rateLimitedResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Forbidden)
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('API rate limit exceeded', $rateLimitedResponse)
+                }
 
                 switch -Regex ($Path) {
                     '^repos/damn-good-b0t/winget-pkgs$' {
@@ -88,11 +98,14 @@ Describe 'Submit-WingetPackage ForkBranch' {
         Remove-Item -LiteralPath $global:ForkBranchSubmissionManifestPath -Recurse -Force -ErrorAction SilentlyContinue
         $env:WINGET_PKGS_FORK_REPO = $global:OriginalForkRepository
         $env:WINGET_UPSTREAM_READ_TOKEN = $global:OriginalUpstreamReadToken
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = $global:OriginalUpstreamReadFallbackToken
         Remove-Variable -Name ForkBranchSubmissionManifestPath -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchSubmissionRequests -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchDuplicateRepositories -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ForkBranchUpstreamReadFailTokens -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalUpstreamReadToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalUpstreamReadFallbackToken -Scope Global -ErrorAction SilentlyContinue
     }
 
     It 'rejects a pull request target in the source fork before querying GitHub' {
@@ -215,6 +228,55 @@ Describe 'Submit-WingetPackage ForkBranch' {
             Select-Object -Last 1
         if ($null -eq $pullRequest -or $pullRequest.Token -cne 'fork-write-token') {
             throw 'The upstream PR creation did not retain the fork submission token.'
+        }
+    }
+
+    It 'fails over to the fallback read token when the primary upstream read token is rate limited' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'primary-read-token'
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = 'fallback-read-token'
+        $global:ForkBranchUpstreamReadFailTokens = @('primary-read-token')
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'fork-write-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $true) {
+            throw "Expected the submission to succeed via the fallback read token, got: $($result.Error)"
+        }
+        $upstreamReads = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/microsoft/winget-pkgs($|/)' -and $_.Method -eq 'Get' }
+        )
+        if ($upstreamReads.Count -ne 6) {
+            throw "Expected each of the three upstream reads to retry exactly once with the fallback token: $($upstreamReads | ConvertTo-Json -Compress)"
+        }
+        foreach ($group in ($upstreamReads | Group-Object Path)) {
+            $attempts = @($group.Group)
+            if ($attempts.Count -ne 2 -or
+                $attempts[0].Token -cne 'primary-read-token' -or
+                $attempts[1].Token -cne 'fallback-read-token') {
+                throw "Upstream read for $($group.Name) did not fail over from the primary to the fallback token: $($attempts | ConvertTo-Json -Compress)"
+            }
+        }
+        if (@($upstreamReads | Where-Object { $_.Unauthenticated }).Count -ne 0) {
+            throw 'A tokened upstream read attempt was marked unauthenticated.'
+        }
+
+        $forkRequests = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/damn-good-b0t/winget-pkgs($|/)' }
+        )
+        if (@($forkRequests | Where-Object { $_.Token -cne 'fork-write-token' }).Count -ne 0) {
+            throw "A fork operation used a read token during failover: $($forkRequests | ConvertTo-Json -Compress)"
+        }
+        $pullRequest = $global:ForkBranchSubmissionRequests |
+            Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' } |
+            Select-Object -Last 1
+        if ($null -eq $pullRequest -or $pullRequest.Token -cne 'fork-write-token') {
+            throw 'The upstream PR creation did not retain the fork submission token during failover.'
         }
     }
 

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -16,7 +16,9 @@ Describe 'Submit-WingetPackage ForkBranch' {
         $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
         $global:ForkBranchDuplicateRepositories = [System.Collections.Generic.List[string]]::new()
         $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
+        $global:OriginalUpstreamReadToken = $env:WINGET_UPSTREAM_READ_TOKEN
         $env:WINGET_PKGS_FORK_REPO = 'damn-good-b0t/winget-pkgs'
+        $env:WINGET_UPSTREAM_READ_TOKEN = ''
 
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs {
@@ -32,6 +34,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                 $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
                     Method          = $Method
                     Path            = $Path
+                    Token           = $Token
                     Unauthenticated = [bool] $Unauthenticated
                     Body            = $Body
                 })
@@ -84,10 +87,12 @@ Describe 'Submit-WingetPackage ForkBranch' {
     AfterEach {
         Remove-Item -LiteralPath $global:ForkBranchSubmissionManifestPath -Recurse -Force -ErrorAction SilentlyContinue
         $env:WINGET_PKGS_FORK_REPO = $global:OriginalForkRepository
+        $env:WINGET_UPSTREAM_READ_TOKEN = $global:OriginalUpstreamReadToken
         Remove-Variable -Name ForkBranchSubmissionManifestPath -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchSubmissionRequests -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchDuplicateRepositories -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalUpstreamReadToken -Scope Global -ErrorAction SilentlyContinue
     }
 
     It 'rejects a pull request target in the source fork before querying GitHub' {
@@ -123,9 +128,6 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
         if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
             throw "Fork submission did not perform exactly one duplicate check against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
-        }
-        InModuleScope WingetMaintainerModule {
-            Assert-MockCalled Test-ExistingPRs -Times 1 -Exactly -Scope It
         }
         $upstreamReads = @(
             $global:ForkBranchSubmissionRequests |
@@ -177,6 +179,42 @@ Describe 'Submit-WingetPackage ForkBranch' {
         )
         if ($upstreamWrites.Count -ne 1 -or $upstreamWrites[0].Path -cne 'repos/microsoft/winget-pkgs/pulls') {
             throw "Upstream write surface is not limited to creating the intended pull request: $($upstreamWrites.Path -join ', ')"
+        }
+    }
+
+    It 'uses a dedicated token only for upstream base reads' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'upstream-read-token'
+
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'fork-write-token' `
+            -With ForkBranch
+
+        if ($result.Success -ne $true) {
+            throw "Expected a successful ForkBranch submission, got: $($result.Error)"
+        }
+        $upstreamReads = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/microsoft/winget-pkgs($|/)' -and $_.Method -eq 'Get' }
+        )
+        if ($upstreamReads.Count -ne 3 -or @($upstreamReads | Where-Object { $_.Unauthenticated -or $_.Token -cne 'upstream-read-token' }).Count -ne 0) {
+            throw "Upstream base reads did not exclusively use the dedicated token: $($upstreamReads | ConvertTo-Json -Compress)"
+        }
+
+        $forkRequests = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object { $_.Path -match '^repos/damn-good-b0t/winget-pkgs($|/)' }
+        )
+        if (@($forkRequests | Where-Object { $_.Token -cne 'fork-write-token' }).Count -ne 0) {
+            throw "A fork operation used the upstream read token: $($forkRequests | ConvertTo-Json -Compress)"
+        }
+        $pullRequest = $global:ForkBranchSubmissionRequests |
+            Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' } |
+            Select-Object -Last 1
+        if ($null -eq $pullRequest -or $pullRequest.Token -cne 'fork-write-token') {
+            throw 'The upstream PR creation did not retain the fork submission token.'
         }
     }
 

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -29,6 +29,20 @@ $workflowPaths = @(
     '.github/workflows-templates/github-releases.yml'
 )
 
+$probeActionPath = Join-Path $repositoryRoot '.github/actions/probe-winget-upstream-read/action.yml'
+$probeAction = Get-Content -LiteralPath $probeActionPath -Raw
+Assert-Match `
+    -Actual $probeAction `
+    -Pattern '(?m)^        WINGET_UPSTREAM_READ_PROBE_TOKEN: \$\{\{\s*inputs\.github-token\s*\}\}\s*$' `
+    -Message 'The upstream read probe must receive its token under a distinct environment name.' | Out-Null
+Assert-Match `
+    -Actual $probeAction `
+    -Pattern "(?s)-Method Get .*?-Uri 'https://api\.github\.com/repos/microsoft/winget-pkgs'" `
+    -Message 'The upstream read probe must perform the isolated public repository GET.' | Out-Null
+if ($probeAction -match '(?im)-Method\s+(Post|Put|Patch|Delete)\b') {
+    throw 'The upstream read probe must not perform writes.'
+}
+
 foreach ($workflowRelativePath in $workflowPaths) {
     $workflowPath = Join-Path $repositoryRoot $workflowRelativePath
     $workflowName = Split-Path -Leaf $workflowPath
@@ -62,6 +76,36 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Message "$workflowName must use the upstream pull request target for every trigger." | Out-Null
     if ([regex]::IsMatch($submitJob, '(?i)WINGET_PKGS_SUBMISSION_TARGET:\s*Fork')) {
         throw "$workflowName may not create fork-only pull requests."
+    }
+
+    $probeSteps = [regex]::Matches(
+        $workflow,
+        '(?ms)^      - name: Probe upstream read access\r?\n.*?^        uses: \./\.github/actions/probe-winget-upstream-read\r?\n.*?^        with:\r?\n.*?^          github-token: \$\{\{\s*github\.token\s*\}\}\s*$'
+    )
+    if ($probeSteps.Count -ne 2) {
+        throw "$workflowName must probe the Actions token separately before generation and submission."
+    }
+
+    $readTokenAssignments = [regex]::Matches(
+        $workflow,
+        '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*steps\.upstream-read-probe\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
+    )
+    if ($readTokenAssignments.Count -ne 2) {
+        throw "$workflowName must use the probed Actions token only as the dedicated upstream read token, with the documented optional fallback."
+    }
+
+    foreach ($stepName in @('Generate manifest', 'Submit PR')) {
+        $stepMatch = Assert-Match `
+            -Actual $workflow `
+            -Pattern "(?ms)^      - name: $stepName\r?\n(?<step>.*?)(?=^      - |\z)" `
+            -Message "$workflowName does not contain the $stepName step."
+        $step = $stepMatch.Groups['step'].Value
+        if ($step -notmatch '(?m)^          GITHUB_TOKEN: \$\{\{\s*secrets\.WINGET_PAT\s*\}\}\s*$') {
+            throw "$workflowName must retain WINGET_PAT for $stepName."
+        }
+        if ($step -match '(?m)^          GITHUB_TOKEN: \$\{\{\s*github\.token\s*\}\}\s*$') {
+            throw "$workflowName must not replace the fork submission token with the Actions token in $stepName."
+        }
     }
 }
 

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -86,20 +86,28 @@ foreach ($workflowRelativePath in $workflowPaths) {
         throw "$workflowName must probe the Actions token separately before generation and submission."
     }
 
+    $primaryReadTokenAssignments = [regex]::Matches(
+        $workflow,
+        '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*secrets\.WINGET_PAT\s*\}\}\s*$'
+    )
+    if ($primaryReadTokenAssignments.Count -ne 2) {
+        throw "$workflowName must pass the classic WINGET_PAT as the primary upstream read token in both the generation and submission steps."
+    }
+
     $generateReadTokenAssignments = [regex]::Matches(
         $workflow,
-        '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*steps\.upstream-read-probe\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
+        '(?m)^          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: \$\{\{\s*steps\.upstream-read-probe\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
     )
     if ($generateReadTokenAssignments.Count -ne 1) {
-        throw "$workflowName must use the generation probe result only as the dedicated upstream read token, with the documented optional fallback."
+        throw "$workflowName must use the generation probe result only as the upstream read fallback token, with the documented optional fallback."
     }
 
     $submitReadTokenAssignments = [regex]::Matches(
         $workflow,
-        '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*steps\.upstream-read-probe-submit\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
+        '(?m)^          WINGET_UPSTREAM_READ_FALLBACK_TOKEN: \$\{\{\s*steps\.upstream-read-probe-submit\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
     )
     if ($submitReadTokenAssignments.Count -ne 1) {
-        throw "$workflowName must use the submission probe result only as the dedicated upstream read token, with the documented optional fallback."
+        throw "$workflowName must use the submission probe result only as the upstream read fallback token, with the documented optional fallback."
     }
 
     foreach ($stepName in @('Generate manifest', 'Submit PR')) {

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -86,12 +86,20 @@ foreach ($workflowRelativePath in $workflowPaths) {
         throw "$workflowName must probe the Actions token separately before generation and submission."
     }
 
-    $readTokenAssignments = [regex]::Matches(
+    $generateReadTokenAssignments = [regex]::Matches(
         $workflow,
         '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*steps\.upstream-read-probe\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
     )
-    if ($readTokenAssignments.Count -ne 2) {
-        throw "$workflowName must use the probed Actions token only as the dedicated upstream read token, with the documented optional fallback."
+    if ($generateReadTokenAssignments.Count -ne 1) {
+        throw "$workflowName must use the generation probe result only as the dedicated upstream read token, with the documented optional fallback."
+    }
+
+    $submitReadTokenAssignments = [regex]::Matches(
+        $workflow,
+        '(?m)^          WINGET_UPSTREAM_READ_TOKEN: \$\{\{\s*steps\.upstream-read-probe-submit\.outputs\.available == ''true'' && github\.token \|\| secrets\.WINGET_PUBLIC_READ_TOKEN\s*\}\}\s*$'
+    )
+    if ($submitReadTokenAssignments.Count -ne 1) {
+        throw "$workflowName must use the submission probe result only as the dedicated upstream read token, with the documented optional fallback."
     }
 
     foreach ($stepName in @('Generate manifest', 'Submit PR')) {

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -7,6 +7,12 @@ Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetM
 Describe 'Test-ExistingPRs' {
     BeforeEach {
         $global:ExistingPrSearchRequests = [System.Collections.Generic.List[object]]::new()
+        $global:OriginalUpstreamReadToken = $env:WINGET_UPSTREAM_READ_TOKEN
+        $global:OriginalGitHubToken = $env:GITHUB_TOKEN
+        $global:OriginalWingetPat = $env:WINGET_PAT
+        $env:WINGET_UPSTREAM_READ_TOKEN = ''
+        $env:GITHUB_TOKEN = 'fork-write-token'
+        $env:WINGET_PAT = 'fork-write-token'
 
         InModuleScope WingetMaintainerModule {
             Mock Invoke-RestMethod {
@@ -30,10 +36,16 @@ Describe 'Test-ExistingPRs' {
     }
 
     AfterEach {
+        $env:WINGET_UPSTREAM_READ_TOKEN = $global:OriginalUpstreamReadToken
+        $env:GITHUB_TOKEN = $global:OriginalGitHubToken
+        $env:WINGET_PAT = $global:OriginalWingetPat
         Remove-Variable -Name ExistingPrSearchRequests -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalUpstreamReadToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalGitHubToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalWingetPat -Scope Global -ErrorAction SilentlyContinue
     }
 
-    It 'searches the public upstream REST API without the fork-scoped token' {
+    It 'falls back to an anonymous public upstream search without a dedicated read token' {
         $result = Test-ExistingPRs `
             -PackageIdentifier 'Test.Package' `
             -Version '1.0.0' `
@@ -51,12 +63,32 @@ Describe 'Test-ExistingPRs' {
             throw "Unexpected upstream PR search request: $($request | ConvertTo-Json -Compress)"
         }
         if ($request.Headers.ContainsKey('Authorization')) {
-            throw 'The public upstream PR search must not send the fork-scoped token.'
+            throw 'The anonymous fallback must not send the fork-scoped token.'
         }
 
         $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
         if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch '\(is:open OR is:merged\)' -or $query -notmatch 'Test.Package 1.0.0') {
             throw "The public upstream PR search used an unexpected query: $query"
+        }
+    }
+
+    It 'uses only the dedicated upstream read token for the public search' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'upstream-read-token'
+
+        Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs' | Out-Null
+
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "Expected one upstream duplicate search, got $($global:ExistingPrSearchRequests.Count)."
+        }
+        $authorization = $global:ExistingPrSearchRequests[0].Headers.Authorization
+        if ($authorization -cne 'Bearer upstream-read-token') {
+            throw "The upstream duplicate search used an unexpected credential: $authorization"
+        }
+        if ($authorization -match 'fork-write-token') {
+            throw 'The upstream duplicate search consumed a fork-scoped credential.'
         }
     }
 

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -8,9 +8,11 @@ Describe 'Test-ExistingPRs' {
     BeforeEach {
         $global:ExistingPrSearchRequests = [System.Collections.Generic.List[object]]::new()
         $global:OriginalUpstreamReadToken = $env:WINGET_UPSTREAM_READ_TOKEN
+        $global:OriginalUpstreamReadFallbackToken = $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN
         $global:OriginalGitHubToken = $env:GITHUB_TOKEN
         $global:OriginalWingetPat = $env:WINGET_PAT
         $env:WINGET_UPSTREAM_READ_TOKEN = ''
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = ''
         $env:GITHUB_TOKEN = 'fork-write-token'
         $env:WINGET_PAT = 'fork-write-token'
 
@@ -37,10 +39,12 @@ Describe 'Test-ExistingPRs' {
 
     AfterEach {
         $env:WINGET_UPSTREAM_READ_TOKEN = $global:OriginalUpstreamReadToken
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = $global:OriginalUpstreamReadFallbackToken
         $env:GITHUB_TOKEN = $global:OriginalGitHubToken
         $env:WINGET_PAT = $global:OriginalWingetPat
         Remove-Variable -Name ExistingPrSearchRequests -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalUpstreamReadToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalUpstreamReadFallbackToken -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalGitHubToken -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalWingetPat -Scope Global -ErrorAction SilentlyContinue
     }
@@ -89,6 +93,87 @@ Describe 'Test-ExistingPRs' {
         }
         if ($authorization -match 'fork-write-token') {
             throw 'The upstream duplicate search consumed a fork-scoped credential.'
+        }
+    }
+
+    It 'fails over from a rate limited primary read token to the fallback and then anonymous access' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'primary-read-token'
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = 'fallback-read-token'
+
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                if ($Headers.ContainsKey('Authorization') -and $Headers.Authorization -notlike '*anonymous*') {
+                    $rateLimitedResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Forbidden)
+                    throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('API rate limit exceeded', $rateLimitedResponse)
+                }
+                return [pscustomobject]@{ items = @() }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs' `
+            -WarningAction SilentlyContinue
+
+        if ($result -ne $false) {
+            throw 'The anonymous final tier unexpectedly reported a duplicate.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 3) {
+            throw "Expected primary, fallback, and anonymous attempts, got $($global:ExistingPrSearchRequests.Count) request(s)."
+        }
+        if ($global:ExistingPrSearchRequests[0].Headers.Authorization -notlike '*primary-read-token') {
+            throw 'The first attempt did not use the primary read token.'
+        }
+        if ($global:ExistingPrSearchRequests[1].Headers.Authorization -notlike '*fallback-read-token') {
+            throw 'The second attempt did not use the fallback read token.'
+        }
+        if ($global:ExistingPrSearchRequests[2].Headers.ContainsKey('Authorization')) {
+            throw 'The final anonymous attempt sent a credential.'
+        }
+    }
+
+    It 'does not fail over when the upstream search fails with a non-rate-limit error' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'primary-read-token'
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = 'fallback-read-token'
+
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                $serverErrorResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::InternalServerError)
+                throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('server error', $serverErrorResponse)
+            }
+        }
+
+        $failed = $false
+        try {
+            Test-ExistingPRs `
+                -PackageIdentifier 'Test.Package' `
+                -Version '1.0.0' `
+                -Repository 'microsoft/winget-pkgs' | Out-Null
+        }
+        catch {
+            $failed = $true
+        }
+
+        if (-not $failed) {
+            throw 'A server error during the upstream search did not surface.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "A non-rate-limit error was retried: $($global:ExistingPrSearchRequests.Count) request(s)."
         }
     }
 

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -226,6 +226,12 @@ $preGenerationGuardResult = & $module {
     function Install-WinMatsch {
         throw 'Manifest generation started despite an existing upstream PR.'
     }
+    function winmatsch {
+        throw 'Manifest generation started despite an existing upstream PR.'
+    }
+    function Test-GeneratedInstallerArchitecture {
+        throw 'Manifest generation started despite an existing upstream PR.'
+    }
 
     $result = Update-WingetPackage `
         -WingetPackage 'Test.Package' `

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -204,4 +204,45 @@ if (@($rewriteUpdateArguments | Where-Object { $_ -eq '--allow-structural-rewrit
     throw 'Update-WingetPackage did not pass structural rewrite approval exactly once.'
 }
 
+Write-Host 'TEST: existing PR guard stops generation before the manifest generator starts'
+$preGenerationGuardResult = & $module {
+    $script:ExistingPrChecks = 0
+
+    function Test-GitHubToken { 'test-token' }
+    function Test-PackageAndVersionInGithub {
+        [PSCustomObject]@{
+            PackageExists          = $true
+            ShouldGenerate         = $true
+            VersionExists          = $false
+            CanonicalVersion       = '1.0.0'
+            PublishedVersion       = $null
+            LatestPublishedVersion = $null
+        }
+    }
+    function Test-ExistingPRs {
+        $script:ExistingPrChecks++
+        return $true
+    }
+    function Install-WinMatsch {
+        throw 'Manifest generation started despite an existing upstream PR.'
+    }
+
+    $result = Update-WingetPackage `
+        -WingetPackage 'Test.Package' `
+        -With 'WinMatsch' `
+        -latestVersion '1.0.0' `
+        -latestVersionURL 'https://example.invalid/app.zip'
+
+    [PSCustomObject]@{
+        Result           = $result
+        ExistingPrChecks = $script:ExistingPrChecks
+    }
+}
+if ($preGenerationGuardResult.ExistingPrChecks -ne 1) {
+    throw "The pre-generation existing-PR guard ran $($preGenerationGuardResult.ExistingPrChecks) times instead of once."
+}
+if ($preGenerationGuardResult.Result.Generated -or $preGenerationGuardResult.Result.Reason -cne 'PRExists') {
+    throw "The pre-generation existing-PR guard did not stop generation: $($preGenerationGuardResult.Result | ConvertTo-Json -Compress)"
+}
+
 Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add a regression proving `Update-WingetPackage` stops before manifest generation when the upstream duplicate guard finds an existing PR
- probe the genuine Actions token (`${{ github.token }}`) in CI with an isolated composite action (`GET /repos/microsoft/winget-pkgs` only) and expose the result as a step output
- authenticate upstream `microsoft/winget-pkgs` reads (duplicate-PR search + base repo/ref/commit lookups) with a tiered credential chain:
  1. **`WINGET_UPSTREAM_READ_TOKEN` = `secrets.WINGET_PAT`** — classic `public_repo` PAT, 5,000 req/h (primary)
  2. **`WINGET_UPSTREAM_READ_FALLBACK_TOKEN`** — probed `github.token` (1,000 req/h) or optional `WINGET_PUBLIC_READ_TOKEN`
  3. anonymous public access (60 req/h)

  Each read retries with the next tier only on HTTP 401/403/404/429; other errors surface immediately.
- read tokens are never used for fork writes or PR creation; fork content writes and the single cross-repo PR POST keep using `WINGET_PAT` via `GITHUB_TOKEN` unchanged
- read-only `Upstream read capability` diagnostic job in module tests reports live status for all three credentials

## Validation
- `./tests/Update-WingetPackage.Tests.ps1`
- `./tests/ForkBranchSubmission.Tests.ps1` (8 tests incl. primary→fallback failover with token-order assertions)
- `./tests/Test-ExistingPRs.Tests.ps1` (6 tests incl. full three-tier failover and non-rate-limit no-failover)
- `./tests/SubmissionWorkflowAuthorization.Tests.ps1` (static: primary/fallback env wiring per workflow, `github.token` never overloads `GITHUB_TOKEN`)
- YAML parse of all four edited workflow files
- Live CI: all 8 checks green; diagnostic job confirms WINGET_PAT, github.token, and anonymous all read upstream successfully