### PR TITLE
Scope nested installer stickiness to archive installers

### DIFF
--- a/modules/WingetMaintainerModule/Private/Test-WingetManifestContent.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-WingetManifestContent.ps1
@@ -912,6 +912,28 @@ $($queryFields -join [Environment]::NewLine)
         return Get-PropertyValue -Object $InstallerDocument -Name $Name
     }
 
+    # Nested installer metadata is only meaningful for archive installers. Carrying it over to a
+    # non-archive installer produces manifests that winget itself rejects.
+    $script:NestedInstallerStickyProperties = @(
+        'NestedInstallerType', 'NestedInstallerFiles', 'ArchiveBinariesDependOnPath'
+    )
+
+    function Test-SupportsNestedInstallerMetadata {
+        param(
+            [Parameter(Mandatory = $true)] [AllowNull()] [object] $Installer,
+            [Parameter(Mandatory = $true)] [object] $InstallerDocument
+        )
+
+        $installerType = if ($null -eq $Installer) {
+            [string](Get-PropertyValue -Object $InstallerDocument -Name 'InstallerType')
+        }
+        else {
+            [string](Get-EffectiveInstallerProperty -Installer $Installer -InstallerDocument $InstallerDocument -Name 'InstallerType')
+        }
+
+        return $installerType -ieq 'zip'
+    }
+
     function Test-InstallerMetadataConsistency {
         param(
             [Parameter(Mandatory = $true)] [pscustomobject] $CurrentManifestSet,
@@ -928,6 +950,25 @@ $($queryFields -join [Environment]::NewLine)
 
         $currentInstallers = @($CurrentManifestSet.InstallerEntries)
         foreach ($propertyName in $script:InstallerManifestStickyProperties) {
+            if ($script:NestedInstallerStickyProperties -contains $propertyName) {
+                $supportsNested = $false
+                if ($currentInstallers.Count -eq 0) {
+                    $supportsNested = Test-SupportsNestedInstallerMetadata -Installer $null -InstallerDocument $currentInstallerDocument
+                }
+                else {
+                    foreach ($currentInstaller in $currentInstallers) {
+                        if (Test-SupportsNestedInstallerMetadata -Installer $currentInstaller -InstallerDocument $currentInstallerDocument) {
+                            $supportsNested = $true
+                            break
+                        }
+                    }
+                }
+
+                if (-not $supportsNested) {
+                    continue
+                }
+            }
+
             $previousValue = Get-PropertyValue -Object $previousInstallerDocument -Name $propertyName
             $currentValue = Get-PropertyValue -Object $currentInstallerDocument -Name $propertyName
 
@@ -955,6 +996,11 @@ $($queryFields -join [Environment]::NewLine)
             $architectureSuffix = if (Test-HasValue $architecture) { " for architecture '$architecture'" } else { '' }
 
             foreach ($propertyName in $script:InstallerEntryStickyProperties) {
+                if (($script:NestedInstallerStickyProperties -contains $propertyName) -and
+                    -not (Test-SupportsNestedInstallerMetadata -Installer $matchingInstaller -InstallerDocument $currentInstallerDocument)) {
+                    continue
+                }
+
                 $previousValue = Get-EffectiveInstallerProperty -Installer $previousInstaller -InstallerDocument $previousInstallerDocument -Name $propertyName
                 $currentValue = Get-EffectiveInstallerProperty -Installer $matchingInstaller -InstallerDocument $currentInstallerDocument -Name $propertyName
 

--- a/tests/Test-ManifestContent.Tests.ps1
+++ b/tests/Test-ManifestContent.Tests.ps1
@@ -29,11 +29,11 @@ NestedInstallerFiles:
     $installerManifest = @"
 PackageIdentifier: Test.StructuralRewrite
 PackageVersion: $Version
-InstallerType: nullsoft
+InstallerType: zip
 $nestedInstallerMetadata
 Installers:
 - Architecture: x64
-  InstallerUrl: https://example.invalid/test-$Version.exe
+  InstallerUrl: https://example.invalid/test-$Version.zip
   InstallerSha256: $Hash
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/tests/Test-ManifestPolicyGuards.Tests.ps1
+++ b/tests/Test-ManifestPolicyGuards.Tests.ps1
@@ -248,6 +248,107 @@ Installers:
     if ($LASTEXITCODE -ne 0) {
         throw "Expected inherited nested installer metadata to pass, got exit code $LASTEXITCODE."
     }
+
+    Write-Host 'TEST: nested installer metadata is not sticky for non-archive installers'
+    $staleNestedPublishedRoot = Join-Path $testRoot 'published-stale-nested'
+    Write-ManifestFile -Path (Join-Path $staleNestedPublishedRoot '0.269/Test.Portable.installer.yaml') -Content @"
+PackageIdentifier: Test.Portable
+PackageVersion: "0.269"
+InstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: app.exe
+  PortableCommandAlias: app
+Commands:
+- app
+ManifestType: installer
+ManifestVersion: 1.12.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.example.invalid/v0.269/app.exe
+  InstallerSha256: DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+"@
+    Write-ManifestFile -Path (Join-Path $staleNestedPublishedRoot '0.269/Test.Portable.yaml') -Content @"
+PackageIdentifier: Test.Portable
+PackageVersion: "0.269"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+"@
+
+    $droppedNestedPath = Join-Path $testRoot 'dropped-nested-portable'
+    Write-ManifestFile -Path (Join-Path $droppedNestedPath 'Test.Portable.installer.yaml') -Content @"
+PackageIdentifier: Test.Portable
+PackageVersion: "0.274"
+InstallerType: portable
+Commands:
+- app
+ManifestType: installer
+ManifestVersion: 1.12.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.example.invalid/v0.274/app.exe
+  InstallerSha256: EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
+"@
+    Write-ManifestFile -Path (Join-Path $droppedNestedPath 'Test.Portable.yaml') -Content @"
+PackageIdentifier: Test.Portable
+PackageVersion: "0.274"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+"@
+    $null = & $validationScript -ManifestPath $droppedNestedPath -PublishedPackageRoot $staleNestedPublishedRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw "Expected dropping inapplicable nested metadata on a portable installer to pass, got exit code $LASTEXITCODE."
+    }
+
+    Write-Host 'TEST: nested installer metadata stays sticky for archive installers'
+    $archivePublishedRoot = Join-Path $testRoot 'published-archive-nested'
+    Write-ManifestFile -Path (Join-Path $archivePublishedRoot '1.0.0/Test.Archive.installer.yaml') -Content @"
+PackageIdentifier: Test.Archive
+PackageVersion: 1.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: app.exe
+  PortableCommandAlias: app
+ManifestType: installer
+ManifestVersion: 1.12.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.example.invalid/v1.0.0/app.zip
+  InstallerSha256: 11111111111111111111111111111111111111111111111111111111111111AA
+"@
+    Write-ManifestFile -Path (Join-Path $archivePublishedRoot '1.0.0/Test.Archive.yaml') -Content @"
+PackageIdentifier: Test.Archive
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+"@
+
+    $archiveRegressionPath = Join-Path $testRoot 'dropped-nested-archive'
+    Write-ManifestFile -Path (Join-Path $archiveRegressionPath 'Test.Archive.installer.yaml') -Content @"
+PackageIdentifier: Test.Archive
+PackageVersion: 2.0.0
+InstallerType: zip
+ManifestType: installer
+ManifestVersion: 1.12.0
+Installers:
+- Architecture: x64
+  InstallerUrl: https://downloads.example.invalid/v2.0.0/app.zip
+  InstallerSha256: 22222222222222222222222222222222222222222222222222222222222222BB
+"@
+    Write-ManifestFile -Path (Join-Path $archiveRegressionPath 'Test.Archive.yaml') -Content @"
+PackageIdentifier: Test.Archive
+PackageVersion: 2.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0
+"@
+    $null = & $validationScript -ManifestPath $archiveRegressionPath -PublishedPackageRoot $archivePublishedRoot
+    if ($LASTEXITCODE -ne 4) {
+        throw "Expected dropping nested metadata on a zip installer to fail with exit code 4, got $LASTEXITCODE."
+    }
 }
 finally {
     if (Test-Path -LiteralPath $testRoot) {


### PR DESCRIPTION
## Why

Content validation was blocking a perfectly valid `seerge.g-helper` 0.274 update with:

```
- Missing property NestedInstallerFiles compared to published version 0.269
- Missing installer property NestedInstallerFiles for architecture 'x64' compared to published version 0.269
```

The published 0.269 manifest carries `NestedInstallerFiles` while declaring `InstallerType: portable` with a bare `.exe` installer URL and **no** `NestedInstallerType`. That is stale metadata that wingetcreate dragged along; nested installer properties only mean anything for archive installers.

This created a catch-22: the sticky-property comparison demanded the new manifest carry `NestedInstallerFiles` forward, but `Test-InstallerTypeMatchesUrl` rejects nested metadata that is incomplete (`NestedInstallerFiles` without `NestedInstallerType`) or attached to a non-archive URL. There was no manifest shape that could pass both checks, so the package was permanently unsubmittable without hand-waving `-AllowStructuralRewrite`.

## Approach

Nested installer properties (`NestedInstallerType`, `NestedInstallerFiles`, `ArchiveBinariesDependOnPath`) are now only treated as sticky when the *current* installer is actually an archive, i.e. its effective `InstallerType` is `zip`. A new `Test-SupportsNestedInstallerMetadata` helper resolves the effective installer type (entry value, falling back to the installer document) and gates both the manifest-level and per-installer-entry sticky loops.

All other sticky properties are untouched, and genuine regressions on real archive packages still fail exactly as before.

## Note on the existing structural-rewrite test

`tests/Test-ManifestContent.Tests.ps1` built its fixture as `InstallerType: nullsoft` plus `NestedInstallerType`/`NestedInstallerFiles` and a `.exe` URL, which is the same inapplicable-nested shape this PR now (correctly) ignores, so the test stopped failing for the right reason. Rather than weaken the check, the fixture was corrected to the realistic shape it was modeling: `InstallerType: zip` with a `.zip` URL and a `nullsoft` nested type. The test still guards that removing applicable nested metadata fails without `-AllowStructuralRewrite` and passes with it.

## Validation

- Reproduced the original failure locally against the real published 0.269 manifest and the real generated 0.274 artifact from run 31752215603: previously exit 4, now `RESULT: PASSED` / exit 0.
- New regression tests in `tests/Test-ManifestPolicyGuards.Tests.ps1` cover both directions: dropping inapplicable nested metadata on a `portable` installer passes, and dropping it on a `zip` installer still fails with exit 4.
- Full suite green: all script-style test files plus 38 Pester tests, 0 failures.