### PR TITLE
Batch published manifest comparison reads

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -105,7 +105,8 @@ jobs:
             './tests/Submit-WingetPackage.Tests.ps1',
             './tests/Test-SubmitFinalValidation.Tests.ps1',
             './tests/ForkBranchSubmission.Tests.ps1',
-            './tests/Test-ExistingPRs.Tests.ps1'
+            './tests/Test-ExistingPRs.Tests.ps1',
+            './tests/Test-ManifestRemoteReads.Tests.ps1'
           )
           $pesterConfig.Run.Exit = $true
           Invoke-Pester -Configuration $pesterConfig

--- a/modules/WingetMaintainerModule/Private/Test-WingetManifestContent.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-WingetManifestContent.ps1
@@ -601,11 +601,43 @@ function Test-WingetManifestContent {
         }
     }
 
-    function Invoke-RemoteTextDownload {
-        param([Parameter(Mandatory = $true)] [string] $Uri)
+    function Invoke-GitHubGraphQl {
+        param([Parameter(Mandatory = $true)] [string] $Query)
 
-        $response = Invoke-WebRequest -Uri $Uri -Headers (Get-GitHubHeaders) -Method Get -ErrorAction Stop
-        return $response.Content
+        $headers = Get-GitHubHeaders
+        if (-not $headers.ContainsKey('Authorization')) {
+            throw 'GitHub authentication is required to batch published manifest reads.'
+        }
+
+        $body = @{ query = $Query } | ConvertTo-Json -Compress
+        $response = Invoke-RestMethod `
+            -Uri 'https://api.github.com/graphql' `
+            -Headers $headers `
+            -Method Post `
+            -ContentType 'application/json' `
+            -Body $body `
+            -ErrorAction Stop
+
+        if ($null -ne $response.PSObject.Properties['errors'] -and @($response.errors).Count -gt 0) {
+            $messages = @($response.errors | ForEach-Object { [string]$_.message })
+            throw "GitHub GraphQL request failed: $($messages -join '; ')"
+        }
+
+        return $response.data
+    }
+
+    function ConvertFrom-GitHubContentResponse {
+        param(
+            [Parameter(Mandatory = $true)] [pscustomobject] $Response,
+            [Parameter(Mandatory = $true)] [string] $SourceName
+        )
+
+        if ([string]$Response.encoding -ne 'base64' -or [string]::IsNullOrWhiteSpace([string]$Response.content)) {
+            throw "GitHub returned unsupported content for '$SourceName'."
+        }
+
+        $encodedContent = ([string]$Response.content) -replace '\s', ''
+        return [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($encodedContent))
     }
 
     function Get-PublishedVersionSources {
@@ -638,8 +670,92 @@ function Test-WingetManifestContent {
                     Kind   = 'GitHub'
                     Path   = [string]$_.path
                     ApiUrl = [string]$_.url
+                    PackageIdentifier = $PackageIdentifier
                 }
             })
