### PR TITLE
Normalize submitted manifest line endings

### DIFF
--- a/modules/WingetMaintainerModule/Private/ManifestLineEndings.ps1
+++ b/modules/WingetMaintainerModule/Private/ManifestLineEndings.ps1
@@ -15,36 +15,28 @@ function Normalize-WingetManifestLineEndings {
     )
 
     foreach ($manifestFile in $manifestFiles) {
-        $fileBytes = [System.IO.File]::ReadAllBytes($manifestFile.FullName)
-        $encoding = if ($fileBytes.Length -ge 4 -and
-            $fileBytes[0] -eq 0xFF -and $fileBytes[1] -eq 0xFE -and
-            $fileBytes[2] -eq 0x00 -and $fileBytes[3] -eq 0x00) {
-            [System.Text.UTF32Encoding]::new($false, $true)
+        # BOM-less fallback encoding: if the reader detects a BOM it swaps in the
+        # matching encoding (whose preamble round-trips the BOM on write); otherwise
+        # the file is written back as UTF-8 without BOM.
+        $reader = [System.IO.StreamReader]::new(
+            $manifestFile.FullName,
+            [System.Text.UTF8Encoding]::new($false),
+            $true
+        )
+        try {
+            $content = $reader.ReadToEnd()
+            $encoding = $reader.CurrentEncoding
         }
-        elseif ($fileBytes.Length -ge 4 -and
-            $fileBytes[0] -eq 0x00 -and $fileBytes[1] -eq 0x00 -and
-            $fileBytes[2] -eq 0xFE -and $fileBytes[3] -eq 0xFF) {
-            [System.Text.UTF32Encoding]::new($true, $true)
-        }
-        elseif ($fileBytes.Length -ge 3 -and
-            $fileBytes[0] -eq 0xEF -and $fileBytes[1] -eq 0xBB -and $fileBytes[2] -eq 0xBF) {
-            [System.Text.UTF8Encoding]::new($true)
-        }
-        elseif ($fileBytes.Length -ge 2 -and $fileBytes[0] -eq 0xFF -and $fileBytes[1] -eq 0xFE) {
-            [System.Text.UnicodeEncoding]::new($false, $true)
-        }
-        elseif ($fileBytes.Length -ge 2 -and $fileBytes[0] -eq 0xFE -and $fileBytes[1] -eq 0xFF) {
-            [System.Text.UnicodeEncoding]::new($true, $true)
-        }
-        else {
-            [System.Text.UTF8Encoding]::new($false)
+        finally {
+            $reader.Dispose()
         }
 
-        $content = [System.IO.File]::ReadAllText($manifestFile.FullName)
         $normalizedContent = [regex]::Replace($content, "`r`n|`r|`n", "`r`n")
         $normalizedContent = [regex]::Replace($normalizedContent, "(?:`r`n)+$", '')
         $normalizedContent += "`r`n"
 
-        [System.IO.File]::WriteAllText($manifestFile.FullName, $normalizedContent, $encoding)
+        if ($normalizedContent -cne $content) {
+            [System.IO.File]::WriteAllText($manifestFile.FullName, $normalizedContent, $encoding)
+        }
     }
 }

--- a/modules/WingetMaintainerModule/Private/ManifestLineEndings.ps1
+++ b/modules/WingetMaintainerModule/Private/ManifestLineEndings.ps1
@@ -1,0 +1,50 @@
+function Normalize-WingetManifestLineEndings {
+    <#
+    .SYNOPSIS
+        Normalizes submitted manifest YAML files to CRLF with one final newline.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $ManifestPath
+    )
+
+    $manifestFiles = @(
+        Get-ChildItem -LiteralPath $ManifestPath -Recurse -File -ErrorAction Stop |
+            Where-Object { $_.Extension -in @('.yaml', '.yml') }
+    )
+
+    foreach ($manifestFile in $manifestFiles) {
+        $fileBytes = [System.IO.File]::ReadAllBytes($manifestFile.FullName)
+        $encoding = if ($fileBytes.Length -ge 4 -and
+            $fileBytes[0] -eq 0xFF -and $fileBytes[1] -eq 0xFE -and
+            $fileBytes[2] -eq 0x00 -and $fileBytes[3] -eq 0x00) {
+            [System.Text.UTF32Encoding]::new($false, $true)
+        }
+        elseif ($fileBytes.Length -ge 4 -and
+            $fileBytes[0] -eq 0x00 -and $fileBytes[1] -eq 0x00 -and
+            $fileBytes[2] -eq 0xFE -and $fileBytes[3] -eq 0xFF) {
+            [System.Text.UTF32Encoding]::new($true, $true)
+        }
+        elseif ($fileBytes.Length -ge 3 -and
+            $fileBytes[0] -eq 0xEF -and $fileBytes[1] -eq 0xBB -and $fileBytes[2] -eq 0xBF) {
+            [System.Text.UTF8Encoding]::new($true)
+        }
+        elseif ($fileBytes.Length -ge 2 -and $fileBytes[0] -eq 0xFF -and $fileBytes[1] -eq 0xFE) {
+            [System.Text.UnicodeEncoding]::new($false, $true)
+        }
+        elseif ($fileBytes.Length -ge 2 -and $fileBytes[0] -eq 0xFE -and $fileBytes[1] -eq 0xFF) {
+            [System.Text.UnicodeEncoding]::new($true, $true)
+        }
+        else {
+            [System.Text.UTF8Encoding]::new($false)
+        }
+
+        $content = [System.IO.File]::ReadAllText($manifestFile.FullName)
+        $normalizedContent = [regex]::Replace($content, "`r`n|`r|`n", "`r`n")
+        $normalizedContent = [regex]::Replace($normalizedContent, "(?:`r`n)+$", '')
+        $normalizedContent += "`r`n"
+
+        [System.IO.File]::WriteAllText($manifestFile.FullName, $normalizedContent, $encoding)
+    }
+}

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -296,12 +296,20 @@ function Submit-WingetPackage {
             }
 
             "WinGetCreate" {
-                # Ensure WinGetCreate is installed
-                Install-WingetCreate
+                # Prefer a PATH-installed wingetcreate; otherwise download it and pin
+                # the absolute path so the call is independent of the working directory.
+                $wingetCreateCommand = Get-Command 'wingetcreate.exe' -CommandType Application -ErrorAction SilentlyContinue
+                if ($wingetCreateCommand) {
+                    $wingetCreatePath = $wingetCreateCommand.Source
+                }
+                else {
+                    Install-WingetCreate
+                    $wingetCreatePath = (Resolve-Path -LiteralPath '.\wingetcreate.exe').Path
+                }
 
                 Write-Host "--> Running: wingetcreate submit" -ForegroundColor White
 
-                $output = & .\wingetcreate.exe submit --prtitle $PrTitle -t $Token $fullManifestPath 2>&1
+                $output = & $wingetCreatePath submit --prtitle $PrTitle -t $Token $fullManifestPath 2>&1
                 $exitCode = $LASTEXITCODE
 
                 Write-Host $output

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -199,6 +199,10 @@ function Submit-WingetPackage {
             }
         }
 
