### PR TITLE
Authenticate published manifest validation reads

### DIFF
--- a/.github/actions/validate-and-submit/action.yml
+++ b/.github/actions/validate-and-submit/action.yml
@@ -93,6 +93,7 @@ runs:
         }
       env:
         INPUTS_MANIFEST_PATH: ${{ inputs.manifest-path }}
+        WINGET_PKGS_GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_TOKEN: ${{ github.token }}
 
     # Step 2: Run sandbox validation (if not skipped)

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -384,6 +384,7 @@ jobs:
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
+          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows/update-github-packages-1-q.yml
+++ b/.github/workflows/update-github-packages-1-q.yml
@@ -1115,6 +1115,7 @@ jobs:
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
+          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows/update-github-packages-r-z.yml
+++ b/.github/workflows/update-github-packages-r-z.yml
@@ -732,6 +732,7 @@ jobs:
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
           MATRIX_ALLOW_STRUCTURAL_REWRITE: ${{ fromJSON(toJSON(matrix)).allowStructuralRewrite }}
+          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run sandbox validation

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -396,6 +396,7 @@ jobs:
           }
         env:
           STEPS_MANIFEST_OUTPUTS_PATH: ${{ steps.manifest.outputs.path }}
+          WINGET_PKGS_GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
           GITHUB_TOKEN: ${{ github.token }}
       
       - name: Run sandbox validation

--- a/tests/SubmissionWorkflowAuthorization.Tests.ps1
+++ b/tests/SubmissionWorkflowAuthorization.Tests.ps1
@@ -43,6 +43,22 @@ if ($probeAction -match '(?im)-Method\s+(Post|Put|Patch|Delete)\b') {
     throw 'The upstream read probe must not perform writes.'
 }
 
+$validateAndSubmitActionPath = Join-Path $repositoryRoot '.github/actions/validate-and-submit/action.yml'
+$validateAndSubmitAction = Get-Content -LiteralPath $validateAndSubmitActionPath -Raw
+$compositeContentValidationMatch = Assert-Match `
+    -Actual $validateAndSubmitAction `
+    -Pattern '(?ms)^    - name: Validate manifest content\r?\n(?<step>.*?)(?=^    - |\z)' `
+    -Message 'The validate-and-submit action does not contain its content-validation step.'
+$compositeContentValidationStep = $compositeContentValidationMatch.Groups['step'].Value
+Assert-Match `
+    -Actual $compositeContentValidationStep `
+    -Pattern '(?m)^        WINGET_PKGS_GITHUB_TOKEN: \$\{\{\s*inputs\.github-token\s*\}\}\s*$' `
+    -Message 'The validate-and-submit action must use its supplied PAT for content validation.' | Out-Null
+Assert-Match `
+    -Actual $compositeContentValidationStep `
+    -Pattern '(?m)^        GITHUB_TOKEN: \$\{\{\s*github\.token\s*\}\}\s*$' `
+    -Message 'The validate-and-submit action must retain the workflow token as the content-validation fallback.' | Out-Null
+
 foreach ($workflowRelativePath in $workflowPaths) {
     $workflowPath = Join-Path $repositoryRoot $workflowRelativePath
     $workflowName = Split-Path -Leaf $workflowPath
@@ -66,6 +82,20 @@ foreach ($workflowRelativePath in $workflowPaths) {
         -Actual $saveStateStep `
         -Pattern '(?m)^          gh auth setup-git\s*$' `
         -Message "$workflowName does not configure an explicit Git credential helper before saving package state." | Out-Null
+
+    $contentValidationStepMatch = Assert-Match `
+        -Actual $workflow `
+        -Pattern '(?ms)^      - name: Run content validation\r?\n(?<step>.*?)(?=^      - |\z)' `
+        -Message "$workflowName does not contain a content-validation step."
+    $contentValidationStep = $contentValidationStepMatch.Groups['step'].Value
+    Assert-Match `
+        -Actual $contentValidationStep `
+        -Pattern '(?m)^          WINGET_PKGS_GITHUB_TOKEN: \$\{\{\s*secrets\.WINGET_PAT\s*\}\}\s*$' `
+        -Message "$workflowName must prefer WINGET_PAT for published-manifest validation." | Out-Null
+    Assert-Match `
+        -Actual $contentValidationStep `
+        -Pattern '(?m)^          GITHUB_TOKEN: \$\{\{\s*github\.token\s*\}\}\s*$' `
+        -Message "$workflowName must retain the workflow token as the content-validation fallback." | Out-Null
 
     $submitMatch = Assert-Match `
         -Actual $workflow `


### PR DESCRIPTION
Published manifest comparison could exhaust GitHub's unauthenticated rate limit because content-validation steps did not expose the configured winget PAT to the validator.

Prefer `WINGET_PAT` for these API reads across generated workflows and the reusable validation action, while retaining `github.token` as a fallback when the PAT is unavailable. Regression assertions protect both the preferred token and fallback wiring.