### PR TITLE
Cache open-PR status in package state to skip redundant matrix runs

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -19,6 +19,11 @@ jobs:
     name: Check for updates
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Test' }}
+    concurrency:
+      group: package-state-write
+      cancel-in-progress: false
+    permissions:
+      contents: write
     outputs:
       include: ${{ steps.select.outputs.include }}
       any: ${{ steps.select.outputs.any }}
@@ -27,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Select packages needing update
         id: select
@@ -38,6 +43,24 @@ jobs:
           MONITORED_PACKAGES: |
             # Orchestrator will insert Packages JSON here
         run: ./scripts/Select-PackagesNeedingUpdate.ps1
+
+      # The precheck caches open-PR markers in the state file; persisting them
+      # is best-effort and must never block the update matrix.
+      - name: Save package state
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Import-Module ./modules/WingetMaintainerModule/WingetMaintainerModule.psd1 -Force
+
+          $stateFile = Join-Path $env:GITHUB_WORKSPACE "data/package-state.json"
+
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          Save-PackageState -StateFilePath $stateFile -RepoPath $env:GITHUB_WORKSPACE
 
   # Job 1: Generate manifests
   generate-manifest:

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -92,6 +92,8 @@ jobs:
         shell: pwsh
         run: |
           ./tests/Save-PackageState.Tests.ps1
+          ./tests/PackageStateOpenPr.Tests.ps1
+          ./tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1

--- a/.github/workflows/update-github-packages-1-z.yml
+++ b/.github/workflows/update-github-packages-1-z.yml
@@ -38,6 +38,11 @@ jobs:
     name: Check for updates
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Test' }}
+    concurrency:
+      group: package-state-write
+      cancel-in-progress: false
+    permissions:
+      contents: write
     outputs:
       include: ${{ steps.select.outputs.include }}
       any: ${{ steps.select.outputs.any }}
@@ -46,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Select packages needing update
         id: select
@@ -402,6 +407,24 @@ jobs:
               {"id": "CrowdSecurity.CrowdSec", "repo": "crowdsecurity/crowdsec", "url": "https://github.com/crowdsecurity/crowdsec/releases/download/v{VERSION}/crowdsec_{VERSION}.msi"}
             ]
         run: ./scripts/Select-PackagesNeedingUpdate.ps1
+
+      # The precheck caches open-PR markers in the state file; persisting them
+      # is best-effort and must never block the update matrix.
+      - name: Save package state
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Import-Module ./modules/WingetMaintainerModule/WingetMaintainerModule.psd1 -Force
+
+          $stateFile = Join-Path $env:GITHUB_WORKSPACE "data/package-state.json"
+
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          Save-PackageState -StateFilePath $stateFile -RepoPath $env:GITHUB_WORKSPACE
 
   # Job 1: Generate manifests
   generate-manifest:

--- a/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
+++ b/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
@@ -123,12 +123,39 @@ function Select-GitHubPackagesNeedingUpdate {
 
         [Parameter()]
         [ValidateRange(1, 200)]
-        [int] $BatchSize = 100
+        [int] $BatchSize = 100,
+
+        # Optional path to package-state.json. When provided, packages whose new
+        # version already has an open upstream PR are skipped, using a cached
+        # marker in the state file (TTL-bound) to avoid repeated live searches.
+        [Parameter()]
+        [string] $StateFilePath,
+
+        [Parameter()]
+        [ValidateRange(1, 8760)]
+        [int] $OpenPrTtlHours = 24,
+
+        # Injectable for tests: receives (PackageIdentifier, Version), returns
+        # $true when an open upstream PR for that version exists.
+        [Parameter()]
+        [scriptblock] $OpenPrTester,
+
+        # Cap on live PR searches per invocation; candidates beyond the cap are
+        # included without a check (fail-open).
+        [Parameter()]
+        [ValidateRange(0, 1000)]
+        [int] $MaxOpenPrChecks = 30
     )
 
     if ($null -eq $GraphQlInvoker) {
         $GraphQlInvoker = { param([string] $Query) Invoke-WingetPrecheckGraphQlRequest -Query $Query }
     }
