### PR TITLE
Add minimal PR body for ForkBranch submissions

### DIFF
--- a/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
+++ b/modules/WingetMaintainerModule/Private/ForkBranchSubmission.ps1
@@ -363,7 +363,12 @@ function Invoke-ForkBranchSubmission {
 
     $forkOwner = $ForkRepository.Split('/')[0]
     $headReference = if ($targetRepository -ieq $ForkRepository) { $branchName } else { "${forkOwner}:$branchName" }
-    $body = if ([string]::IsNullOrWhiteSpace($Resolves)) { $null } else { "Resolves #$Resolves" }
+    $bodyLines = @("Update $PackageId to version $Version.")
+    if (-not [string]::IsNullOrWhiteSpace($Resolves)) {
+        $bodyLines += ''
+        $bodyLines += "Resolves #$Resolves"
+    }
+    $body = $bodyLines -join "`n"
     Write-Host "ForkBranch: opening PR in $targetRepository (head: $headReference)" -ForegroundColor DarkGray
     $pullRequest = Invoke-WingetPkgsGitHubApi `
         -Method Post `


### PR DESCRIPTION
## Problem
PRs opened via the `ForkBranch` submission path (used for scheduled/monitored package updates) had an empty body — or just a bare `Resolves #N` line when an issue was linked. Confirmed against live PRs from this bot (e.g. `microsoft/winget-pkgs#417389`, `#417388`), which have no description at all.

## Fix
`Invoke-ForkBranchSubmission` now always includes a short one-line description, mirroring the style real winget-pkgs submissions use (e.g. WinMatsch's own generated bodies) — minus any tool attribution:

```
Update <PackageId> to version <Version>.
```

When an issue is linked, the existing `Resolves #N` line is still appended below it:

```
Update <PackageId> to version <Version>.

Resolves #<N>
```

No "Created with ..." footer is added anywhere.

## Scope
Only the `ForkBranch` code path is affected — `WinMatsch`, `Komac`, and `WinGetCreate` all shell out to external tools that manage their own PR body already.

## Testing
- Verified PowerShell syntax parses cleanly.
- Ran the `ForkBranchSubmission`, `Submit-WingetPackage`, and `Test-SubmitFinalValidation` Pester suites; no new failures introduced (a handful of pre-existing `Should` operator failures exist in this environment independent of this change, confirmed by reproducing them on `main` as well).
- Manually verified the generated body string for both the with/without `Resolves` cases.