+    }
+
+    function Read-GitHubPublishedManifestSets {
+        param(
+            [Parameter(Mandatory = $true)] [object[]] $VersionSources,
+            [Parameter(Mandatory = $true)] [string] $PackageIdentifier
+        )
+
+        $manifestSets = [System.Collections.Generic.List[object]]::new()
+        $batchSize = 50
+
+        for ($offset = 0; $offset -lt $VersionSources.Count; $offset += $batchSize) {
+            $batch = @($VersionSources | Select-Object -Skip $offset -First $batchSize)
+            $queryFields = [System.Collections.Generic.List[string]]::new()
+            $fieldMappings = [System.Collections.Generic.List[object]]::new()
+
+            for ($batchIndex = 0; $batchIndex -lt $batch.Count; $batchIndex++) {
+                $versionSource = $batch[$batchIndex]
+                $globalIndex = $offset + $batchIndex
+                $installerAlias = "installer$globalIndex"
+                $baseAlias = "base$globalIndex"
+                $installerPath = "$($versionSource.Path)/$PackageIdentifier.installer.yaml"
+                $basePath = "$($versionSource.Path)/$PackageIdentifier.yaml"
+                $installerExpression = ConvertTo-Json -InputObject "master:$installerPath" -Compress
+                $baseExpression = ConvertTo-Json -InputObject "master:$basePath" -Compress
+
+                $queryFields.Add("      ${installerAlias}: object(expression: $installerExpression) { ... on Blob { text } }")
+                $queryFields.Add("      ${baseAlias}: object(expression: $baseExpression) { ... on Blob { text } }")
+                $fieldMappings.Add([pscustomobject]@{
+                        VersionSource = $versionSource
+                        InstallerAlias = $installerAlias
+                        InstallerPath = $installerPath
+                        BaseAlias = $baseAlias
+                        BasePath = $basePath
+                    })
+            }
+
+            $query = @"
+query {
+  repository(owner: "microsoft", name: "winget-pkgs") {
+$($queryFields -join [Environment]::NewLine)
+  }
+}
+"@
+            $data = Invoke-GitHubGraphQl -Query $query
+            $repositoryData = $data.repository
+            if ($null -eq $repositoryData) {
+                throw 'GitHub GraphQL did not return microsoft/winget-pkgs.'
+            }
+
+            foreach ($mapping in $fieldMappings) {
+                $installerBlob = $repositoryData.PSObject.Properties[$mapping.InstallerAlias].Value
+                $baseBlob = $repositoryData.PSObject.Properties[$mapping.BaseAlias].Value
+                $content = $null
+                $path = $null
+
+                if ($null -ne $installerBlob -and -not [string]::IsNullOrWhiteSpace([string]$installerBlob.text)) {
+                    $content = [string]$installerBlob.text
+                    $path = $mapping.InstallerPath
+                }
+                elseif ($null -ne $baseBlob -and -not [string]::IsNullOrWhiteSpace([string]$baseBlob.text)) {
+                    $content = [string]$baseBlob.text
+                    $path = $mapping.BasePath
+                }
+                else {
+                    continue
+                }
+
+                $parseResult = Test-YamlParseable -Content $content -SourceName $path
+                if (-not $parseResult.Success) {
+                    throw "Failed to parse published manifest '$path': $($parseResult.Error)"
+                }
+
+                $documents = @([pscustomobject]@{
+                        Name = Split-Path -Leaf $path
+                        Path = $path
+                        Data = $parseResult.Data
+                    })
+                $manifestSets.Add((ConvertTo-ManifestSet -Documents $documents -Source $mapping.VersionSource.Name))
+            }
+        }
+
+        return $manifestSets.ToArray()
     }
 
     function Read-PublishedManifestSet {
@@ -668,14 +784,24 @@ function Test-WingetManifestContent {
             if ([string]::IsNullOrWhiteSpace($apiUrl)) {
                 throw "ApiUrl is null or empty for published version source '$($VersionSource.Name)'."
             }
+            $packageIdentifier = [string]$VersionSource.PackageIdentifier
+            if ([string]::IsNullOrWhiteSpace($packageIdentifier)) {
+                throw "PackageIdentifier is null or empty for published version source '$($VersionSource.Name)'."
+            }
             $files = Invoke-GitHubApiJson -Uri $apiUrl
-            $yamlFiles = @($files | Where-Object { $_.type -eq 'file' -and $_.name -like '*.yaml' } | Sort-Object name)
+            $installerName = "$packageIdentifier.installer.yaml"
+            $baseName = "$packageIdentifier.yaml"
+            $yamlFiles = @($files | Where-Object { $_.type -eq 'file' -and $_.name -eq $installerName } | Select-Object -First 1)
+            if ($yamlFiles.Count -eq 0) {
+                $yamlFiles = @($files | Where-Object { $_.type -eq 'file' -and $_.name -eq $baseName } | Select-Object -First 1)
+            }
             foreach ($yamlFile in $yamlFiles) {
-                $downloadUrl = [string]$yamlFile.download_url
-                if ([string]::IsNullOrWhiteSpace($downloadUrl)) {
-                    throw "download_url is null or empty for file '$($yamlFile.name)' in version '$($VersionSource.Name)'."
+                $contentUrl = [string]$yamlFile.url
+                if ([string]::IsNullOrWhiteSpace($contentUrl)) {
+                    throw "API URL is null or empty for file '$($yamlFile.name)' in version '$($VersionSource.Name)'."
                 }
-                $content = Invoke-RemoteTextDownload -Uri $downloadUrl
+                $contentResponse = Invoke-GitHubApiJson -Uri $contentUrl
+                $content = ConvertFrom-GitHubContentResponse -Response $contentResponse -SourceName $yamlFile.path
                 $parseResult = Test-YamlParseable -Content $content -SourceName $yamlFile.path
                 if (-not $parseResult.Success) {
                     throw "Failed to parse published manifest '$($yamlFile.path)': $($parseResult.Error)"
@@ -966,10 +1092,18 @@ function Test-WingetManifestContent {
                     Write-Host "  Found $($publishedVersionSources.Count) published version folder(s) to compare against." -ForegroundColor Gray
 
                     $publishedManifestSets = @()
-                    foreach ($publishedVersionSource in $publishedVersionSources) {
-                        $publishedManifestSet = Read-PublishedManifestSet -VersionSource $publishedVersionSource
-                        if ($null -ne $publishedManifestSet) {
-                            $publishedManifestSets += $publishedManifestSet
+                    $githubHeaders = Get-GitHubHeaders
+                    if ($publishedVersionSources[0].Kind -eq 'GitHub' -and $githubHeaders.ContainsKey('Authorization')) {
+                        $publishedManifestSets = @(Read-GitHubPublishedManifestSets `
+                                -VersionSources $publishedVersionSources `
+                                -PackageIdentifier $localManifestSet.PackageIdentifier)
+                    }
+                    else {
+                        foreach ($publishedVersionSource in $publishedVersionSources) {
+                            $publishedManifestSet = Read-PublishedManifestSet -VersionSource $publishedVersionSource
+                            if ($null -ne $publishedManifestSet) {
+                                $publishedManifestSets += $publishedManifestSet
+                            }
                         }
                     }
 

--- a/tests/Test-ManifestRemoteReads.Tests.ps1
+++ b/tests/Test-ManifestRemoteReads.Tests.ps1
@@ -1,0 +1,220 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
+
+Describe 'Test-WingetManifestContent remote reads' {
+    BeforeEach {
+        $global:ManifestReadRequests = [System.Collections.Generic.List[object]]::new()
+        $global:OriginalManifestReadToken = $env:WINGET_PKGS_GITHUB_TOKEN
+        $global:OriginalManifestGitHubToken = $env:GITHUB_TOKEN
+        $global:ManifestReadPublishedInstaller = @'
+PackageIdentifier: Test.BatchReads
+PackageVersion: 1.0.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://example.invalid/test-1.0.0.exe
+  InstallerSha256: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+ManifestType: installer
+ManifestVersion: 1.12.0
+'@
+        $global:ManifestReadPublishedSingleton = @'
+PackageIdentifier: Test.BatchReads
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Test
+PackageName: Batch Reads
+License: MIT
+ShortDescription: Test package
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://example.invalid/test-1.0.0.exe
+  InstallerSha256: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+ManifestType: singleton
+ManifestVersion: 1.12.0
+'@
+        $global:ManifestReadGraphQlInstaller = $global:ManifestReadPublishedInstaller
+        $global:ManifestReadGraphQlBase = $null
+        $global:ManifestReadFallbackName = 'Test.BatchReads.installer.yaml'
+        $global:ManifestReadFallbackContent = $global:ManifestReadPublishedInstaller
+        $env:WINGET_PKGS_GITHUB_TOKEN = 'primary-read-token'
+        $env:GITHUB_TOKEN = ''
+        $global:ManifestReadRoot = Join-Path ([IO.Path]::GetTempPath()) "winget-remote-read-test-$([guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $global:ManifestReadRoot -Force | Out-Null
+
+        @'
+PackageIdentifier: Test.BatchReads
+PackageVersion: 2.0.0
+InstallerType: nullsoft
+Installers:
+- Architecture: x64
+  InstallerUrl: https://example.invalid/test-2.0.0.exe
+  InstallerSha256: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+ManifestType: installer
+ManifestVersion: 1.12.0
+'@ | Set-Content -LiteralPath (Join-Path $global:ManifestReadRoot 'Test.BatchReads.installer.yaml') -Encoding utf8
+
+        @'
+PackageIdentifier: Test.BatchReads
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+'@ | Set-Content -LiteralPath (Join-Path $global:ManifestReadRoot 'Test.BatchReads.yaml') -Encoding utf8
+
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-WebRequest {
+                throw 'Published manifests must not be downloaded from raw.githubusercontent.com.'
+            }
+
+            Mock Invoke-RestMethod {
+                param($Uri, $Headers, $Method, $ContentType, $Body, $ErrorAction)
+
+                $global:ManifestReadRequests.Add([pscustomobject]@{
+                        Uri = [string]$Uri
+                        Headers = $Headers
+                        Method = [string]$Method
+                        ContentType = [string]$ContentType
+                        Body = [string]$Body
+                    })
+
+                if ([string]$Uri -eq 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/Test/BatchReads') {
+                    return [pscustomobject]@{
+                        type = 'dir'
+                        name = '1.0.0'
+                        path = 'manifests/t/Test/BatchReads/1.0.0'
+                        url = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/Test/BatchReads/1.0.0'
+                    }
+                }
+
+                if ([string]$Uri -eq 'https://api.github.com/graphql') {
+                    return [pscustomobject]@{
+                        data = [pscustomobject]@{
+                            repository = [pscustomobject]@{
+                                installer0 = if ($null -eq $global:ManifestReadGraphQlInstaller) {
+                                    $null
+                                } else {
+                                    [pscustomobject]@{ text = $global:ManifestReadGraphQlInstaller }
+                                }
+                                base0 = if ($null -eq $global:ManifestReadGraphQlBase) {
+                                    $null
+                                } else {
+                                    [pscustomobject]@{ text = $global:ManifestReadGraphQlBase }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if ([string]$Uri -eq 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/Test/BatchReads/1.0.0') {
+                    return [pscustomobject]@{
+                        type = 'file'
+                        name = $global:ManifestReadFallbackName
+                        path = "manifests/t/Test/BatchReads/1.0.0/$($global:ManifestReadFallbackName)"
+                        url = 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/Test/BatchReads/1.0.0/published'
+                        download_url = 'https://raw.githubusercontent.com/microsoft/winget-pkgs/master/forbidden.yaml'
+                    }
+                }
+
+                if ([string]$Uri -eq 'https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/t/Test/BatchReads/1.0.0/published') {
+                    return [pscustomobject]@{
+                        encoding = 'base64'
+                        content = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($global:ManifestReadFallbackContent))
+                    }
+                }
+
+                throw "Unexpected GitHub request: $Method $Uri"
+            }
+        }
+    }
+
+    AfterEach {
+        $env:WINGET_PKGS_GITHUB_TOKEN = $global:OriginalManifestReadToken
+        $env:GITHUB_TOKEN = $global:OriginalManifestGitHubToken
+        if (Test-Path -LiteralPath $global:ManifestReadRoot) {
+            Remove-Item -LiteralPath $global:ManifestReadRoot -Recurse -Force
+        }
+        Remove-Variable -Name ManifestReadRequests -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalManifestReadToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name OriginalManifestGitHubToken -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadPublishedInstaller -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadPublishedSingleton -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadGraphQlInstaller -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadGraphQlBase -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadFallbackName -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadFallbackContent -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name ManifestReadRoot -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'batches authenticated published manifests through the GitHub API' {
+        $result = InModuleScope WingetMaintainerModule -Parameters @{ ManifestPath = $global:ManifestReadRoot } {
+            param($ManifestPath)
+            Test-WingetManifestContent -ManifestPath $ManifestPath
+        }
+
+        if (-not $result.Valid) {
+            throw "Expected remote published comparison to pass: $($result.Errors -join '; ')"
+        }
+        if ($global:ManifestReadRequests.Count -ne 2) {
+            throw "Expected one contents request and one batched GraphQL request, got $($global:ManifestReadRequests.Count)."
+        }
+
+        $graphqlRequest = $global:ManifestReadRequests | Where-Object Uri -eq 'https://api.github.com/graphql' | Select-Object -First 1
+        if ($null -eq $graphqlRequest -or $graphqlRequest.Method -cne 'Post') {
+            throw 'Published manifests were not read through a batched GitHub GraphQL request.'
+        }
+        if ($graphqlRequest.Headers.Authorization -notlike '*primary-read-token') {
+            throw 'The batched manifest request did not use the configured read token.'
+        }
+        if ($graphqlRequest.Body -notmatch 'Test\.BatchReads\.installer\.yaml' -or
+            $graphqlRequest.Body -notmatch 'Test\.BatchReads\.yaml') {
+            throw "The GraphQL request did not include both installer and singleton candidates: $($graphqlRequest.Body)"
+        }
+        if (@($global:ManifestReadRequests | Where-Object Uri -NotLike 'https://api.github.com/*').Count -ne 0) {
+            throw 'Published manifest comparison made a request outside the authenticated GitHub API.'
+        }
+    }
+
+    It 'supports published singleton manifests in the batched request' {
+        $global:ManifestReadGraphQlInstaller = $null
+        $global:ManifestReadGraphQlBase = $global:ManifestReadPublishedSingleton
+
+        $result = InModuleScope WingetMaintainerModule -Parameters @{ ManifestPath = $global:ManifestReadRoot } {
+            param($ManifestPath)
+            Test-WingetManifestContent -ManifestPath $ManifestPath
+        }
+
+        if (-not $result.Valid) {
+            throw "Expected singleton published comparison to pass: $($result.Errors -join '; ')"
+        }
+        if ($global:ManifestReadRequests.Count -ne 2) {
+            throw "Expected singleton comparison to remain batched into two API requests, got $($global:ManifestReadRequests.Count)."
+        }
+    }
+
+    It 'uses API content instead of raw downloads when no token is available' {
+        $env:WINGET_PKGS_GITHUB_TOKEN = ''
+        $env:GITHUB_TOKEN = ''
+
+        $result = InModuleScope WingetMaintainerModule -Parameters @{ ManifestPath = $global:ManifestReadRoot } {
+            param($ManifestPath)
+            Test-WingetManifestContent -ManifestPath $ManifestPath
+        }
+
+        if (-not $result.Valid) {
+            throw "Expected unauthenticated API fallback comparison to pass: $($result.Errors -join '; ')"
+        }
+        if ($global:ManifestReadRequests.Count -ne 3) {
+            throw "Expected contents listing and API content requests, got $($global:ManifestReadRequests.Count)."
+        }
+        if (@($global:ManifestReadRequests | Where-Object Uri -Like 'https://raw.githubusercontent.com/*').Count -ne 0) {
+            throw 'The unauthenticated fallback used raw.githubusercontent.com.'
+        }
+        if (@($global:ManifestReadRequests | Where-Object { $_.Headers.ContainsKey('Authorization') }).Count -ne 0) {
+            throw 'The unauthenticated fallback unexpectedly sent an Authorization header.'
+        }
+    }
+}

--- a/tests/Test-ManifestRemoteReads.Tests.ps1
+++ b/tests/Test-ManifestRemoteReads.Tests.ps1
@@ -45,25 +45,11 @@ ManifestVersion: 1.12.0
         $global:ManifestReadRoot = Join-Path ([IO.Path]::GetTempPath()) "winget-remote-read-test-$([guid]::NewGuid().ToString('N'))"
         New-Item -ItemType Directory -Path $global:ManifestReadRoot -Force | Out-Null
 
-        @'
-PackageIdentifier: Test.BatchReads
-PackageVersion: 2.0.0
-InstallerType: nullsoft
-Installers:
-- Architecture: x64
-  InstallerUrl: https://example.invalid/test-2.0.0.exe
-  InstallerSha256: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
-ManifestType: installer
-ManifestVersion: 1.12.0
-'@ | Set-Content -LiteralPath (Join-Path $global:ManifestReadRoot 'Test.BatchReads.installer.yaml') -Encoding utf8
+        $localInstallerContent = "PackageIdentifier: Test.BatchReads`r`nPackageVersion: 2.0.0`r`nInstallerType: nullsoft`r`nInstallers:`r`n- Architecture: x64`r`n  InstallerUrl: https://example.invalid/test-2.0.0.exe`r`n  InstallerSha256: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB`r`nManifestType: installer`r`nManifestVersion: 1.12.0`r`n"
+        [System.IO.File]::WriteAllBytes((Join-Path $global:ManifestReadRoot 'Test.BatchReads.installer.yaml'), [System.Text.Encoding]::UTF8.GetBytes($localInstallerContent))
 
-        @'
-PackageIdentifier: Test.BatchReads
-PackageVersion: 2.0.0
-DefaultLocale: en-US
-ManifestType: version
-ManifestVersion: 1.12.0
-'@ | Set-Content -LiteralPath (Join-Path $global:ManifestReadRoot 'Test.BatchReads.yaml') -Encoding utf8
+        $localVersionContent = "PackageIdentifier: Test.BatchReads`r`nPackageVersion: 2.0.0`r`nDefaultLocale: en-US`r`nManifestType: version`r`nManifestVersion: 1.12.0`r`n"
+        [System.IO.File]::WriteAllBytes((Join-Path $global:ManifestReadRoot 'Test.BatchReads.yaml'), [System.Text.Encoding]::UTF8.GetBytes($localVersionContent))
 
         InModuleScope WingetMaintainerModule {
             Mock Invoke-WebRequest {


### PR DESCRIPTION
A valid PAT did not prevent content validation from receiving HTTP 429 because the validator used `raw.githubusercontent.com` for every published YAML after the initial authenticated API listing. Packages with substantial history generated roughly 140 raw requests per comparison.

Batch installer and singleton candidates through authenticated GitHub GraphQL requests, capped at 50 versions per batch. A package like `seerge.g-helper` now needs one REST listing plus one GraphQL request instead of approximately 140 requests. The unauthenticated fallback also uses Contents API data rather than raw download URLs.

Regression coverage verifies authenticated batching, singleton manifests, and the API-only fallback. The original failed `seerge.g-helper` artifact reaches all 46 published versions without a 429 and proceeds to its actual structural validation results.