+
+    $openPrCheckEnabled = -not [string]::IsNullOrWhiteSpace($StateFilePath)
+    if ($openPrCheckEnabled -and $null -eq $OpenPrTester) {
+        $OpenPrTester = { param([string] $PackageIdentifier, [string] $Version) Test-ExistingPRs -Version $Version -PackageIdentifier $PackageIdentifier -OnlyOpen }
+    }
+    $openPrChecksUsed = 0
 
     $include = [System.Collections.Generic.List[object]]::new()
     $skipped = [System.Collections.Generic.List[object]]::new()
@@ -246,8 +273,52 @@ function Select-GitHubPackagesNeedingUpdate {
         if ($null -ne $match) {
             $skipped.Add([PSCustomObject]@{ Package = $package; Reason = 'AlreadyPublished'; Version = $version })
         }
-        else {
+        elseif (-not $openPrCheckEnabled) {
             $include.Add([PSCustomObject]@{ Package = $package; Reason = 'NewVersion'; Version = $version })
+        }
+        elseif (Test-PackageStateOpenPrFresh -StateFilePath $StateFilePath -PackageIdentifier $packageId -Version $version -TtlHours $OpenPrTtlHours) {
+            # Cached marker is fresh — an open upstream PR for this version was
+            # seen recently, so skip without spending a live search.
+            $skipped.Add([PSCustomObject]@{ Package = $package; Reason = 'OpenPrExists'; Version = $version })
+        }
+        elseif ($openPrChecksUsed -ge $MaxOpenPrChecks) {
+            $include.Add([PSCustomObject]@{ Package = $package; Reason = 'NewVersion'; Version = $version })
+        }
+        else {
+            $openPrChecksUsed++
+            $hasOpenPr = $false
+            $openPrCheckSucceeded = $true
+            try {
+                $hasOpenPr = [bool](& $OpenPrTester $packageId $version)
+            }
+            catch {
+                # Fail-open: a PR search error must never suppress a real update.
+                Write-Warning "Open-PR check for $packageId $version failed: $($_.Exception.Message). Including the package."
+                $openPrCheckSucceeded = $false
+            }
+
+            if (-not $openPrCheckSucceeded) {
+                $include.Add([PSCustomObject]@{ Package = $package; Reason = 'NewVersion'; Version = $version })
+            }
+            elseif ($hasOpenPr) {
+                $skipped.Add([PSCustomObject]@{ Package = $package; Reason = 'OpenPrExists'; Version = $version })
+                try {
+                    Set-PackageStateOpenPr -StateFilePath $StateFilePath -PackageIdentifier $packageId -Version $version
+                }
+                catch {
+                    Write-Warning "Could not record open-PR marker for $packageId : $($_.Exception.Message)"
+                }
+            }
+            else {
+                $include.Add([PSCustomObject]@{ Package = $package; Reason = 'NewVersion'; Version = $version })
+                try {
+                    # Drop any stale marker so future runs don't trust it.
+                    Set-PackageStateOpenPr -StateFilePath $StateFilePath -PackageIdentifier $packageId -Clear
+                }
+                catch {
+                    Write-Warning "Could not clear open-PR marker for $packageId : $($_.Exception.Message)"
+                }
+            }
         }
     }
 

--- a/modules/WingetMaintainerModule/Public/Set-PackageStateOpenPr.ps1
+++ b/modules/WingetMaintainerModule/Public/Set-PackageStateOpenPr.ps1
@@ -1,0 +1,81 @@
+function Set-PackageStateOpenPr {
+    <#
+    .SYNOPSIS
+        Records or clears the cached open-PR marker for a package in the state file.
+
+    .DESCRIPTION
+        Stores a nested "openPr" object ({ version, checkedAt }) on the package's state
+        entry so the pre-matrix update check can skip packages that already have an open
+        upstream PR for the pending version. Creates a minimal entry when the package has
+        no state yet and preserves all other fields on existing entries.
+
+        With -Clear, removes the openPr marker (and the entry itself when nothing else
+        remains). Clearing is a no-op that leaves the file untouched when no marker exists.
+
+    .PARAMETER StateFilePath
+        Path to the package-state.json file.
+
+    .PARAMETER PackageIdentifier
+        The winget package identifier (e.g., "MongoDB.Server").
+
+    .PARAMETER Version
+        The pending version an open upstream PR was found for.
+
+    .PARAMETER CheckedAt
+        UTC timestamp of the PR check. Defaults to now; injectable for tests.
+
+    .PARAMETER Clear
+        Removes the cached open-PR marker instead of setting it.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Set')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $StateFilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageIdentifier,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Set')]
+        [string] $Version,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Set')]
+        [datetime] $CheckedAt = (Get-Date).ToUniversalTime(),
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Clear')]
+        [switch] $Clear
+    )
+
+    $stateData = @{}
+    if (Test-Path -Path $StateFilePath -PathType Leaf) {
+        $stateData = Get-Content -Path $StateFilePath -Raw -ErrorAction Stop | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    }
+
+    if ($Clear) {
+        if (-not $stateData.ContainsKey($PackageIdentifier)) {
+            return
+        }
+        $entry = $stateData[$PackageIdentifier]
+        if (-not $entry.ContainsKey('openPr')) {
+            return
+        }
+        $entry.Remove('openPr')
+        if ($entry.Count -eq 0) {
+            $stateData.Remove($PackageIdentifier)
+        }
+    }
+    else {
+        $entry = if ($stateData.ContainsKey($PackageIdentifier)) { $stateData[$PackageIdentifier] } else { @{} }
+        $entry['openPr'] = @{
+            version   = $Version
+            checkedAt = $CheckedAt.ToUniversalTime().ToString('o')
+        }
+        $stateData[$PackageIdentifier] = $entry
+    }
+
+    $directory = Split-Path -Path $StateFilePath -Parent
+    if (-not (Test-Path -Path $directory -PathType Container)) {
+        New-Item -Path $directory -ItemType Directory -Force | Out-Null
+    }
+
+    $stateData | ConvertTo-Json -Depth 5 | Set-Content -Path $StateFilePath -Encoding utf8 -Force
+}