+        # Generators can emit mixed line endings. Normalize only after validation
+        # and immediately before any submitter or fork commit consumes the files.
+        Normalize-WingetManifestLineEndings -ManifestPath $fullManifestPath
+
         switch ($With) {
             "WinMatsch" {
                 # Ensure WinMatsch is installed

--- a/scripts/manifest_updater.ps1
+++ b/scripts/manifest_updater.ps1
@@ -203,8 +203,17 @@ function Create-GitHubPRPlaceholder {
         Write-Host "    PR body suggestion: $prBody"
         #Write-Host "    >>>> INSERT YOUR PR CREATION CODE HERE <<<<" -ForegroundColor Cyan
         Write-Host "  No existing PR found for $PackageId $PackageVersion. Proceeding with PR creation." -ForegroundColor Green
-        wingetcreate.exe submit --prtitle $prTitle -t $gitToken $ManifestPath.replace($ManifestPath.split("\")[-1], "")
-        #.\wingetcreate.exe submit --prtitle $prMessage -t $gitToken $ManifestPath
+        Import-Module (Join-Path $PSScriptRoot '..\modules\WingetMaintainerModule\WingetMaintainerModule.psd1') -Force
+        $submission = Submit-WingetPackage `
+            -ManifestPath (Split-Path -Parent $ManifestPath) `
+            -PackageId $PackageId `
+            -Version $PackageVersion `
+            -PrTitle $prTitle `
+            -Token $gitToken `
+            -With WinGetCreate
+        if (-not $submission.Success) {
+            throw "WinGetCreate submission failed: $($submission.Error)"
+        }
     }
 }
 
@@ -535,4 +544,3 @@ if ($MyInvocation.MyCommand.CommandType -eq 'ExternalScript') {
         # (Ensure https://example.com/latest.exe is actually reachable or mock the Download-FileContent function)
     }
 }
-

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -164,6 +164,52 @@ Describe 'Submit-WingetPackage branch-moved retry' {
             }
         }
 
+        It 'normalizes mixed-ending locale YAML before WinMatsch submission' {
+            $localeManifestPath = Join-Path $global:SubmitWingetPackageTestManifestPath 'Test.Package.locale.en-US.yaml'
+            $mixedContent = "PackageLocale: en-US`r`nPublisher: Test Publisher`nPackageName: Test Package`r`nShortDescription: Mixed line endings`n"
+            [System.IO.File]::WriteAllText(
+                $localeManifestPath,
+                $mixedContent,
+                [System.Text.UTF8Encoding]::new($false)
+            )
+
+            InModuleScope WingetMaintainerModule {
+                Mock Invoke-WinMatschSubmitAttempt {
+                    & $global:NewTestSubmissionAttempt -ExitCode 0 -PrUrl 'https://github.com/microsoft/winget-pkgs/pull/12345'
+                }
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token'
+
+                if ($result.Success -ne $true) {
+                    throw "Expected the WinMatsch submission to succeed, got: $($result.Error)"
+                }
+            }
+
+            $normalizedBytes = [System.IO.File]::ReadAllBytes($localeManifestPath)
+            $bareLineFeedCount = 0
+            for ($index = 0; $index -lt $normalizedBytes.Length; $index++) {
+                if ($normalizedBytes[$index] -eq 10 -and ($index -eq 0 -or $normalizedBytes[$index - 1] -ne 13)) {
+                    $bareLineFeedCount++
+                }
+            }
+            if ($bareLineFeedCount -ne 0) {
+                throw "The submitted locale YAML still contains $bareLineFeedCount bare LF character(s)."
+            }
+
+            $normalizedContent = [System.Text.Encoding]::UTF8.GetString($normalizedBytes)
+            $expectedContent = "PackageLocale: en-US`r`nPublisher: Test Publisher`r`nPackageName: Test Package`r`nShortDescription: Mixed line endings`r`n"
+            if ($normalizedContent -cne $expectedContent) {
+                throw "Locale YAML content changed beyond line endings: $normalizedContent"
+            }
+            if (-not $normalizedContent.EndsWith("`r`n") -or $normalizedContent.EndsWith("`r`n`r`n")) {
+                throw 'The submitted locale YAML does not have exactly one final CRLF.'
+            }
+        }
+
         It 'fails closed instead of retrying an uncertain GH2020 remote outcome' {
             InModuleScope WingetMaintainerModule {
                 Mock Invoke-WinMatschSubmitAttempt {


### PR DESCRIPTION
## Summary
- Normalize every submitted YAML file to CRLF with exactly one final newline at the shared submission boundary.
- Route the legacy WinGetCreate hash-update submission through the shared gateway.
- Cover mixed-ending locale manifests before WinMatsch submission.

## Tests
- `pwsh -NoProfile -Command "Invoke-Pester -Path @('.\tests\Submit-WingetPackage.Tests.ps1', '.\tests\ForkBranchSubmission.Tests.ps1', '.\tests\SubmissionWorkflowAuthorization.Tests.ps1') -Output Normal"`