### PR TITLE
Prevent duplicate WinGet submissions

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -737,6 +737,7 @@ jobs:
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
+          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -748,7 +749,8 @@ jobs:
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
             -With "ForkBranch" `
-            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET" `
+            -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1463,6 +1463,7 @@ jobs:
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
+          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -1474,7 +1475,8 @@ jobs:
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
             -With "ForkBranch" `
-            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET" `
+            -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -1064,6 +1064,7 @@ jobs:
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
+          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -1075,7 +1076,8 @@ jobs:
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
             -With "ForkBranch" `
-            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET" `
+            -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
 
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -743,6 +743,7 @@ jobs:
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
+          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}
@@ -754,7 +755,8 @@ jobs:
             -PackageId "$env:MATRIX_PACKAGENAME" `
             -Version "$env:MATRIX_VERSION" `
             -With "ForkBranch" `
-            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET"
+            -SubmissionTarget "$env:WINGET_PKGS_SUBMISSION_TARGET" `
+            -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
           
           if ($result.Success) {
             Write-Host "PR submitted successfully!" -ForegroundColor Green

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -35,6 +35,10 @@
     pull request against microsoft/winget-pkgs. It never directly pushes or
     commits content to microsoft/winget-pkgs.
 
+    .PARAMETER Repository
+    The repository where existing pull requests are checked. ForkBranch only
+    supports microsoft/winget-pkgs as its write target.
+
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses
     GITHUB_TOKEN or WINGET_PAT environment variables.
@@ -99,7 +103,11 @@ function Submit-WingetPackage {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet('Upstream', 'Fork')]
-        [string] $SubmissionTarget = 'Upstream'
+        [string] $SubmissionTarget = 'Upstream',
+
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+        [string] $Repository = 'microsoft/winget-pkgs'
     )
 
     # Get GitHub token
