### PR TITLE
Prevent duplicate winget submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@
 Validated scheduled manifests use `ForkBranch` submission rather than
 `wingetcreate submit`. `WINGET_PKGS_FORK_REPO` must name a user-owned fork;
 the module verifies that repository is a fork of `microsoft/winget-pkgs`,
-creates a disposable branch directly from its default branch, and commits only
-the manifest files to that branch. It never syncs or writes the fork default
-branch.
+atomically claims a deterministic package/version branch rooted at the
+upstream base commit, and commits only the manifest files to that branch. It
+never syncs or writes the fork default branch. If the claim already exists,
+the module reconciles it to a matching upstream PR when searchable; otherwise
+it fails closed and leaves the branch untouched for manual reconciliation.
 
 Every trigger, including scheduled main-branch runs, opens the pull request
 from the configured fork branch to `microsoft/winget-pkgs`. The submission
@@ -42,6 +44,13 @@ module retries the same request with the next tier, ending with anonymous
 public access, so a rate-limited or misbehaving credential can never block a
 submission. Read tokens are never used for fork writes or PR creation; fork
 writes and the cross-repository PR POST always use `WINGET_PAT`.
+
+Duplicate detection uses one broad `repo:<repository> is:pr in:title` search
+and accepts only exact current or legacy combined title formats for the package
+and version. It filters GitHub's returned `state` and `pull_request.merged_at`
+fields client-side, accepting open or actually merged PRs while ignoring
+closed-unmerged PRs. Search/API response failures and incomplete result pages
+fail closed rather than being treated as no duplicate.
 
 ## Package-specific WinMatsch overrides
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ submission. Read tokens are never used for fork writes or PR creation; fork
 writes and the cross-repository PR POST always use `WINGET_PAT`.
 
 Duplicate detection uses one broad `repo:<repository> is:pr in:title` search
-and accepts only exact current or legacy combined title formats for the package
-and version. It filters GitHub's returned `state` and `pull_request.merged_at`
-fields client-side, accepting open or actually merged PRs while ignoring
-closed-unmerged PRs. Search/API response failures and incomplete result pages
-fail closed rather than being treated as no duplicate.
+and requires bounded package and normalized-version title tokens, including
+the current and legacy combined formats. It filters GitHub's returned `state`
+and `pull_request.merged_at` fields client-side, accepting open or actually
+merged PRs while ignoring closed-unmerged PRs. Search/API response failures
+and incomplete result pages fail closed rather than being treated as no
+duplicate.
 
 ## Package-specific WinMatsch overrides
 

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -102,12 +102,7 @@ function Get-ForkBranchSubmissionFiles {
         [string] $Version
     )
 
-    if ($PackageId -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]*$') {
-        throw "Package ID '$PackageId' is not safe for a winget manifest path."
-    }
-    if ($Version -match '[\\/]' -or $Version -match '^\.+$') {
-        throw "Version '$Version' is not safe for a winget manifest path."
-    }
+    Assert-WingetPkgsSubmissionIdentity -PackageId $PackageId -Version $Version
 
     $files = @(Get-ChildItem -LiteralPath $ManifestPath -File -ErrorAction Stop)
     if ($files.Count -eq 0) {
@@ -129,6 +124,57 @@ function Get-ForkBranchSubmissionFiles {
             }
         }
     )
+}
+
+function Assert-WingetPkgsSubmissionIdentity {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    if ($PackageId -notmatch '^[A-Za-z0-9][A-Za-z0-9.-]*$') {
+        throw "Package ID '$PackageId' is not safe for a winget manifest path."
+    }
+    if ($Version -match '[\\/]' -or $Version -match '^\.+$') {
+        throw "Version '$Version' is not safe for a winget manifest path."
+    }
+}
+
+function Get-WingetPkgsSubmissionBranchName {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    Assert-WingetPkgsSubmissionIdentity -PackageId $PackageId -Version $Version
+
+    $normalizedPackageId = $PackageId.ToLowerInvariant()
+    $normalizedVersion = $Version.ToLowerInvariant()
+    $identity = $normalizedPackageId + [string][char]0 + $normalizedVersion
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $hasher.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($identity))
+    }
+    finally {
+        $hasher.Dispose()
+    }
+    $identityHash = ([BitConverter]::ToString($hashBytes)).Replace('-', '').ToLowerInvariant().Substring(0, 16)
+
+    $readableSuffix = "$normalizedPackageId-$normalizedVersion" -replace '[^A-Za-z0-9._-]', '-'
+    if ($readableSuffix.Length -gt 96) {
+        $readableSuffix = $readableSuffix.Substring(0, 96)
+    }
+
+    return "winget-autosubmit/$readableSuffix-$identityHash"
 }
 
 function Assert-SafeWingetPkgsForkRepository {
@@ -216,8 +262,8 @@ function Invoke-ForkBranchSubmission {
             }
         }
 