--- a/modules/WingetMaintainerModule/Public/Test-PackageStateOpenPrFresh.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-PackageStateOpenPrFresh.ps1
@@ -1,0 +1,64 @@
+function Test-PackageStateOpenPrFresh {
+    <#
+    .SYNOPSIS
+        Tests whether the state file holds a fresh cached open-PR marker for a package version.
+
+    .DESCRIPTION
+        Returns $true only when the package's state entry carries an "openPr" object whose
+        version matches the pending version and whose checkedAt timestamp is within the TTL.
+        Any missing, mismatched, unparsable, or expired marker returns $false so the caller
+        falls back to a live PR search.
+
+    .PARAMETER StateFilePath
+        Path to the package-state.json file.
+
+    .PARAMETER PackageIdentifier
+        The winget package identifier (e.g., "MongoDB.Server").
+
+    .PARAMETER Version
+        The pending version to compare against the cached marker.
+
+    .PARAMETER TtlHours
+        Maximum age of the cached marker in hours. Defaults to 24.
+
+    .PARAMETER Now
+        Reference time for the age calculation. Defaults to UTC now; injectable for tests.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $StateFilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageIdentifier,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Version,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, 8760)]
+        [int] $TtlHours = 24,
+
+        [Parameter(Mandatory = $false)]
+        [datetime] $Now = (Get-Date).ToUniversalTime()
+    )
+
+    $entry = Get-PackageState -StateFilePath $StateFilePath -PackageIdentifier $PackageIdentifier
+    if ($null -eq $entry -or -not $entry.ContainsKey('openPr')) {
+        return $false
+    }
+
+    $openPr = $entry['openPr']
+    if ($null -eq $openPr -or $openPr['version'] -ne $Version) {
+        return $false
+    }
+
+    $checkedAt = [datetime]::MinValue
+    if (-not [datetime]::TryParse([string]$openPr['checkedAt'], [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AdjustToUniversal -bor [System.Globalization.DateTimeStyles]::AssumeUniversal, [ref]$checkedAt)) {
+        return $false
+    }
+
+    $ageHours = ($Now.ToUniversalTime() - $checkedAt).TotalHours
+    return $ageHours -le $TtlHours
+}