@@ -137,6 +145,59 @@ function Submit-WingetPackage {
     try {
         $winmatschResult = $null
 
+        # Reject invalid ForkBranch configurations before contacting the
+        # upstream read API.
+        if ($With -eq 'ForkBranch') {
+            if ($SubmissionTarget -ne 'Upstream') {
+                return @{
+                    Success  = $false
+                    Error    = 'ForkBranch submissions are restricted to the Upstream target; manifest writes remain in the configured fork.'
+                    PrUrl    = $null
+                    PrNumber = $null
+                }
+            }
+            if ($Repository -ine 'microsoft/winget-pkgs') {
+                return @{
+                    Success  = $false
+                    Error    = 'ForkBranch submissions can only target microsoft/winget-pkgs.'
+                    PrUrl    = $null
+                    PrNumber = $null
+                }
+            }
+
+            $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
+            if ([string]::IsNullOrWhiteSpace($forkRepository)) {
+                return @{
+                    Success  = $false
+                    Error    = 'WINGET_PKGS_FORK_REPO is required for ForkBranch submissions.'
+                    PrUrl    = $null
+                    PrNumber = $null
+                }
+            }
+
+            Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
+        }
+
+        # A durable upstream check protects all submitters; tool-specific
+        # concurrency only serializes workers from this workflow.
+        if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -OnlyOpen -Repository $Repository) {
+            $existingPrUrl = Get-WingetPkgsPrUrl -PackageId $PackageId -Version $Version -Repository $Repository
+            $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
+                $Matches['Number']
+            }
+            else {
+                $null
+            }
+
+            Write-Host "A matching open PR already exists in $Repository; skipping submission." -ForegroundColor Yellow
+            return @{
+                Success  = $true
+                Error    = $null
+                PrUrl    = $existingPrUrl
+                PrNumber = $existingPrNumber
+            }
+        }
+
         switch ($With) {
             "WinMatsch" {
                 # Ensure WinMatsch is installed
@@ -144,10 +205,10 @@ function Submit-WingetPackage {
 
                 $maxAttempts = $MaxBranchMovedRetries + 1
                 for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-                    # This is a read-only check against microsoft/winget-pkgs.
-                    # WinMatsch remains the only component that creates the PR.
-                    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version) {
-                        $existingPrUrl = Get-WingetPkgsPrUrl -PackageId $PackageId -Version $Version
+                    # Recheck before each retry in case another worker created
+                    # the PR after the universal preflight completed.
+                    if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -OnlyOpen -Repository $Repository) {
+                        $existingPrUrl = Get-WingetPkgsPrUrl -PackageId $PackageId -Version $Version -Repository $Repository
                         $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
                             $Matches['Number']
                         }
@@ -251,27 +312,6 @@ function Submit-WingetPackage {
             }
 
             "ForkBranch" {
-                if ($SubmissionTarget -ne 'Upstream') {
-                    return @{
-                        Success  = $false
-                        Error    = 'ForkBranch submissions are restricted to the Upstream target; manifest writes remain in the configured fork.'
-                        PrUrl    = $null
-                        PrNumber = $null
-                    }
-                }
-
-                $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
-                if ([string]::IsNullOrWhiteSpace($forkRepository)) {
-                    return @{
-                        Success  = $false
-                        Error    = 'WINGET_PKGS_FORK_REPO is required for ForkBranch submissions.'
-                        PrUrl    = $null
-                        PrNumber = $null
-                    }
-                }
-
-                Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
-
                 $forkSubmission = Invoke-ForkBranchSubmission `
                     -ManifestPath $fullManifestPath `
                     -PackageId $PackageId `

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -4,10 +4,10 @@
 
 .DESCRIPTION
     The `Test-ExistingPRs` function searches for existing open and merged pull
-    requests in the 'microsoft/winget-pkgs' repository that exactly match the
-    specified package identifier and version. It uses one broad title search
-    and validates the returned PR state client-side because GitHub Search does
-    not support combining open and merged state qualifiers with a Boolean OR
+    requests in the selected repository that exactly match the specified
+    package identifier and version. It paginates the GitHub Search results and
+    validates the returned PR state client-side because GitHub Search does not
+    support combining open and merged state qualifiers with a Boolean OR
     expression.
 
     The search authenticates with the dedicated `WINGET_UPSTREAM_READ_TOKEN`
@@ -60,111 +60,135 @@ function Test-ExistingPRs {
     $query = "repo:$Repository is:pr$openOnlyQuery in:title `"$escapedPackageIdentifier`" `"$escapedVersion`""
     $encodedQuery = [uri]::EscapeDataString($query)
 
-    $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
-    $response = $null
-    for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
-        $tier = $credentialTiers[$tierIndex]
-        $headers = @{
-            Accept                 = 'application/vnd.github+json'
-            'X-GitHub-Api-Version' = '2022-11-28'
-            'User-Agent'           = 'winget-pkgs-updates'
-        }
-        if (-not [string]::IsNullOrWhiteSpace($tier.Token)) {
-            $headers.Authorization = "Bearer $($tier.Token)"
-        }
-        try {
-            $response = Invoke-RestMethod `
-                -Method Get `
-                -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=100" `
-                -Headers $headers `
-                -ErrorAction Stop
-            break
-        }
-        catch {
-            $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
-            $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
-            if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
-                throw
+    $pageSize = 100
+    $maximumSearchResults = 1000
+    $page = 1
+    $retrievedCount = 0
+    $totalCount = $null
+
+    while ($true) {
+        $response = $null
+        $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
+        for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
+            $tier = $credentialTiers[$tierIndex]
+            $headers = @{
+                Accept                 = 'application/vnd.github+json'
+                'X-GitHub-Api-Version' = '2022-11-28'
+                'User-Agent'           = 'winget-pkgs-updates'
             }
-            $nextTier = $credentialTiers[$tierIndex + 1]
-            Write-Warning "Existing-PR search with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label)."
+            if (-not [string]::IsNullOrWhiteSpace($tier.Token)) {
+                $headers.Authorization = "Bearer $($tier.Token)"
+            }
+            try {
+                $response = Invoke-RestMethod `
+                    -Method Get `
+                    -Uri "https://api.github.com/search/issues?q=$encodedQuery&per_page=$pageSize&page=$page" `
+                    -Headers $headers `
+                    -ErrorAction Stop
+                break
+            }
+            catch {
+                $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
+                $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
+                if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
+                    throw
+                }
+                $nextTier = $credentialTiers[$tierIndex + 1]
+                Write-Warning "Existing-PR search page $page with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label)."
+            }
         }
-    }
-    if ($null -eq $response) {
-        throw 'GitHub existing-PR search returned no response.'
-    }
-
-    $itemsProperty = $response.PSObject.Properties['items']
-    $totalCountProperty = $response.PSObject.Properties['total_count']
-    if ($null -eq $itemsProperty -or $null -eq $totalCountProperty -or $null -eq $itemsProperty.Value) {
-        throw 'GitHub existing-PR search returned an incomplete response.'
-    }
-
-    $incompleteResultsProperty = $response.PSObject.Properties['incomplete_results']
-    if ($null -ne $incompleteResultsProperty) {
-        $incompleteResults = $false
-        if (-not [bool]::TryParse("$($incompleteResultsProperty.Value)", [ref] $incompleteResults)) {
-            throw 'GitHub existing-PR search returned an invalid incomplete_results value.'
-        }
-        if ($incompleteResults) {
-            throw 'GitHub existing-PR search reported incomplete_results=true; refusing to make a duplicate decision.'
-        }
-    }
-
-    $totalCount = 0
-    if (-not [int]::TryParse("$($totalCountProperty.Value)", [ref] $totalCount) -or $totalCount -lt 0) {
-        throw 'GitHub existing-PR search returned an invalid total_count.'
-    }
-
-    $existingPrs = @($itemsProperty.Value)
-    if ($existingPrs.Count -ne $totalCount) {
-        throw "GitHub existing-PR search returned $($existingPrs.Count) of $totalCount candidate(s); refusing to make an incomplete duplicate decision."
-    }
-
-    foreach ($existingPr in $existingPrs) {
-        if ($null -eq $existingPr) {
-            throw 'GitHub existing-PR search returned an invalid candidate.'
+        if ($null -eq $response) {
+            throw 'GitHub existing-PR search returned no response.'
         }
 
-        $titleProperty = $existingPr.PSObject.Properties['title']
-        $stateProperty = $existingPr.PSObject.Properties['state']
-        if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
-            throw 'GitHub existing-PR search returned a candidate without a title or state.'
+        $itemsProperty = $response.PSObject.Properties['items']
+        $totalCountProperty = $response.PSObject.Properties['total_count']
+        if ($null -eq $itemsProperty -or $null -eq $totalCountProperty -or $null -eq $itemsProperty.Value) {
+            throw 'GitHub existing-PR search returned an incomplete response.'
         }
 
-        $state = "$($stateProperty.Value)".ToLowerInvariant()
-        if ($state -notin @('open', 'closed')) {
-            throw "GitHub existing-PR search returned an unrecognized PR state '$state'."
+        $incompleteResultsProperty = $response.PSObject.Properties['incomplete_results']
+        if ($null -ne $incompleteResultsProperty) {
+            $incompleteResults = $false
+            if (-not [bool]::TryParse("$($incompleteResultsProperty.Value)", [ref] $incompleteResults)) {
+                throw 'GitHub existing-PR search returned an invalid incomplete_results value.'
+            }
+            if ($incompleteResults) {
+                throw 'GitHub existing-PR search reported incomplete_results=true; refusing to make a duplicate decision.'
+            }
         }
 
-        $pullRequestProperty = $existingPr.PSObject.Properties['pull_request']
-        $mergedAt = $null
-        if ($state -eq 'closed') {
-            if ($null -eq $pullRequestProperty -or $null -eq $pullRequestProperty.Value) {
-                throw 'GitHub existing-PR search returned a closed PR without pull request metadata.'
+        $responseTotalCount = 0
+        if (-not [int]::TryParse("$($totalCountProperty.Value)", [ref] $responseTotalCount) -or $responseTotalCount -lt 0) {
+            throw 'GitHub existing-PR search returned an invalid total_count.'
+        }
+        if ($responseTotalCount -gt $maximumSearchResults) {
+            throw "GitHub existing-PR search returned $responseTotalCount candidate(s), exceeding the $maximumSearchResults-result API limit; refusing to make an incomplete duplicate decision."
+        }
+        if ($null -eq $totalCount) {
+            $totalCount = $responseTotalCount
+        }
+        elseif ($totalCount -ne $responseTotalCount) {
+            throw 'GitHub existing-PR search changed total_count while paging; refusing to make a duplicate decision.'
+        }
+
+        $existingPrs = @($itemsProperty.Value)
+        if ($existingPrs.Count -gt $pageSize) {
+            throw "GitHub existing-PR search returned more than $pageSize candidates on one page."
+        }
+
+        foreach ($existingPr in $existingPrs) {
+            if ($null -eq $existingPr) {
+                throw 'GitHub existing-PR search returned an invalid candidate.'
             }
 
-            $mergedAtProperty = $pullRequestProperty.Value.PSObject.Properties['merged_at']
-            if ($null -eq $mergedAtProperty) {
-                throw 'GitHub existing-PR search returned a closed PR without merged_at metadata.'
+            $titleProperty = $existingPr.PSObject.Properties['title']
+            $stateProperty = $existingPr.PSObject.Properties['state']
+            if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
+                throw 'GitHub existing-PR search returned a candidate without a title or state.'
             }
-            $mergedAt = $mergedAtProperty.Value
+
+            $state = "$($stateProperty.Value)".ToLowerInvariant()
+            if ($state -notin @('open', 'closed')) {
+                throw "GitHub existing-PR search returned an unrecognized PR state '$state'."
+            }
+
+            $pullRequestProperty = $existingPr.PSObject.Properties['pull_request']
+            $mergedAt = $null
+            if ($state -eq 'closed') {
+                if ($null -eq $pullRequestProperty -or $null -eq $pullRequestProperty.Value) {
+                    throw 'GitHub existing-PR search returned a closed PR without pull request metadata.'
+                }
+
+                $mergedAtProperty = $pullRequestProperty.Value.PSObject.Properties['merged_at']
+                if ($null -eq $mergedAtProperty) {
+                    throw 'GitHub existing-PR search returned a closed PR without merged_at metadata.'
+                }
+                $mergedAt = $mergedAtProperty.Value
+            }
+
+            if (-not (Test-WingetPkgsExistingPrTitle `
+                        -Title "$($titleProperty.Value)" `
+                        -PackageIdentifier $PackageIdentifier `
+                        -Version $Version)) {
+                continue
+            }
+
+            $isMatchingPr = $state -eq 'open' -or (-not $OnlyOpen -and -not [string]::IsNullOrWhiteSpace("$mergedAt"))
+            if ($isMatchingPr) {
+                Write-Host "Found existing PR: $($titleProperty.Value)"
+                Write-Host "-> $($existingPr.html_url)"
+                return $true
+            }
         }
 
-        if (-not (Test-WingetPkgsExistingPrTitle `
-                    -Title "$($titleProperty.Value)" `
-                    -PackageIdentifier $PackageIdentifier `
-                    -Version $Version)) {
-            continue
+        $retrievedCount += $existingPrs.Count
+        if ($retrievedCount -ge $totalCount) {
+            return $false
         }
-
-        $isMatchingPr = $state -eq 'open' -or (-not $OnlyOpen -and -not [string]::IsNullOrWhiteSpace("$mergedAt"))
-        if ($isMatchingPr) {
-            Write-Host "Found existing PR: $($titleProperty.Value)"
-            Write-Host "-> $($existingPr.html_url)"
-            return $true
+        if ($existingPrs.Count -lt $pageSize) {
+            throw "GitHub existing-PR search returned $retrievedCount of $totalCount candidate(s); refusing to make an incomplete duplicate decision."
         }
+        $page++
     }
-
-    return $false
 }

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -136,8 +136,9 @@ Describe 'Submit-WingetPackage ForkBranch' {
         if ($result.Success -ne $true) {
             throw "Expected a successful cross-repository ForkBranch submission, got: $($result.Error)"
         }
-        if ($global:ForkBranchDuplicateRepositories.Count -ne 1 -or $global:ForkBranchDuplicateRepositories[0] -cne 'microsoft/winget-pkgs') {
-            throw "Fork submission did not perform exactly one duplicate check against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        if ($global:ForkBranchDuplicateRepositories.Count -ne 2 -or
+            @($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'microsoft/winget-pkgs' }).Count -ne 0) {
+            throw "Fork submission did not perform preflight and final duplicate checks against the upstream target: $($global:ForkBranchDuplicateRepositories -join ', ')"
         }
         $upstreamReads = @(
             $global:ForkBranchSubmissionRequests |

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -64,7 +64,7 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Message "$workflowName may cancel an in-progress same-package submission." | Out-Null
     Assert-Match `
         -Actual $submitJob `
-        -Pattern '(?s)\$result = Submit-WingetPackage.*?-With "ForkBranch".*?-SubmissionTarget "\$env:WINGET_PKGS_SUBMISSION_TARGET"' `
+        -Pattern '(?s)\$result = Submit-WingetPackage.*?-With "ForkBranch".*?-SubmissionTarget "\$env:WINGET_PKGS_SUBMISSION_TARGET".*?-Repository "\$env:WINGET_PKGS_SUBMISSION_REPOSITORY"' `
         -Message "$workflowName must use the no-sync ForkBranch submission mode." | Out-Null
     Assert-Match `
         -Actual $submitJob `
@@ -74,6 +74,10 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Actual $submitJob `
         -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_TARGET: Upstream\s*$' `
         -Message "$workflowName must use the upstream pull request target for every trigger." | Out-Null
+    Assert-Match `
+        -Actual $submitJob `
+        -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs\s*$' `
+        -Message "$workflowName must explicitly preserve the production upstream repository." | Out-Null
     if ([regex]::IsMatch($submitJob, '(?i)WINGET_PKGS_SUBMISSION_TARGET:\s*Fork')) {
         throw "$workflowName may not create fork-only pull requests."
     }

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Submit-WingetPackage branch-moved retry' {
                     throw "The retry returned an unexpected PR URL: $($result.PrUrl)"
                 }
                 Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 2 -Exactly -Scope It
-                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 3 -Exactly -Scope It
             }
         }
 