-    # A branch is created directly from the selected base commit; the fork's
-    # default branch is read-only throughout this flow.
+    # The fork default branch remains read-only. The manifest commit is rooted
+    # at the selected upstream base commit before its ref is atomically claimed.
     $tree = Invoke-WingetPkgsGitHubApi `
         -Method Post `
         -Path "repos/$ForkRepository/git/trees" `
@@ -236,29 +282,57 @@ function Invoke-ForkBranchSubmission {
             parents = @($baseSha)
         }
 
-    $branchSuffix = "$PackageId-$Version" -replace '[^A-Za-z0-9._-]', '-'
-    $branchName = "winget-autosubmit/$branchSuffix-$([guid]::NewGuid().ToString('N'))"
-    Invoke-WingetPkgsGitHubApi `
-        -Method Post `
-        -Path "repos/$ForkRepository/git/refs" `
-        -Token $Token `
-        -Body @{
-            ref = "refs/heads/$branchName"
-            sha = "$($commit.sha)"
-        } | Out-Null
-
-    # Recheck immediately before the external write. Workflow concurrency handles
-    # scheduled workers; this closes the remaining generate-to-submit window.
-    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
+    # Creating this deterministic ref is the atomic package/version claim.
+    # A collision is never retried with another name because that could open a
+    # second upstream PR while the first worker's PR is not searchable yet.
+    $branchName = Get-WingetPkgsSubmissionBranchName -PackageId $PackageId -Version $Version
+    try {
         Invoke-WingetPkgsGitHubApi `
-            -Method Delete `
-            -Path "repos/$ForkRepository/git/refs/heads/$branchName" `
-            -Token $Token | Out-Null
+            -Method Post `
+            -Path "repos/$ForkRepository/git/refs" `
+            -Token $Token `
+            -Body @{
+                ref = "refs/heads/$branchName"
+                sha = "$($commit.sha)"
+            } | Out-Null
+    }
+    catch {
+        $statusCode = Get-WingetPkgsGitHubApiFailureStatusCode -ErrorRecord $_
+        if ($statusCode -notin @(409, 422)) {
+            throw
+        }
+
+        if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
+            return [pscustomobject]@{
+                Created             = $false
+                DuplicateDetected   = $true
+                SubmissionClaimed   = $true
+                BranchName          = $branchName
+                PullRequest         = $null
+                Error               = $null
+            }
+        }
 
         return [pscustomobject]@{
-            Created    = $false
-            BranchName = $branchName
-            PullRequest = $null
+            Created             = $false
+            DuplicateDetected   = $false
+            SubmissionClaimed   = $true
+            BranchName          = $branchName
+            PullRequest         = $null
+            Error               = "The deterministic submission branch '$branchName' already exists, but no matching upstream PR is searchable. Refusing to create another PR; reconcile the existing branch before retrying."
+        }
+    }
+
+    # Recheck immediately before the external PR write. The branch claim closes
+    # the remaining read-to-write race when GitHub Search has not indexed a PR.
+    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
+        return [pscustomobject]@{
+            Created             = $false
+            DuplicateDetected   = $true
+            SubmissionClaimed   = $true
+            BranchName          = $branchName
+            PullRequest         = $null
+            Error               = $null
         }
     }
 
@@ -276,8 +350,11 @@ function Invoke-ForkBranchSubmission {
         }
 
     return [pscustomobject]@{
-        Created     = $true
-        BranchName  = $branchName
-        PullRequest = $pullRequest
+        Created             = $true
+        DuplicateDetected   = $false
+        SubmissionClaimed   = $true
+        BranchName          = $branchName
+        PullRequest         = $pullRequest
+        Error               = $null
     }
 }

--- a/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
+++ b/modules/WingetMaintainerModule/Private/Get-WingetPkgsPrUrl.ps1
@@ -73,7 +73,7 @@ function Get-WingetPkgsPrUrl {
             --search "$PackageId $Version in:title" `
             --state 'open' `
             --limit 10 `
-            --json 'url,createdAt' `
+            --json 'title,url,createdAt' `
             --repo $Repository 2>$null
 
         if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
@@ -85,7 +85,20 @@ function Get-WingetPkgsPrUrl {
             return $null
         }
 
