### PR TITLE
Scope test generation to target

### DIFF
--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -386,6 +386,7 @@ jobs:
           WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
           WINGET_UPSTREAM_READ_FALLBACK_TOKEN: ${{ steps.upstream-read-probe.outputs.available == 'true' && github.token || secrets.WINGET_PUBLIC_READ_TOKEN }}
           WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          WINGET_PKGS_SUBMISSION_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && inputs.submission_repository || 'microsoft/winget-pkgs' }}
           GHURLs: ${{ matrix.url }}
           GHRepo: ${{ matrix.repo }}
           GHTagPattern: ${{ fromJSON(toJSON(matrix)).tagPattern }}

--- a/modules/WingetMaintainerModule/Private/VersionNormalization.ps1
+++ b/modules/WingetMaintainerModule/Private/VersionNormalization.ps1
@@ -30,11 +30,14 @@ function Get-WingetGitHubHeaders {
 
 function Get-WingetPublishedVersionsFromGitHub {
     param(
-        [Parameter(Mandatory = $true)] [string] $PackageIdentifier
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+        [string] $Repository = 'microsoft/winget-pkgs'
     )
 
     $packageRelativePath = Get-WingetPackageRelativePath -PackageIdentifier $PackageIdentifier
-    $uri = "https://api.github.com/repos/microsoft/winget-pkgs/contents/$packageRelativePath`?ref=master"
+    $uri = "https://api.github.com/repos/$Repository/contents/$packageRelativePath`?ref=master"
     $response = Invoke-WebRequest -Uri $uri -Headers (Get-WingetGitHubHeaders) -Method Get -SkipHttpErrorCheck
     $statusCode = [int]$response.StatusCode
 
@@ -46,7 +49,7 @@ function Get-WingetPublishedVersionsFromGitHub {
     }
 
     if ($statusCode -lt 200 -or $statusCode -ge 300) {
-        throw "GitHub API request failed for $PackageIdentifier with HTTP status $statusCode."
+        throw "GitHub API request failed for $PackageIdentifier in $Repository with HTTP status $statusCode."
     }
 
     $entries = @($response.Content | ConvertFrom-Json)

--- a/modules/WingetMaintainerModule/Public/Test-PackageAndVersionInGithub.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-PackageAndVersionInGithub.ps1
@@ -18,10 +18,15 @@ function Test-PackageAndVersionInGithub {
     #>
     param(
         [Parameter(Mandatory = $true)] [string] $latestVersion,
-        [Parameter(Mandatory = $false)] [string] $wingetPackage = ${Env:PackageName}
+        [Parameter(Mandatory = $false)] [string] $wingetPackage = ${Env:PackageName},
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+        [string] $Repository = 'microsoft/winget-pkgs'
     )
-    Write-Host "Checking if $wingetPackage is already in winget (via GH) and version $latestVersion is already present"
-    $publishedVersionInfo = Get-WingetPublishedVersionsFromGitHub -PackageIdentifier $wingetPackage
+    Write-Host "Checking if $wingetPackage version $latestVersion is already present in $Repository"
+    $publishedVersionInfo = Get-WingetPublishedVersionsFromGitHub `
+        -PackageIdentifier $wingetPackage `
+        -Repository $Repository
     $publishedVersions = @($publishedVersionInfo.Versions)
     $latestPublishedVersion = $publishedVersions |
         Sort-Object { Get-WingetSortableVersionKey -Version $_ } -Descending |
@@ -39,7 +44,7 @@ function Test-PackageAndVersionInGithub {
     }
 
     if (-not $publishedVersionInfo.PackageExists) {
-        Write-Host "Package not yet in winget. Please add new package manually"
+        Write-Host "Package not yet in $Repository. Please add new package manually"
         $result.PackageExists = $false
         return $result
     }
@@ -52,10 +57,10 @@ function Test-PackageAndVersionInGithub {
         $result.CanonicalVersion = $versionMatch.Version
 
         if ($versionMatch.MatchType -eq 'Exact') {
-            Write-Host "Latest version of $wingetPackage $latestVersion is already present in winget."
+            Write-Host "Latest version of $wingetPackage $latestVersion is already present in $Repository."
         }
         else {
-            Write-Host "Latest version of $wingetPackage $latestVersion is already present in winget as $($versionMatch.Version) ($($versionMatch.MatchType))."
+            Write-Host "Latest version of $wingetPackage $latestVersion is already present in $Repository as $($versionMatch.Version) ($($versionMatch.MatchType))."
         }
 
         return $result
@@ -68,7 +73,7 @@ function Test-PackageAndVersionInGithub {
         Write-Host "Aligning PackageVersion notation with published winget versions: $latestVersion -> $canonicalVersion"
     }
 
-    Write-Host "Package $wingetPackage is in winget, but version $latestVersion is not present."
+    Write-Host "Package $wingetPackage is in $Repository, but version $latestVersion is not present."
     $result.ShouldGenerate = $true
     return $result
 }

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -33,7 +33,10 @@ function Update-WingetPackage {
         [Parameter(Mandatory = $false)] [string] $GHTagPattern,
         [Parameter(Mandatory = $false)][ValidateSet('Tag', 'ReleaseName')] [string] $GHVersionSource = 'Tag',
         [Parameter(Mandatory = $false)] [string] $WinMatschOverridePack,
-        [Parameter(Mandatory = $false)] [bool] $AllowStructuralRewrite = $false
+        [Parameter(Mandatory = $false)] [bool] $AllowStructuralRewrite = $false,
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+        [string] $Repository = 'microsoft/winget-pkgs'
     )
 
     # Initialize result object
@@ -143,7 +146,10 @@ function Update-WingetPackage {
     $prMessage = "Update version: $wingetPackage version $($Latest.Version)"
     $result.PrTitle = $prMessage
 
-    $PackageAndVersionInWinget = Test-PackageAndVersionInGithub -wingetPackage $wingetPackage -latestVersion $($Latest.Version)
+    $PackageAndVersionInWinget = Test-PackageAndVersionInGithub `
+        -wingetPackage $wingetPackage `
+        -latestVersion $($Latest.Version) `
+        -Repository $Repository
     $canonicalVersionProperty = $PackageAndVersionInWinget.PSObject.Properties['CanonicalVersion']
     $canonicalVersion = if ($canonicalVersionProperty) { [string]$canonicalVersionProperty.Value } else { $Latest.Version }
     $publishedVersionProperty = $PackageAndVersionInWinget.PSObject.Properties['PublishedVersion']
@@ -178,7 +184,10 @@ function Update-WingetPackage {
 
     if ($PackageAndVersionInWinget.ShouldGenerate) {
 
-        $PRExists = Test-ExistingPRs -PackageIdentifier $wingetPackage -Version $($Latest.Version)
+        $PRExists = Test-ExistingPRs `
+            -PackageIdentifier $wingetPackage `
+            -Version $($Latest.Version) `
+            -Repository $Repository
 
         if (!$PRExists) {
             Write-Host "Downloading $EffectiveWith and generate manifest for $wingetPackage Version $($Latest.Version)"

--- a/scripts/Update-Package.ps1
+++ b/scripts/Update-Package.ps1
@@ -60,5 +60,8 @@ if ($Env:WinMatschOverridePack) {
 if ($Env:AllowStructuralRewrite -eq $true) {
     $params.Add("AllowStructuralRewrite", $true)
 }
+if ($Env:WINGET_PKGS_SUBMISSION_REPOSITORY) {
+    $params.Add("Repository", $Env:WINGET_PKGS_SUBMISSION_REPOSITORY)
+}
 
 Update-WingetPackage @params

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -88,6 +88,15 @@ foreach ($workflowRelativePath in $workflowPaths) {
             -Actual $submitJob `
             -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: \$\{\{\s*github\.event_name == ''workflow_dispatch'' && inputs\.submission_repository \|\| ''microsoft/winget-pkgs''\s*\}\}\s*$' `
             -Message "$workflowName must keep scheduled and push submissions pinned to production." | Out-Null
+        $generateStepMatch = Assert-Match `
+            -Actual $workflow `
+            -Pattern '(?ms)^      - name: Generate manifest\r?\n(?<step>.*?)(?=^      - |\z)' `
+            -Message "$workflowName does not contain the Generate manifest step."
+        $generateStep = $generateStepMatch.Groups['step'].Value
+        Assert-Match `
+            -Actual $generateStep `
+            -Pattern '(?m)^          WINGET_PKGS_SUBMISSION_REPOSITORY: \$\{\{\s*github\.event_name == ''workflow_dispatch'' && inputs\.submission_repository \|\| ''microsoft/winget-pkgs''\s*\}\}\s*$' `
+            -Message "$workflowName must use the selected target for its generation duplicate checks." | Out-Null
         Assert-Match `
             -Actual $submitJob `
             -Pattern '(?ms)allow_test_fork_submission workflow_dispatch acknowledgement.*?WINGET_PKGS_ALLOW_TEST_FORK_SUBMISSION: \$\{\{\s*github\.event_name == ''workflow_dispatch'' && inputs\.allow_test_fork_submission \|\| ''false''\s*\}\}' `

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -251,4 +251,85 @@ if ($preGenerationGuardResult.Result.Generated -or $preGenerationGuardResult.Res
     throw "The pre-generation existing-PR guard did not stop generation: $($preGenerationGuardResult.Result | ConvertTo-Json -Compress)"
 }
 
+Write-Host 'TEST: selected repository scopes version and existing-PR checks'
+$selectedRepositoryResult = & $module {
+    $script:VersionCheckRepository = $null
+    $script:ExistingPrRepository = $null
+
+    function Test-GitHubToken { 'test-token' }
+    function Test-PackageAndVersionInGithub {
+        param($latestVersion, $wingetPackage, $Repository)
+
+        $script:VersionCheckRepository = $Repository
+        [PSCustomObject]@{
+            PackageExists          = $true
+            ShouldGenerate         = $true
+            VersionExists          = $false
+            CanonicalVersion       = '1.0.0'
+            PublishedVersion       = $null
+            LatestPublishedVersion = $null
+        }
+    }
+    function Test-ExistingPRs {
+        param($PackageIdentifier, $Version, $Repository)
+
+        $script:ExistingPrRepository = $Repository
+        return $true
+    }
+    function Install-WinMatsch {
+        throw 'Manifest generation started despite the selected target having an existing PR.'
+    }
+
+    $result = Update-WingetPackage `
+        -WingetPackage 'Test.Package' `
+        -With 'WinMatsch' `
+        -latestVersion '1.0.0' `
+        -latestVersionURL 'https://example.invalid/app.zip' `
+        -Repository 'damn-good-b0t/winget-pkgs'
+
+    [PSCustomObject]@{
+        Result                 = $result
+        VersionCheckRepository = $script:VersionCheckRepository
+        ExistingPrRepository   = $script:ExistingPrRepository
+    }
+}
+if ($selectedRepositoryResult.VersionCheckRepository -cne 'damn-good-b0t/winget-pkgs' -or
+    $selectedRepositoryResult.ExistingPrRepository -cne 'damn-good-b0t/winget-pkgs') {
+    throw "Generation did not scope its duplicate checks to the selected repository: $($selectedRepositoryResult | ConvertTo-Json -Compress)"
+}
+if ($selectedRepositoryResult.Result.Generated -or $selectedRepositoryResult.Result.Reason -cne 'PRExists') {
+    throw "The selected-repository existing-PR guard did not stop generation: $($selectedRepositoryResult.Result | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: version lookup queries the selected repository'
+$publishedVersionLookupResult = & $module {
+    $script:PublishedVersionRepository = $null
+
+    function Get-WingetPublishedVersionsFromGitHub {
+        param($PackageIdentifier, $Repository)
+
+        $script:PublishedVersionRepository = $Repository
+        [PSCustomObject]@{
+            PackageExists = $true
+            Versions      = @('0.69.0')
+        }
+    }
+
+    $result = Test-PackageAndVersionInGithub `
+        -wingetPackage 'Wilfred.difftastic' `
+        -latestVersion '0.70.0' `
+        -Repository 'damn-good-b0t/winget-pkgs'
+
+    [PSCustomObject]@{
+        Result       = $result
+        Repository   = $script:PublishedVersionRepository
+    }
+}
+if ($publishedVersionLookupResult.Repository -cne 'damn-good-b0t/winget-pkgs') {
+    throw "The version lookup did not query the selected repository: $($publishedVersionLookupResult | ConvertTo-Json -Compress)"
+}
+if (-not $publishedVersionLookupResult.Result.ShouldGenerate) {
+    throw "The version lookup incorrectly suppressed a version missing from the selected repository: $($publishedVersionLookupResult.Result | ConvertTo-Json -Compress)"
+}
+
 Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Summary
- scope generation-time published-version and open-PR checks to the selected upstream repository
- pass the dispatch-only R-Z target into generation while schedules and pushes remain pinned to production
- cover the test-fork missing-version regression using Wilfred.difftastic 0.70.0

## Validation
- pwsh -NoProfile -File tests\\Update-WingetPackage.Tests.ps1
- pwsh -NoProfile -File tests\\SubmissionWorkflowAuthorization.Tests.ps1
- Invoke-Pester targeted duplicate-submission suite (30 passing)