--- a/scripts/Select-PackagesNeedingUpdate.ps1
+++ b/scripts/Select-PackagesNeedingUpdate.ps1
@@ -16,7 +16,8 @@ $packages = @($env:MONITORED_PACKAGES | ConvertFrom-Json)
 $include = $packages
 
 try {
-    $result = Select-GitHubPackagesNeedingUpdate -Packages $packages
+    $stateFilePath = Join-Path $PSScriptRoot '..' 'data' 'package-state.json'
+    $result = Select-GitHubPackagesNeedingUpdate -Packages $packages -StateFilePath $stateFilePath
     $include = @($result.Include | ForEach-Object { $_.Package })
 
     $skippedGroups = @($result.Skipped | Group-Object -Property Reason)

--- a/tests/PackageStateOpenPr.Tests.ps1
+++ b/tests/PackageStateOpenPr.Tests.ps1
@@ -1,0 +1,80 @@
+# Tests for Set-PackageStateOpenPr / Test-PackageStateOpenPrFresh (open-PR cache markers).
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -WarningAction SilentlyContinue
+
+$script:failures = 0
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Name)
+
+    if ("$Expected" -ne "$Actual") {
+        $script:failures++
+        Write-Host "FAIL: $Name (expected '$Expected', got '$Actual')"
+    } else {
+        Write-Host "PASS: $Name"
+    }
+}
+
+$stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "packagestate-openpr-$([guid]::NewGuid()).json"
+
+try {
+    # 1) Setting a marker creates the file and a minimal entry.
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.New' -Version '2.0.0'
+    $entry = Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.New'
+    Assert-Equal '2.0.0' $entry['openPr']['version'] 'marker is written with the pending version'
+    Assert-Equal 1 $entry.Count 'fresh entry carries only the openPr marker'
+
+    # 2) Fresh marker is reported fresh; wrong version and expired markers are not.
+    Assert-Equal $true (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.New' -Version '2.0.0') 'just-written marker is fresh'
+    Assert-Equal $false (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.New' -Version '3.0.0') 'version mismatch is not fresh'
+    Assert-Equal $false (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.Other' -Version '2.0.0') 'unknown package is not fresh'
+
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Old' -Version '1.0.0' -CheckedAt ((Get-Date).ToUniversalTime().AddHours(-25))
+    Assert-Equal $false (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.Old' -Version '1.0.0') 'marker older than the default TTL is not fresh'
+    Assert-Equal $true (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.Old' -Version '1.0.0' -TtlHours 48) 'larger TTL accepts an older marker'
+
+    # 3) Markers coexist with validation state fields and survive re-sets.
+    Set-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Version '1.0.0' -ManifestHash 'hash1' -InstallerHashes @('abc') -State 'VALIDATION_PASSED'
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Version '1.1.0'
+    $entry = Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated'
+    Assert-Equal 'VALIDATION_PASSED' $entry['state'] 'validation fields survive setting a marker'
+    Assert-Equal '1.1.0' $entry['openPr']['version'] 'marker is added next to validation fields'
+
+    # 4) Clearing removes the marker but keeps other fields; entries that held
+    #    only a marker are removed entirely.
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Clear
+    $entry = Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated'
+    Assert-Equal $false $entry.ContainsKey('openPr') 'clear removes the marker'
+    Assert-Equal 'VALIDATION_PASSED' $entry['state'] 'clear keeps validation fields'
+
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.New' -Clear
+    Assert-Equal '' "$(Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.New')" 'marker-only entry is removed on clear'
+
+    # 5) Clearing a non-existent marker is a silent no-op.
+    $before = Get-Content -Path $stateFile -Raw
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Ghost' -Clear
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Clear
+    Assert-Equal $before (Get-Content -Path $stateFile -Raw) 'clearing absent markers leaves the file untouched'
+
+    # 6) Freshness checks against a missing state file return false.
+    Assert-Equal $false (Test-PackageStateOpenPrFresh -StateFilePath (Join-Path ([System.IO.Path]::GetTempPath()) 'does-not-exist.json') -PackageIdentifier 'Vendor.New' -Version '1.0.0') 'missing state file is not fresh'
+
+    # 7) An unparsable checkedAt value is treated as stale.
+    $raw = Get-Content -Path $stateFile -Raw | ConvertFrom-Json -AsHashtable
+    $raw['Vendor.Broken'] = @{ openPr = @{ version = '1.0.0'; checkedAt = 'not-a-date' } }
+    $raw | ConvertTo-Json -Depth 5 | Set-Content -Path $stateFile -Encoding utf8 -Force
+    Assert-Equal $false (Test-PackageStateOpenPrFresh -StateFilePath $stateFile -PackageIdentifier 'Vendor.Broken' -Version '1.0.0') 'unparsable checkedAt is not fresh'
+}
+finally {
+    Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:failures -gt 0) {
+    Write-Host "$script:failures assertion(s) failed."
+    exit 1
+}
+
+Write-Host 'All PackageStateOpenPr tests passed.'

--- a/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+++ b/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
@@ -216,6 +216,138 @@ Assert-Equal 2 $rateLimit.Calls 'RATE_LIMITED response is retried'
 Assert-Equal $true $rateLimit.Ok 'successful retry returns the GraphQL payload'
 Assert-Equal '5' $rateLimit.Sleeps 'retry uses backoff delay'
 
+# 7) Open-PR cache: fresh marker skips, stale/mismatched markers trigger a live
+#    check, tester results are recorded, and tester failures fail open.
+$openPr = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(')) {
+                $data[$alias.Groups[1].Value] = @{ latestRelease = @{ tagName = 'v2.0.0' } }
+            }
+            return @{ data = $data }
+        }
+        $repoData = @{}
+        foreach ($alias in [regex]::Matches($Query, '(p\d+): object\(')) {
+            $repoData[$alias.Groups[1].Value] = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) }
+        }
+        return @{ data = @{ repository = $repoData } }
+    }
+
+    $newPackage = { param([string] $Id) @{ id = $Id; repo = "vendor/$($Id.ToLowerInvariant())"; url = 'https://example.com/{VERSION}.exe' } }
+    $stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "openpr-state-$([guid]::NewGuid()).json"
+
+    # Seed: fresh marker for Vendor.Fresh, expired marker for Vendor.Expired,
+    # version-mismatched marker for Vendor.Mismatch.
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Fresh' -Version '2.0.0'
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Expired' -Version '2.0.0' -CheckedAt ((Get-Date).ToUniversalTime().AddHours(-48))
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Mismatch' -Version '1.5.0'
+
+    $script:testerCalls = [System.Collections.Generic.List[string]]::new()
+    $tester = {
+        param([string] $PackageIdentifier, [string] $Version)
+        $script:testerCalls.Add("$PackageIdentifier@$Version")
+        switch ($PackageIdentifier) {
+            'Vendor.Expired'  { return $true }   # PR still open -> refresh marker
+            'Vendor.Mismatch' { return $false }  # stale marker -> clear
+            'Vendor.PrFound'  { return $true }   # new marker recorded
+            'Vendor.Error'    { throw 'search unavailable' }
+            default           { return $false }
+        }
+    }
+
+    $packages = @(
+        (& $newPackage 'Vendor.Fresh'),
+        (& $newPackage 'Vendor.Expired'),
+        (& $newPackage 'Vendor.Mismatch'),
+        (& $newPackage 'Vendor.PrFound'),
+        (& $newPackage 'Vendor.Error'),
+        (& $newPackage 'Vendor.NoPr')
+    )
+
+    $selection = Select-GitHubPackagesNeedingUpdate -Packages $packages -GraphQlInvoker $invoker -StateFilePath $stateFile -OpenPrTester $tester -WarningAction SilentlyContinue
+
+    $state = Get-PackageState -StateFilePath $stateFile
+    Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+
+    [PSCustomObject]@{
+        Selection        = $selection
+        TesterCalls      = @($script:testerCalls)
+        FreshMarker      = $state.ContainsKey('Vendor.Fresh')
+        ExpiredVersion   = $state['Vendor.Expired']['openPr']['version']
+        MismatchCleared  = -not $state.ContainsKey('Vendor.Mismatch')
+        PrFoundVersion   = $state['Vendor.PrFound']['openPr']['version']
+        ErrorHasMarker   = $state.ContainsKey('Vendor.Error')
+        NoPrHasMarker    = $state.ContainsKey('Vendor.NoPr')
+    }
+}
+Assert-Equal 'Skipped:OpenPrExists' (Get-ReasonFor $openPr.Selection 'Vendor.Fresh') 'fresh cached open-PR marker skips the package'
+Assert-Equal 'Skipped:OpenPrExists' (Get-ReasonFor $openPr.Selection 'Vendor.Expired') 'expired marker with still-open PR is re-checked and skipped'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $openPr.Selection 'Vendor.Mismatch') 'mismatched marker with no open PR is included'
+Assert-Equal 'Skipped:OpenPrExists' (Get-ReasonFor $openPr.Selection 'Vendor.PrFound') 'live check finding an open PR skips the package'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $openPr.Selection 'Vendor.Error') 'tester failure fails open and includes the package'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $openPr.Selection 'Vendor.NoPr') 'no cached marker and no open PR includes the package'
+Assert-Equal $false ($openPr.TesterCalls -contains 'Vendor.Fresh@2.0.0') 'fresh marker avoids a live PR search'
+Assert-Equal 5 $openPr.TesterCalls.Count 'every non-fresh candidate performs one live PR search'
+Assert-Equal $true $openPr.FreshMarker 'fresh marker is left in place'
+Assert-Equal '2.0.0' $openPr.ExpiredVersion 'refreshed marker keeps the pending version'
+Assert-Equal $true $openPr.MismatchCleared 'stale marker is cleared when no open PR exists'
+Assert-Equal '2.0.0' $openPr.PrFoundVersion 'newly found open PR is recorded in the state file'
+Assert-Equal $false $openPr.ErrorHasMarker 'tester failure records no marker'
+Assert-Equal $false $openPr.NoPrHasMarker 'absent PR records no marker'
+
+# 8) Without a state file path the tester is never consulted.
+$openPrDisabled = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            return @{ data = @{ r0 = @{ latestRelease = @{ tagName = 'v2.0.0' } } } }
+        }
+        return @{ data = @{ repository = @{ p0 = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) } } } }
+    }
+    $script:testerCalls = 0
+    $selection = Select-GitHubPackagesNeedingUpdate -Packages @(@{ id = 'Vendor.A'; repo = 'vendor/a'; url = 'https://example.com/{VERSION}.exe' }) -GraphQlInvoker $invoker -OpenPrTester { $script:testerCalls++; $true }
+    [PSCustomObject]@{ Reason = $selection.Include[0].Reason; TesterCalls = $script:testerCalls }
+}
+Assert-Equal 'NewVersion' $openPrDisabled.Reason 'open-PR check is disabled without a state file path'
+Assert-Equal 0 $openPrDisabled.TesterCalls 'tester is not consulted without a state file path'
+
+# 9) MaxOpenPrChecks caps live searches; capped candidates are included.
+$openPrCapped = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(')) {
+                $data[$alias.Groups[1].Value] = @{ latestRelease = @{ tagName = 'v2.0.0' } }
+            }
+            return @{ data = $data }
+        }
+        $repoData = @{}
+        foreach ($alias in [regex]::Matches($Query, '(p\d+): object\(')) {
+            $repoData[$alias.Groups[1].Value] = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) }
+        }
+        return @{ data = @{ repository = $repoData } }
+    }
+
+    $stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "openpr-cap-$([guid]::NewGuid()).json"
+    $script:testerCalls = 0
+    $packages = @(1..3 | ForEach-Object { @{ id = "Vendor.P$_"; repo = "vendor/p$_"; url = 'https://example.com/{VERSION}.exe' } })
+
+    $selection = Select-GitHubPackagesNeedingUpdate -Packages $packages -GraphQlInvoker $invoker -StateFilePath $stateFile -OpenPrTester { $script:testerCalls++; $true } -MaxOpenPrChecks 1
+    Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+
+    [PSCustomObject]@{
+        TesterCalls  = $script:testerCalls
+        SkippedCount = $selection.Skipped.Count
+        IncludeCount = $selection.Include.Count
+    }
+}
+Assert-Equal 1 $openPrCapped.TesterCalls 'live PR searches stop at MaxOpenPrChecks'
+Assert-Equal 1 $openPrCapped.SkippedCount 'checked candidate with open PR is skipped'
+Assert-Equal 2 $openPrCapped.IncludeCount 'capped candidates are included unchecked'
+
 if ($script:failures -gt 0) {
     Write-Host "$script:failures assertion(s) failed."
     exit 1


### PR DESCRIPTION
## Summary

The consolidated `check-updates` precheck now tracks whether an open winget-pkgs PR already exists for a package's pending version, and skips those packages **before** the generate/validate matrix — saving a full runner job per already-submitted package (e.g. Trivy 0.74.0 in run 31801595028 went through a whole Generate job only to find PR #417388 open).

## State schema

New nested per-package marker in `data/package-state.json`:

```json
"openPr": { "version": "0.74.0", "checkedAt": "2026-08-14T12:00:00.0000000Z" }
```

## Behavior

- **Fresh marker** (TTL 24h, matching version) → skip with reason `OpenPrExists`, zero API calls
- **Stale/missing marker** → live `Test-ExistingPRs -OnlyOpen` search, capped at `MaxOpenPrChecks` (default 30) per run
  - PR found → skip + record/refresh marker
  - PR gone → include + clear marker
- **Errors fail open** (package included); `submit-pr` keeps its own live duplicate check as backstop
- Merged PRs naturally exit via `AlreadyPublished` once winget-pkgs has the version

## Changes

- New module functions `Set-PackageStateOpenPr` / `Test-PackageStateOpenPrFresh`
- `Select-GitHubPackagesNeedingUpdate`: new `-StateFilePath`, `-OpenPrTtlHours`, `-OpenPrTester`, `-MaxOpenPrChecks` params + skip logic
- `check-updates` job (template + generated workflow): write permissions, `package-state-write` concurrency, best-effort state push after selection
- Tests: new `PackageStateOpenPr.Tests.ps1`, extended `SelectGitHubPackagesNeedingUpdate.Tests.ps1`; both registered in `module-tests.yml`

All module/regression tests pass locally, including the template↔generated workflow consistency test.