-        $newest = $pullRequests |
+        $matchingPullRequests = @(
+            $pullRequests |
+                Where-Object {
+                    Test-WingetPkgsExistingPrTitle `
+                        -Title "$($_.title)" `
+                        -PackageIdentifier $PackageId `
+                        -Version $Version
+                }
+        )
+        if ($matchingPullRequests.Count -eq 0) {
+            return $null
+        }
+
+        $newest = $matchingPullRequests |
             Sort-Object -Property { [datetime] $_.createdAt } -Descending |
             Select-Object -First 1
 

--- a/modules/WingetMaintainerModule/Private/PullRequestTitles.ps1
+++ b/modules/WingetMaintainerModule/Private/PullRequestTitles.ps1
@@ -1,0 +1,23 @@
+function Test-WingetPkgsExistingPrTitle {
+    <#
+    .SYNOPSIS
+        Tests whether a pull request title represents the package/version pair.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Title,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageIdentifier,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    $updateTitle = "Update version: $PackageIdentifier version $Version"
+    $legacyCombinedTitle = "Add version: $PackageIdentifier version $Version - $updateTitle"
+
+    return $Title -ieq $updateTitle -or $Title -ieq $legacyCombinedTitle
+}

--- a/modules/WingetMaintainerModule/Private/PullRequestTitles.ps1
+++ b/modules/WingetMaintainerModule/Private/PullRequestTitles.ps1
@@ -19,5 +19,26 @@ function Test-WingetPkgsExistingPrTitle {
     $updateTitle = "Update version: $PackageIdentifier version $Version"
     $legacyCombinedTitle = "Add version: $PackageIdentifier version $Version - $updateTitle"
 
-    return $Title -ieq $updateTitle -or $Title -ieq $legacyCombinedTitle
+    if ($Title -ieq $updateTitle -or $Title -ieq $legacyCombinedTitle) {
+        return $true
+    }
+
+    # GitHub Search can return community and tool-specific title wording. Match
+    # the requested package and normalized version as whole title tokens so
+    # "Foo.Bar" never accepts "Foo.BarPro", nor "1.2" accepts "1.2.1".
+    $packagePattern = '(?<![A-Za-z0-9._-])' + [regex]::Escape($PackageIdentifier) + '(?![A-Za-z0-9._-])'
+    if (-not [regex]::IsMatch($Title, $packagePattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)) {
+        return $false
+    }
+
+    $normalizedVersion = $Version.Trim()
+    if ($normalizedVersion.Length -gt 1 -and $normalizedVersion[0] -in @('v', 'V')) {
+        $normalizedVersion = $normalizedVersion.Substring(1)
+    }
+    if ([string]::IsNullOrWhiteSpace($normalizedVersion)) {
+        return $false
+    }
+
+    $versionPattern = '(?<![A-Za-z0-9._+-])(?:v)?' + [regex]::Escape($normalizedVersion) + '(?![A-Za-z0-9._+-])'
+    return [regex]::IsMatch($Title, $versionPattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
 }

--- a/modules/WingetMaintainerModule/Private/UpstreamReadFailover.ps1
+++ b/modules/WingetMaintainerModule/Private/UpstreamReadFailover.ps1
@@ -44,7 +44,7 @@ function Get-WingetPkgsUpstreamReadCredentialTiers {
     return $tiers
 }
 
-function Get-WingetPkgsUpstreamReadFailureStatusCode {
+function Get-WingetPkgsGitHubApiFailureStatusCode {
     [CmdletBinding()]
     [OutputType([int])]
     param(
@@ -60,6 +60,17 @@ function Get-WingetPkgsUpstreamReadFailureStatusCode {
     }
 
     return 0
+}
+
+function Get-WingetPkgsUpstreamReadFailureStatusCode {
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.ErrorRecord] $ErrorRecord
+    )
+
+    return Get-WingetPkgsGitHubApiFailureStatusCode -ErrorRecord $ErrorRecord
 }
 
 function Test-WingetPkgsUpstreamReadFailoverStatus {

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -282,10 +282,19 @@ function Submit-WingetPackage {
                     -Resolves $Resolves
 
                 if (-not $forkSubmission.Created) {
+                    if (-not $forkSubmission.DuplicateDetected) {
+                        return @{
+                            Success  = $false
+                            Error    = $forkSubmission.Error
+                            PrUrl    = $null
+                            PrNumber = $null
+                        }
+                    }
+
                     $existingPrUrl = Get-WingetPkgsPrUrl `
                         -PackageId $PackageId `
                         -Version $Version `
-                        -Repository $targetRepository
+                        -Repository 'microsoft/winget-pkgs'
                     $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
                         $Matches['Number']
                     }

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -3,16 +3,21 @@
     Checks for existing pull requests (PRs) for a specified package identifier and version in the 'microsoft/winget-pkgs' repository.
 
 .DESCRIPTION
-    The `Test-ExistingPRs` function searches for existing open and merged pull requests in the 'microsoft/winget-pkgs' repository that match the specified package identifier and version.
+    The `Test-ExistingPRs` function searches for existing open and merged pull
+    requests in the 'microsoft/winget-pkgs' repository that exactly match the
+    specified package identifier and version. It uses one broad title search
+    and validates the returned PR state client-side because GitHub Search does
+    not support combining open and merged state qualifiers with a Boolean OR
+    expression.
+
     The search authenticates with the dedicated `WINGET_UPSTREAM_READ_TOKEN`
     first (workflows pass the classic public-read WINGET_PAT there). When
     GitHub rejects that credential with an authorization or rate-limit status
     (401/403/404/429), the search retries once with
     `WINGET_UPSTREAM_READ_FALLBACK_TOKEN` and finally falls back to the
-    anonymous public REST search endpoint, so a degraded credential can never
-    block duplicate detection. The fork-scoped submission token is never used
-    for this search. It returns `true` if matching open or merged PRs are
-    found, otherwise returns `false`.
+    anonymous public REST search endpoint. The fork-scoped submission token is
+    never used for this search. API and response-shape failures are surfaced so
+    callers fail closed instead of treating an uncertain result as no duplicate.
 
 .PARAMETER Version
     The version of the package to check for existing PRs. This parameter is mandatory.
@@ -51,8 +56,8 @@ function Test-ExistingPRs {
 
     $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
     $escapedVersion = $Version.Replace('"', '\"')
-    $stateQuery = if ($OnlyOpen) { 'is:open' } else { '(is:open OR is:merged)' }
-    $query = "repo:$Repository is:pr $stateQuery in:title `"$escapedPackageIdentifier $escapedVersion`""
+    $openOnlyQuery = if ($OnlyOpen) { ' is:open' } else { '' }
+    $query = "repo:$Repository is:pr$openOnlyQuery in:title `"$escapedPackageIdentifier $escapedVersion`""
     $encodedQuery = [uri]::EscapeDataString($query)
 
     $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
@@ -85,14 +90,69 @@ function Test-ExistingPRs {
             Write-Warning "Existing-PR search with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label)."
         }
     }
-    $existingPrs = @($response.items)
+    if ($null -eq $response) {
+        throw 'GitHub existing-PR search returned no response.'
+    }
 
-    if ($existingPrs.Count -gt 0) {
-        $existingPrs | ForEach-Object {
-            Write-Host "Found existing PR: $($_.title)"
-            Write-Host "-> $($_.html_url)"
+    $itemsProperty = $response.PSObject.Properties['items']
+    $totalCountProperty = $response.PSObject.Properties['total_count']
+    if ($null -eq $itemsProperty -or $null -eq $totalCountProperty -or $null -eq $itemsProperty.Value) {
+        throw 'GitHub existing-PR search returned an incomplete response.'
+    }
+
+    $totalCount = 0
+    if (-not [int]::TryParse("$($totalCountProperty.Value)", [ref] $totalCount) -or $totalCount -lt 0) {
+        throw 'GitHub existing-PR search returned an invalid total_count.'
+    }
+
+    $existingPrs = @($itemsProperty.Value)
+    if ($existingPrs.Count -ne $totalCount) {
+        throw "GitHub existing-PR search returned $($existingPrs.Count) of $totalCount candidate(s); refusing to make an incomplete duplicate decision."
+    }
+
+    foreach ($existingPr in $existingPrs) {
+        if ($null -eq $existingPr) {
+            throw 'GitHub existing-PR search returned an invalid candidate.'
         }
-        return $true
+
+        $titleProperty = $existingPr.PSObject.Properties['title']
+        $stateProperty = $existingPr.PSObject.Properties['state']
+        if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
+            throw 'GitHub existing-PR search returned a candidate without a title or state.'
+        }
+
+        $state = "$($stateProperty.Value)".ToLowerInvariant()
+        if ($state -notin @('open', 'closed')) {
+            throw "GitHub existing-PR search returned an unrecognized PR state '$state'."
+        }
+
+        $pullRequestProperty = $existingPr.PSObject.Properties['pull_request']
+        $mergedAt = $null
+        if ($state -eq 'closed') {
+            if ($null -eq $pullRequestProperty -or $null -eq $pullRequestProperty.Value) {
+                throw 'GitHub existing-PR search returned a closed PR without pull request metadata.'
+            }
+
+            $mergedAtProperty = $pullRequestProperty.Value.PSObject.Properties['merged_at']
+            if ($null -eq $mergedAtProperty) {
+                throw 'GitHub existing-PR search returned a closed PR without merged_at metadata.'
+            }
+            $mergedAt = $mergedAtProperty.Value
+        }
+
+        if (-not (Test-WingetPkgsExistingPrTitle `
+                    -Title "$($titleProperty.Value)" `
+                    -PackageIdentifier $PackageIdentifier `
+                    -Version $Version)) {
+            continue
+        }
+
+        $isMatchingPr = $state -eq 'open' -or (-not $OnlyOpen -and -not [string]::IsNullOrWhiteSpace("$mergedAt"))
+        if ($isMatchingPr) {
+            Write-Host "Found existing PR: $($titleProperty.Value)"
+            Write-Host "-> $($existingPr.html_url)"
+            return $true
+        }
     }
 
     return $false

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -57,7 +57,7 @@ function Test-ExistingPRs {
     $escapedPackageIdentifier = $PackageIdentifier.Replace('"', '\"')
     $escapedVersion = $Version.Replace('"', '\"')
     $openOnlyQuery = if ($OnlyOpen) { ' is:open' } else { '' }
-    $query = "repo:$Repository is:pr$openOnlyQuery in:title `"$escapedPackageIdentifier $escapedVersion`""
+    $query = "repo:$Repository is:pr$openOnlyQuery in:title `"$escapedPackageIdentifier`" `"$escapedVersion`""
     $encodedQuery = [uri]::EscapeDataString($query)
 
     $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
@@ -98,6 +98,17 @@ function Test-ExistingPRs {
     $totalCountProperty = $response.PSObject.Properties['total_count']
     if ($null -eq $itemsProperty -or $null -eq $totalCountProperty -or $null -eq $itemsProperty.Value) {
         throw 'GitHub existing-PR search returned an incomplete response.'
+    }
+
+    $incompleteResultsProperty = $response.PSObject.Properties['incomplete_results']
+    if ($null -ne $incompleteResultsProperty) {
+        $incompleteResults = $false
+        if (-not [bool]::TryParse("$($incompleteResultsProperty.Value)", [ref] $incompleteResults)) {
+            throw 'GitHub existing-PR search returned an invalid incomplete_results value.'
+        }
+        if ($incompleteResults) {
+            throw 'GitHub existing-PR search reported incomplete_results=true; refusing to make a duplicate decision.'
+        }
     }
 
     $totalCount = 0

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
 
         $global:ForkBranchSubmissionRequests = [System.Collections.Generic.List[object]]::new()
         $global:ForkBranchDuplicateRepositories = [System.Collections.Generic.List[string]]::new()
+        $global:ForkBranchPrUrlRepositories = [System.Collections.Generic.List[string]]::new()
         $global:ForkBranchUpstreamReadFailTokens = @()
         $global:OriginalForkRepository = $env:WINGET_PKGS_FORK_REPO
         $global:OriginalUpstreamReadToken = $env:WINGET_UPSTREAM_READ_TOKEN
@@ -97,6 +98,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         Remove-Variable -Name ForkBranchSubmissionManifestPath -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchSubmissionRequests -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchDuplicateRepositories -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ForkBranchPrUrlRepositories -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name ForkBranchUpstreamReadFailTokens -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalForkRepository -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name OriginalUpstreamReadToken -Scope Global -ErrorAction SilentlyContinue
@@ -284,7 +286,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
     }
 
-    It 'keeps its claimed branch and skips PR creation when the final duplicate preflight finds a target PR' {
+    It 'returns the upstream PR when the final duplicate preflight returns Created=false' {
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs {
                 param($PackageIdentifier, $Version, $Repository)
@@ -292,7 +294,12 @@ Describe 'Submit-WingetPackage ForkBranch' {
                 $global:ForkBranchDuplicateRepositories.Add($Repository)
                 return $true
             }
-            Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
+            Mock Get-WingetPkgsPrUrl {
+                param($PackageId, $Version, $Repository)
+
+                $global:ForkBranchPrUrlRepositories.Add($Repository)
+                return 'https://github.com/microsoft/winget-pkgs/pull/54321'
+            }
         }
 
         $result = Submit-WingetPackage `
@@ -307,6 +314,9 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
         if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
             throw "Duplicate detection did not use the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        }
+        if ($global:ForkBranchPrUrlRepositories.Count -ne 1 -or $global:ForkBranchPrUrlRepositories[0] -cne 'microsoft/winget-pkgs') {
+            throw "Created=false did not resolve the existing pull request against the upstream target: $($global:ForkBranchPrUrlRepositories -join ', ')"
         }
         $branchDeletes = @(
             $global:ForkBranchSubmissionRequests |

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -75,11 +75,6 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     '/git/refs$' {
                         return [pscustomobject]@{ ref = 'refs/heads/winget-autosubmit/test' }
                     }
-                    '/git/refs/heads/winget-autosubmit/' {
-                        if ($Method -eq 'Delete') {
-                            return $null
-                        }
-                    }
                     '/pulls$' {
                         return [pscustomobject]@{
                             html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
@@ -172,6 +167,15 @@ Describe 'Submit-WingetPackage ForkBranch' {
         $treeRequest = $forkWrites | Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/git/trees' }
         if ($treeRequest.Body.base_tree -cne 'base-tree-sha') {
             throw "ForkBranch did not base the manifest tree on the resolved base tree: $($treeRequest.Body.base_tree)"
+        }
+        $branchClaim = $forkWrites |
+            Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/git/refs' -and $_.Method -eq 'Post' } |
+            Select-Object -Last 1
+        if ($null -eq $branchClaim -or $branchClaim.Body.ref -notmatch '^refs/heads/winget-autosubmit/test\.package-1\.0\.0-[a-f0-9]{16}$') {
+            throw "ForkBranch did not create the deterministic package/version claim ref: $($branchClaim | ConvertTo-Json -Compress)"
+        }
+        if ($branchClaim.Body.sha -cne 'commit-sha') {
+            throw "ForkBranch did not claim the manifest commit: $($branchClaim.Body.sha)"
         }
 
         $pullRequest = $global:ForkBranchSubmissionRequests |
@@ -280,7 +284,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
         }
     }
 
-    It 'removes the temporary fork branch when the final duplicate preflight finds a target PR' {
+    It 'keeps its claimed branch and skips PR creation when the final duplicate preflight finds a target PR' {
         InModuleScope WingetMaintainerModule {
             Mock Test-ExistingPRs {
                 param($PackageIdentifier, $Version, $Repository)
@@ -311,11 +315,118 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     $_.Path -match '^repos/damn-good-b0t/winget-pkgs/git/refs/heads/winget-autosubmit/'
                 }
         )
-        if ($branchDeletes.Count -ne 1) {
-            throw "The temporary fork branch was not removed after duplicate detection: $($global:ForkBranchSubmissionRequests | ConvertTo-Json -Compress)"
+        if ($branchDeletes.Count -ne 0) {
+            throw "Duplicate handling deleted a deterministic claim that could belong to an existing PR: $($global:ForkBranchSubmissionRequests | ConvertTo-Json -Compress)"
         }
         if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' -and $_.Method -eq 'Post' }).Count -ne 0) {
             throw 'Duplicate detection created an upstream pull request.'
+        }
+    }
+
+    It 'uses one deterministic source ref claim when competing submissions cannot yet search each other PRs' {
+        $competingResults = InModuleScope WingetMaintainerModule {
+            $script:DeterministicClaimCreated = $false
+            Mock Test-ExistingPRs { $false }
+            Mock Invoke-WingetPkgsGitHubApi {
+                param($Method, $Path, $Token, $Unauthenticated, $Body)
+
+                $global:ForkBranchSubmissionRequests.Add([pscustomobject]@{
+                    Method          = $Method
+                    Path            = $Path
+                    Token           = $Token
+                    Unauthenticated = [bool] $Unauthenticated
+                    Body            = $Body
+                })
+
+                switch -Regex ($Path) {
+                    '^repos/damn-good-b0t/winget-pkgs$' {
+                        return [pscustomobject]@{
+                            fork           = $true
+                            default_branch = 'master'
+                            parent         = [pscustomobject]@{ full_name = 'microsoft/winget-pkgs' }
+                        }
+                    }
+                    '^repos/microsoft/winget-pkgs$' {
+                        return [pscustomobject]@{ default_branch = 'master' }
+                    }
+                    '/git/ref/heads/master$' {
+                        return [pscustomobject]@{ object = [pscustomobject]@{ sha = 'base-sha' } }
+                    }
+                    '/git/commits/base-sha$' {
+                        return [pscustomobject]@{ tree = [pscustomobject]@{ sha = 'base-tree-sha' } }
+                    }
+                    '/git/trees$' {
+                        return [pscustomobject]@{ sha = 'tree-sha' }
+                    }
+                    '/git/commits$' {
+                        return [pscustomobject]@{ sha = 'commit-sha' }
+                    }
+                    '/git/refs$' {
+                        if (-not $script:DeterministicClaimCreated) {
+                            $script:DeterministicClaimCreated = $true
+                            return [pscustomobject]@{ ref = "$($Body.ref)" }
+                        }
+
+                        $conflictResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::UnprocessableEntity)
+                        throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('Reference already exists', $conflictResponse)
+                    }
+                    '/pulls$' {
+                        return [pscustomobject]@{
+                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            number   = 12345
+                        }
+                    }
+                    default {
+                        throw "Unexpected GitHub API request: $Method $Path"
+                    }
+                }
+            }
+
+            $first = Invoke-ForkBranchSubmission `
+                -ManifestPath $global:ForkBranchSubmissionManifestPath `
+                -PackageId 'Test.Package' `
+                -Version '1.0.0' `
+                -PrTitle 'Update version: Test.Package version 1.0.0' `
+                -Token 'test-token' `
+                -ForkRepository 'damn-good-b0t/winget-pkgs'
+            $second = Invoke-ForkBranchSubmission `
+                -ManifestPath $global:ForkBranchSubmissionManifestPath `
+                -PackageId 'Test.Package' `
+                -Version '1.0.0' `
+                -PrTitle 'Update version: Test.Package version 1.0.0' `
+                -Token 'test-token' `
+                -ForkRepository 'damn-good-b0t/winget-pkgs'
+
+            return [pscustomobject]@{
+                First  = $first
+                Second = $second
+            }
+        }
+
+        $first = $competingResults.First
+        $second = $competingResults.Second
+        if (-not $first.Created) {
+            throw "The claim owner did not create the PR: $($first | ConvertTo-Json -Compress)"
+        }
+        if ($second.Created -or $second.DuplicateDetected -or $second.Error -notmatch 'already exists') {
+            throw "The competing submission was not fail-closed by the existing claim: $($second | ConvertTo-Json -Compress)"
+        }
+
+        $claimRequests = @(
+            $global:ForkBranchSubmissionRequests |
+                Where-Object {
+                    $_.Method -eq 'Post' -and
+                    $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/git/refs'
+                }
+        )
+        if ($claimRequests.Count -ne 2 -or $claimRequests[0].Body.ref -cne $claimRequests[1].Body.ref) {
+            throw "Competing submissions did not use the same deterministic source ref: $($claimRequests | ConvertTo-Json -Compress)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/git/trees' -and $_.Method -eq 'Post' }).Count -ne 2) {
+            throw 'Both competing submissions must reach their immutable manifest commits before the deterministic ref claim arbitrates ownership.'
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -eq 'repos/microsoft/winget-pkgs/pulls' -and $_.Method -eq 'Post' }).Count -ne 1) {
+            throw 'Competing submissions created more than one upstream pull request.'
         }
     }
 

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -26,10 +26,13 @@ Describe 'Test-ExistingPRs' {
                     Headers = $Headers
                 })
                 return [pscustomobject]@{
+                    total_count = 1
                     items = @(
                         [pscustomobject]@{
-                            title    = 'Update version: Test.Package version 1.0.0'
-                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
                         }
                     )
                 }
@@ -71,7 +74,8 @@ Describe 'Test-ExistingPRs' {
         }
 
         $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
-        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch '\(is:open OR is:merged\)' -or $query -notmatch 'Test.Package 1.0.0') {
+        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch 'Test.Package 1.0.0' -or
+            $query -match '\(is:open OR is:merged\)' -or $query -match 'is:merged') {
             throw "The public upstream PR search used an unexpected query: $query"
         }
     }
@@ -113,7 +117,7 @@ Describe 'Test-ExistingPRs' {
                     $rateLimitedResponse = [System.Net.Http.HttpResponseMessage]::new([System.Net.HttpStatusCode]::Forbidden)
                     throw [Microsoft.PowerShell.Commands.HttpResponseException]::new('API rate limit exceeded', $rateLimitedResponse)
                 }
-                return [pscustomobject]@{ items = @() }
+                return [pscustomobject]@{ total_count = 0; items = @() }
             }
         }
 
@@ -177,7 +181,7 @@ Describe 'Test-ExistingPRs' {
         }
     }
 
-    It 'checks open and merged pull requests in one upstream request' {
+    It 'detects exact open and merged titles while ignoring closed-unmerged and substring candidates' {
         InModuleScope WingetMaintainerModule {
             Mock Invoke-RestMethod {
                 param($Method, $Uri, $Headers, $ErrorAction)
@@ -187,7 +191,77 @@ Describe 'Test-ExistingPRs' {
                     Uri     = $Uri
                     Headers = $Headers
                 })
-                return [pscustomobject]@{ items = @() }
+                return [pscustomobject]@{
+                    total_count = 4
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/100'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        },
+                        [pscustomobject]@{
+                            title        = 'Add version: Test.Package version 1.0.0 - Update version: Test.Package version 1.0.0'
+                            state        = 'closed'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/101'
+                            pull_request = [pscustomobject]@{ merged_at = '2026-08-06T12:00:00Z' }
+                        },
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'closed'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/102'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        },
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package.Extra version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/103'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $true) {
+            throw 'An exact matching open upstream pull request was not found.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw "Duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of one."
+        }
+
+        $query = [uri]::UnescapeDataString(([uri] $global:ExistingPrSearchRequests[0].Uri).Query)
+        if ($query -match '\(is:open OR is:merged\)' -or $query -match 'is:merged') {
+            throw "Duplicate detection used the invalid GitHub Search state expression: $query"
+        }
+    }
+
+    It 'ignores an exact closed-unmerged title when no open or merged title exists' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'closed'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/102'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
             }
         }
 
@@ -197,10 +271,70 @@ Describe 'Test-ExistingPRs' {
             -Repository 'microsoft/winget-pkgs'
 
         if ($result -ne $false) {
-            throw 'An empty upstream PR search unexpectedly found a match.'
+            throw 'A closed-unmerged upstream PR was treated as a duplicate.'
         }
         if ($global:ExistingPrSearchRequests.Count -ne 1) {
-            throw "Open and merged duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of one."
+            throw "Duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of one."
+        }
+    }
+
+    It 'detects the legacy combined add-and-update title when the PR was merged' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Add version: Test.Package version 1.0.0 - Update version: Test.Package version 1.0.0'
+                            state        = 'closed'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/101'
+                            pull_request = [pscustomobject]@{ merged_at = '2026-08-06T12:00:00Z' }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $true) {
+            throw 'A merged legacy add-and-update pull request was not detected.'
+        }
+    }
+
+    It 'ignores substring and tokenized title search candidates' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                return [pscustomobject]@{
+                    total_count = 2
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package.Extra version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/103'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        },
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0.1'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/104'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $false) {
+            throw 'A substring or tokenized title candidate was treated as an exact duplicate.'
         }
     }
 
@@ -214,7 +348,7 @@ Describe 'Test-ExistingPRs' {
                     Uri     = $Uri
                     Headers = $Headers
                 })
-                return [pscustomobject]@{ items = @() }
+                return [pscustomobject]@{ total_count = 0; items = @() }
             }
         }
 
@@ -234,6 +368,59 @@ Describe 'Test-ExistingPRs' {
         $query = [uri]::UnescapeDataString(([uri] $global:ExistingPrSearchRequests[0].Uri).Query)
         if ($query -notmatch 'is:open' -or $query -match 'is:merged') {
             throw "OnlyOpen used an unexpected query: $query"
+        }
+    }
+
+    It 'fails closed when GitHub cannot provide state metadata for a candidate' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        {
+            Test-ExistingPRs `
+                -PackageIdentifier 'Test.Package' `
+                -Version '1.0.0' `
+                -Repository 'microsoft/winget-pkgs'
+        } | Should -Throw '*without a title or state*'
+    }
+
+    It 'fails closed rather than treating a malformed authenticated response as no duplicate' {
+        $env:WINGET_UPSTREAM_READ_TOKEN = 'primary-read-token'
+        $env:WINGET_UPSTREAM_READ_FALLBACK_TOKEN = 'fallback-read-token'
+
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                return [pscustomobject]@{ total_count = 1 }
+            }
+        }
+
+        {
+            Test-ExistingPRs `
+                -PackageIdentifier 'Test.Package' `
+                -Version '1.0.0' `
+                -Repository 'microsoft/winget-pkgs'
+        } | Should -Throw '*incomplete response*'
+
+        if ($global:ExistingPrSearchRequests.Count -ne 1) {
+            throw 'A malformed primary response was converted into a fallback no-duplicate decision.'
         }
     }
 }

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -74,7 +74,7 @@ Describe 'Test-ExistingPRs' {
         }
 
         $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
-        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch 'Test.Package 1.0.0' -or
+        if ($query -notmatch 'repo:microsoft/winget-pkgs' -or $query -notmatch 'in:title "Test\.Package" "1\.0\.0"' -or
             $query -match '\(is:open OR is:merged\)' -or $query -match 'is:merged') {
             throw "The public upstream PR search used an unexpected query: $query"
         }
@@ -213,7 +213,7 @@ Describe 'Test-ExistingPRs' {
                             pull_request = [pscustomobject]@{ merged_at = $null }
                         },
                         [pscustomobject]@{
-                            title        = 'Update version: Test.Package.Extra version 1.0.0'
+                            title        = 'Update version: Test.PackagePro version 1.0.0'
                             state        = 'open'
                             html_url     = 'https://github.com/microsoft/winget-pkgs/pull/103'
                             pull_request = [pscustomobject]@{ merged_at = $null }
@@ -305,6 +305,25 @@ Describe 'Test-ExistingPRs' {
         }
     }
 
+    It 'detects community and custom title forms with bounded package and version tokens' {
+        $titleMatches = InModuleScope WingetMaintainerModule {
+            [pscustomobject]@{
+                Community = Test-WingetPkgsExistingPrTitle `
+                    -Title 'Community update: Test.Package v1.0.0' `
+                    -PackageIdentifier 'Test.Package' `
+                    -Version '1.0.0'
+                Custom = Test-WingetPkgsExistingPrTitle `
+                    -Title 'Bump Test.Package from 0.9.0 to 1.0.0' `
+                    -PackageIdentifier 'Test.Package' `
+                    -Version '1.0.0'
+            }
+        }
+
+        if (-not $titleMatches.Community -or -not $titleMatches.Custom) {
+            throw "Bounded package/version matching did not recognize custom title forms: $($titleMatches | ConvertTo-Json -Compress)"
+        }
+    }
+
     It 'ignores substring and tokenized title search candidates' {
         InModuleScope WingetMaintainerModule {
             Mock Invoke-RestMethod {
@@ -312,7 +331,7 @@ Describe 'Test-ExistingPRs' {
                     total_count = 2
                     items = @(
                         [pscustomobject]@{
-                            title        = 'Update version: Test.Package.Extra version 1.0.0'
+                            title        = 'Update version: Test.PackagePro version 1.0.0'
                             state        = 'open'
                             html_url     = 'https://github.com/microsoft/winget-pkgs/pull/103'
                             pull_request = [pscustomobject]@{ merged_at = $null }
@@ -336,6 +355,32 @@ Describe 'Test-ExistingPRs' {
         if ($result -ne $false) {
             throw 'A substring or tokenized title candidate was treated as an exact duplicate.'
         }
+    }
+
+    It 'fails closed when GitHub Search reports incomplete results despite a complete page' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                return [pscustomobject]@{
+                    incomplete_results = $true
+                    total_count        = 1
+                    items              = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        {
+            Test-ExistingPRs `
+                -PackageIdentifier 'Test.Package' `
+                -Version '1.0.0' `
+                -Repository 'microsoft/winget-pkgs'
+        } | Should -Throw '*incomplete_results=true*'
     }
 
     It 'searches only open pull requests when requested' {


### PR DESCRIPTION
## Incident repair

PR #166 replaced two valid GitHub Search state queries with `is:open OR is:merged`. GitHub Search did not apply that Boolean state expression as intended, so both duplicate guards returned false and allowed duplicate manifest generation and PR submission.

At incident reproduction time, `repo:microsoft/winget-pkgs is:pr (is:open OR is:merged) in:title "jj-vcs.jj 0.44.0"` returned `total_count: 0`, while the valid `is:open` query returned three matching PRs.

## Changes

- Use one valid broad `repo:<repository> is:pr in:title` search, with package and version title terms separate so custom title wording is considered.
- Match known titles exactly and community/custom titles only when the package identifier and normalized version are bounded title tokens; `Foo.Bar` cannot match `Foo.BarPro`, and `1.2` cannot match `1.2.1`.
- Treat only `state=open` or `state=closed` with `pull_request.merged_at` as duplicates; closed-unmerged PRs are ignored.
- Fail closed on malformed, truncated, or `incomplete_results=true` search responses; tiered upstream-read fallback cannot turn a response/API error into "no duplicate".
- Preserve the generation and pre-PR guards.
- Make the deterministic, normalized package/version fork ref the atomic submission claim. An existing claim is reconciled to a searchable duplicate or fails closed without a second PR; claimed refs are never deleted automatically.
- Keep upstream reads on their existing tiered read credentials and fork writes/PR POST on the submission token.
- Regress the `Created=false` ForkBranch path so it resolves the existing upstream PR without the former undefined `$targetRepository` reference.

## Validation

- Focused Pester 5.7.1: 26 passing (`Test-ExistingPRs`, `ForkBranchSubmission`, `Submit-WingetPackage`)
- `tests/Update-WingetPackage.Tests.ps1`
- `tests/SubmissionWorkflowAuthorization.Tests.ps1`
- PowerShell parse and whitespace checks

No package workflow was enabled or dispatched, and no repository other than this source repository was mutated.