@@ -105,7 +105,7 @@ Describe 'Submit-WingetPackage branch-moved retry' {
                     throw "Retry exhaustion did not report the bounded attempt count: $($result.Error)"
                 }
                 Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 2 -Exactly -Scope It
-                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 3 -Exactly -Scope It
             }
         }
 
@@ -114,7 +114,7 @@ Describe 'Submit-WingetPackage branch-moved retry' {
                 $script:existingChecks = 0
                 Mock Test-ExistingPRs {
                     $script:existingChecks++
-                    return $script:existingChecks -eq 2
+                    return $script:existingChecks -eq 3
                 }
                 Mock Get-WingetPkgsPrUrl { 'https://github.com/microsoft/winget-pkgs/pull/54321' }
                 Mock Invoke-WinMatschSubmitAttempt {
@@ -135,7 +135,32 @@ Describe 'Submit-WingetPackage branch-moved retry' {
                     throw "The existing PR URL was not returned: $($result.PrUrl)"
                 }
                 Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 1 -Exactly -Scope It
-                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 3 -Exactly -Scope It
+            }
+        }
+
+        It 'skips every submission attempt when the explicit target already has an open PR' {
+            InModuleScope WingetMaintainerModule {
+                Mock Test-ExistingPRs { $true }
+                Mock Get-WingetPkgsPrUrl { 'https://github.com/damn-good-b0t/winget-pkgs/pull/99' }
+                Mock Install-WinMatsch {}
+                Mock Invoke-WinMatschSubmitAttempt {}
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token' `
+                    -Repository 'damn-good-b0t/winget-pkgs'
+
+                if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/damn-good-b0t/winget-pkgs/pull/99') {
+                    throw "The explicit-target duplicate was not returned: $($result | ConvertTo-Json -Compress)"
+                }
+                Assert-MockCalled Test-ExistingPRs -Times 1 -Exactly -Scope It -ParameterFilter {
+                    $OnlyOpen -and $Repository -ceq 'damn-good-b0t/winget-pkgs'
+                }
+                Assert-MockCalled Install-WinMatsch -Times 0 -Exactly -Scope It
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 0 -Exactly -Scope It
             }
         }
 
