### PR TITLE
Add safe R-Z test fork dispatch

### DIFF
--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -2,6 +2,20 @@ name: GH Packages R-Z
 
 on:
   workflow_dispatch:
+    inputs:
+      submission_repository:
+        description: "Pull request target; test fork requires acknowledgement"
+        required: true
+        default: microsoft/winget-pkgs
+        type: choice
+        options:
+          - microsoft/winget-pkgs
+          - damn-good-b0t/winget-pkgs
+      allow_test_fork_submission:
+        description: "Acknowledge that this dispatch may create PRs only in damn-good-b0t/winget-pkgs"
+        required: true
+        default: false
+        type: boolean
   schedule:
     - cron: "3 0/4 * * *" # every 4 hours
   push:
@@ -995,15 +1009,28 @@ jobs:
         id: check-submit
         shell: pwsh
         run: |
+          $targetRepository = "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
+          $isTestForkTarget = $targetRepository -ceq 'damn-good-b0t/winget-pkgs'
+          if ($isTestForkTarget -and "$env:WINGET_PKGS_ALLOW_TEST_FORK_SUBMISSION" -cne 'true') {
+            throw 'Test-fork submission requires the allow_test_fork_submission workflow_dispatch acknowledgement.'
+          }
+          if ($targetRepository -notin @('microsoft/winget-pkgs', 'damn-good-b0t/winget-pkgs')) {
+            throw "Unsupported submission repository '$targetRepository'."
+          }
           if ("$env:VARS_SUBMIT_PR" -ne "true") {
             Write-Host "::warning::SUBMIT_PR is not set to 'true', skipping PR submission"
             "skip=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           } else {
+            if ($isTestForkTarget) {
+              Write-Host 'Test-fork submission is explicitly acknowledged; any PR will be created only in damn-good-b0t/winget-pkgs.'
+            }
             Write-Host "SUBMIT_PR is enabled, proceeding with PR submission"
             "skip=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
         env:
           VARS_SUBMIT_PR: ${{ vars.SUBMIT_PR }}
+          WINGET_PKGS_SUBMISSION_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && inputs.submission_repository || 'microsoft/winget-pkgs' }}
+          WINGET_PKGS_ALLOW_TEST_FORK_SUBMISSION: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_test_fork_submission || 'false' }}
 
       - name: Checkout
         if: steps.check-submit.outputs.skip != 'true'
@@ -1064,7 +1091,7 @@ jobs:
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe-submit.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
           WINGET_PKGS_SUBMISSION_TARGET: Upstream
-          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs
+          WINGET_PKGS_SUBMISSION_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && inputs.submission_repository || 'microsoft/winget-pkgs' }}
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
           MATRIX_VERSION: ${{ matrix.version }}

--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -219,6 +219,9 @@ function Invoke-ForkBranchSubmission {
         [string] $ForkRepository,
 
         [Parameter(Mandatory = $false)]
+        [string] $TargetRepository = 'microsoft/winget-pkgs',
+
+        [Parameter(Mandatory = $false)]
         [string] $Resolves
     )
 
@@ -230,12 +233,16 @@ function Invoke-ForkBranchSubmission {
         throw "Configured repository '$ForkRepository' is not a fork of $upstreamRepository."
     }
 
-    # Upstream reads use the tiered read credentials (WINGET_UPSTREAM_READ_TOKEN,
-    # then WINGET_UPSTREAM_READ_FALLBACK_TOKEN, then anonymous); fork writes and
-    # the final cross-repository PR creation keep using $Token.
-    $targetRepository = $upstreamRepository
-    $upstream = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$upstreamRepository"
-    $targetDefaultBranch = "$($upstream.default_branch)"
+    if ($TargetRepository -ine $upstreamRepository -and $TargetRepository -ine $ForkRepository) {
+        throw "ForkBranch target '$TargetRepository' must be microsoft/winget-pkgs or the configured fork '$ForkRepository'."
+    }
+
+    # Target base reads use the tiered read credentials
+    # (WINGET_UPSTREAM_READ_TOKEN, then WINGET_UPSTREAM_READ_FALLBACK_TOKEN,
+    # then anonymous); fork writes and PR creation keep using $Token.
+    $targetRepository = $TargetRepository
+    $target = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$targetRepository"
+    $targetDefaultBranch = "$($target.default_branch)"
     $baseRepository = $targetRepository
 
     $baseReference = Invoke-WingetPkgsUpstreamReadApi -Path "repos/$baseRepository/git/ref/heads/$targetDefaultBranch"
@@ -263,7 +270,7 @@ function Invoke-ForkBranchSubmission {
         }
 
     # The fork default branch remains read-only. The manifest commit is rooted
-    # at the selected upstream base commit before its ref is atomically claimed.
+    # at the selected target base commit before its ref is atomically claimed.
     $tree = Invoke-WingetPkgsGitHubApi `
         -Method Post `
         -Path "repos/$ForkRepository/git/trees" `
@@ -284,7 +291,7 @@ function Invoke-ForkBranchSubmission {
 
     # Creating this deterministic ref is the atomic package/version claim.
     # A collision is never retried with another name because that could open a
-    # second upstream PR while the first worker's PR is not searchable yet.
+    # second target PR while the first worker's PR is not searchable yet.
     $branchName = Get-WingetPkgsSubmissionBranchName -PackageId $PackageId -Version $Version
     try {
         Invoke-WingetPkgsGitHubApi `
@@ -319,11 +326,11 @@ function Invoke-ForkBranchSubmission {
             SubmissionClaimed   = $true
             BranchName          = $branchName
             PullRequest         = $null
-            Error               = "The deterministic submission branch '$branchName' already exists, but no matching upstream PR is searchable. Refusing to create another PR; reconcile the existing branch before retrying."
+            Error               = "The deterministic submission branch '$branchName' already exists, but no matching target PR is searchable. Refusing to create another PR; reconcile the existing branch before retrying."
         }
     }
 