@@ -159,7 +184,7 @@ Describe 'Submit-WingetPackage branch-moved retry' {
                     throw 'An uncertain remote outcome unexpectedly retried or reported success.'
                 }
                 Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 1 -Exactly -Scope It
-                Assert-MockCalled Test-ExistingPRs -Times 1 -Exactly -Scope It
+                Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
             }
         }
     }

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -357,6 +357,71 @@ Describe 'Test-ExistingPRs' {
         }
     }
 
+    It 'paginates the explicit test-fork search until it finds a matching open PR' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                $pageMatch = [regex]::Match(([uri] $Uri).Query, '(?:\?|&)page=(\d+)(?:&|$)')
+                if (-not $pageMatch.Success) {
+                    throw "The paginated request did not include a page number: $Uri"
+                }
+                $page = [int] $pageMatch.Groups[1].Value
+                if ($page -eq 1) {
+                    return [pscustomobject]@{
+                        total_count = 101
+                        items = @(
+                            foreach ($index in 1..100) {
+                                [pscustomobject]@{
+                                    title        = "Update version: Test.Package version 2.0.$index"
+                                    state        = 'open'
+                                    html_url     = "https://github.com/damn-good-b0t/winget-pkgs/pull/$index"
+                                    pull_request = [pscustomobject]@{ merged_at = $null }
+                                }
+                            }
+                        )
+                    }
+                }
+
+                return [pscustomobject]@{
+                    total_count = 101
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Update version: Test.Package version 1.0.0'
+                            state        = 'open'
+                            html_url     = 'https://github.com/damn-good-b0t/winget-pkgs/pull/101'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'damn-good-b0t/winget-pkgs' `
+            -OnlyOpen
+
+        if ($result -ne $true) {
+            throw 'The second page matching test-fork pull request was not found.'
+        }
+        if ($global:ExistingPrSearchRequests.Count -ne 2) {
+            throw "Expected two paginated test-fork requests, got $($global:ExistingPrSearchRequests.Count)."
+        }
+        $firstUri = [uri] $global:ExistingPrSearchRequests[0].Uri
+        $secondUri = [uri] $global:ExistingPrSearchRequests[1].Uri
+        if ($firstUri.Query -notmatch 'page=1' -or $secondUri.Query -notmatch 'page=2' -or
+            $global:ExistingPrSearchRequests[0].Uri -notmatch 'repo%3Adamn-good-b0t%2Fwinget-pkgs') {
+            throw 'The test-fork search did not request the expected paginated repository scope.'
+        }
+    }
+
     It 'fails closed when GitHub Search reports incomplete results despite a complete page' {
         InModuleScope WingetMaintainerModule {
             Mock Invoke-RestMethod {


### PR DESCRIPTION
## Summary
- gate submissions on existing open package/version PRs with paginated upstream search
- pass the production upstream repository explicitly from scheduled workflows
- cover duplicate preflight, pagination, and workflow target wiring

## Validation
- Pester 5 targeted suite: 28 passed
- submission workflow authorization regression test passed
- read-only test-fork query against damn-good-b0t/winget-pkgs

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>