-    # Recheck immediately before the external PR write. The branch claim closes
+    # Recheck immediately before the target PR write. The branch claim closes
     # the remaining read-to-write race when GitHub Search has not indexed a PR.
     if (Test-ExistingPRs -PackageIdentifier $PackageId -Version $Version -Repository $targetRepository) {
         return [pscustomobject]@{
@@ -337,6 +344,7 @@ function Invoke-ForkBranchSubmission {
     }
 
     $forkOwner = $ForkRepository.Split('/')[0]
+    $headReference = if ($targetRepository -ieq $ForkRepository) { $branchName } else { "${forkOwner}:$branchName" }
     $body = if ([string]::IsNullOrWhiteSpace($Resolves)) { $null } else { "Resolves #$Resolves" }
     $pullRequest = Invoke-WingetPkgsGitHubApi `
         -Method Post `
@@ -344,7 +352,7 @@ function Invoke-ForkBranchSubmission {
         -Token $Token `
         -Body @{
             title = $PrTitle
-            head  = "${forkOwner}:$branchName"
+            head  = $headReference
             base  = $targetDefaultBranch
             body  = $body
         }

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -36,8 +36,10 @@
     commits content to microsoft/winget-pkgs.
 
     .PARAMETER Repository
-    The repository where existing pull requests are checked. ForkBranch only
-    supports microsoft/winget-pkgs as its write target.
+    The repository where existing pull requests are checked and, for
+    ForkBranch, where the pull request is created. ForkBranch supports
+    microsoft/winget-pkgs or the configured verified fork, allowing an
+    explicitly scoped test-fork submission.
 
 .PARAMETER Token
     GitHub Personal Access Token with repo scope. If not provided, uses
@@ -156,15 +158,6 @@ function Submit-WingetPackage {
                     PrNumber = $null
                 }
             }
-            if ($Repository -ine 'microsoft/winget-pkgs') {
-                return @{
-                    Success  = $false
-                    Error    = 'ForkBranch submissions can only target microsoft/winget-pkgs.'
-                    PrUrl    = $null
-                    PrNumber = $null
-                }
-            }
-
             $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
             if ([string]::IsNullOrWhiteSpace($forkRepository)) {
                 return @{
@@ -176,6 +169,14 @@ function Submit-WingetPackage {
             }
 
             Assert-SafeWingetPkgsForkRepository -ForkRepository $forkRepository
+            if ($Repository -ine 'microsoft/winget-pkgs' -and $Repository -ine $forkRepository) {
+                return @{
+                    Success  = $false
+                    Error    = "ForkBranch submissions can only target microsoft/winget-pkgs or the configured fork '$forkRepository'."
+                    PrUrl    = $null
+                    PrNumber = $null
+                }
+            }
         }
 
         # A durable upstream check protects all submitters; tool-specific
@@ -319,6 +320,7 @@ function Submit-WingetPackage {
                     -PrTitle $PrTitle `
                     -Token $Token `
                     -ForkRepository $forkRepository `
+                    -TargetRepository $Repository `
                     -Resolves $Resolves
 
                 if (-not $forkSubmission.Created) {
@@ -334,7 +336,7 @@ function Submit-WingetPackage {
                     $existingPrUrl = Get-WingetPkgsPrUrl `
                         -PackageId $PackageId `
                         -Version $Version `
-                        -Repository 'microsoft/winget-pkgs'
+                        -Repository $Repository
                     $existingPrNumber = if ($existingPrUrl -match '/pull/(?<Number>\d+)$') {
                         $Matches['Number']
                     }

--- a/tests/ForkBranchSubmission.Tests.ps1
+++ b/tests/ForkBranchSubmission.Tests.ps1
@@ -78,7 +78,7 @@ Describe 'Submit-WingetPackage ForkBranch' {
                     }
                     '/pulls$' {
                         return [pscustomobject]@{
-                            html_url = 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                            html_url = "https://github.com/$($Path.Substring(6, $Path.Length - 12))/pull/12345"
                             number   = 12345
                         }
                     }
@@ -199,6 +199,59 @@ Describe 'Submit-WingetPackage ForkBranch' {
         )
         if ($upstreamWrites.Count -ne 1 -or $upstreamWrites[0].Path -cne 'repos/microsoft/winget-pkgs/pulls') {
             throw "Upstream write surface is not limited to creating the intended pull request: $($upstreamWrites.Path -join ', ')"
+        }
+    }
+
+    It 'creates an explicitly targeted pull request only in the configured test fork' {
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch `
+            -Repository 'damn-good-b0t/winget-pkgs'
+
+        if ($result.Success -ne $true -or $result.PrUrl -cne 'https://github.com/damn-good-b0t/winget-pkgs/pull/12345') {
+            throw "Expected a successful test-fork submission, got: $($result | ConvertTo-Json -Compress)"
+        }
+        if (@($global:ForkBranchDuplicateRepositories | Where-Object { $_ -cne 'damn-good-b0t/winget-pkgs' }).Count -ne 0) {
+            throw "Test-fork duplicate detection queried another repository: $($global:ForkBranchDuplicateRepositories -join ', ')"
+        }
+
+        $testForkPullRequest = $global:ForkBranchSubmissionRequests |
+            Where-Object { $_.Method -eq 'Post' -and $_.Path -eq 'repos/damn-good-b0t/winget-pkgs/pulls' } |
+            Select-Object -Last 1
+        if ($null -eq $testForkPullRequest) {
+            throw 'The explicit test-fork target did not receive the pull request write.'
+        }
+        if ($testForkPullRequest.Body.head -match ':') {
+            throw "A same-repository test-fork PR must use its local branch name, got: $($testForkPullRequest.Body.head)"
+        }
+        if ($testForkPullRequest.Body.base -cne 'master') {
+            throw "The test-fork PR used an unexpected base branch: $($testForkPullRequest.Body.base)"
+        }
+        if (@($global:ForkBranchSubmissionRequests | Where-Object { $_.Path -match '^repos/microsoft/winget-pkgs($|/)' }).Count -ne 0) {
+            throw "The explicit test-fork route touched the production repository: $($global:ForkBranchSubmissionRequests | ConvertTo-Json -Compress)"
+        }
+    }
+
+    It 'rejects an unconfigured ForkBranch target before querying GitHub' {
+        $result = Submit-WingetPackage `
+            -ManifestPath $global:ForkBranchSubmissionManifestPath `
+            -PackageId 'Test.Package' `
+            -Version '1.0.0' `
+            -Token 'test-token' `
+            -With ForkBranch `
+            -Repository 'untrusted/example'
+
+        if ($result.Success -ne $false) {
+            throw 'An unconfigured ForkBranch target unexpectedly succeeded.'
+        }
+        if ($result.Error -notmatch 'configured fork') {
+            throw "The unconfigured target was not identified clearly: $($result.Error)"
+        }
+        if ($global:ForkBranchSubmissionRequests.Count -ne 0) {
+            throw 'An unconfigured ForkBranch target queried or wrote GitHub.'
         }
     }
 

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -74,10 +74,31 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Actual $submitJob `
         -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_TARGET: Upstream\s*$' `
         -Message "$workflowName must use the upstream pull request target for every trigger." | Out-Null
-    Assert-Match `
-        -Actual $submitJob `
-        -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs\s*$' `
-        -Message "$workflowName must explicitly preserve the production upstream repository." | Out-Null
+    $isRzWorkflow = $workflowRelativePath -ceq '.github/workflows/update-github-packages-r-z.yml'
+    if ($isRzWorkflow) {
+        Assert-Match `
+            -Actual $workflow `
+            -Pattern '(?ms)^  workflow_dispatch:\r?\n    inputs:\r?\n      submission_repository:.*?^          - microsoft/winget-pkgs\r?\n          - damn-good-b0t/winget-pkgs\s*$' `
+            -Message "$workflowName must expose only the production and designated test-fork targets." | Out-Null
+        Assert-Match `
+            -Actual $workflow `
+            -Pattern '(?ms)^      allow_test_fork_submission:.*?^        type: boolean\s*$' `
+            -Message "$workflowName must require an explicit test-fork acknowledgement." | Out-Null
+        Assert-Match `
+            -Actual $submitJob `
+            -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: \$\{\{\s*github\.event_name == ''workflow_dispatch'' && inputs\.submission_repository \|\| ''microsoft/winget-pkgs''\s*\}\}\s*$' `
+            -Message "$workflowName must keep scheduled and push submissions pinned to production." | Out-Null
+        Assert-Match `
+            -Actual $submitJob `
+            -Pattern '(?ms)allow_test_fork_submission workflow_dispatch acknowledgement.*?WINGET_PKGS_ALLOW_TEST_FORK_SUBMISSION: \$\{\{\s*github\.event_name == ''workflow_dispatch'' && inputs\.allow_test_fork_submission \|\| ''false''\s*\}\}' `
+            -Message "$workflowName must block test-fork submission without acknowledgement." | Out-Null
+    }
+    else {
+        Assert-Match `
+            -Actual $submitJob `
+            -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: microsoft/winget-pkgs\s*$' `
+            -Message "$workflowName must explicitly preserve the production upstream repository." | Out-Null
+    }
     if ([regex]::IsMatch($submitJob, '(?i)WINGET_PKGS_SUBMISSION_TARGET:\s*Fork')) {
         throw "$workflowName may not create fork-only pull requests."
     }


### PR DESCRIPTION
## Summary
- add dispatch-only R-Z target selection for the designated test fork
- require explicit boolean acknowledgement before a test-fork submission
- constrain ForkBranch targets to production or the verified configured fork

## Safe invocation
```text
gh workflow run "GH Packages R-Z" --repo b0t-at/winget-pkgs-updates --ref main -f submission_repository=damn-good-b0t/winget-pkgs -f allow_test_fork_submission=true
```

Scheduled and push runs remain pinned to `microsoft/winget-pkgs`.

## Validation
- focused Pester suite: 30 passed
- submission workflow authorization regression test passed

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
