### PR TITLE
Resolve tagPattern/ReleaseName/ARPVERSION versions in the update precheck

### DIFF
--- a/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
+++ b/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
@@ -95,6 +95,93 @@ function Get-WingetPrecheckPackageField {
     return [string]$value
 }
 
+function Resolve-WingetPrecheckReleaseVersion {
+    <#
+    .SYNOPSIS
+        Resolves a package's pending version from release metadata.
+
+    .DESCRIPTION
+        Mirrors the full update job's version resolution (Get-LatestGHVersionTag
+        + Get-LatestARPVersion) using a single package-scoped GraphQL response:
+        tagPattern packages pick the newest stable release whose tag matches,
+        versionSource=ReleaseName uses the release name, {ARPVERSION} URLs derive
+        the version from asset download URLs, everything else strips known tag
+        prefixes. Returns $null whenever resolution is not possible so callers
+        can fail open and include the package.
+    #>
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter()] $Repository
+    )
+
+    $url = Get-WingetPrecheckPackageField -Package $Package -Name 'url'
+    $tagPattern = Get-WingetPrecheckPackageField -Package $Package -Name 'tagPattern'
+    $versionSource = Get-WingetPrecheckPackageField -Package $Package -Name 'versionSource'
+
+    $release = $null
+    if (-not [string]::IsNullOrWhiteSpace($tagPattern)) {
+        $releasesValue = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $Repository -Name 'releases') -Name 'nodes'
+        $releaseNodes = if ($null -eq $releasesValue) { @() } else { @($releasesValue) }
+        # Same selection as Get-LatestGHVersionTag: stable releases whose tag
+        # matches the pattern, newest publish date first.
+        $matching = @($releaseNodes |
+                Where-Object {
+                    $null -ne $_ -and
+                    -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isDraft') -and
+                    -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isPrerelease') -and
+                    "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'tagName')" -match $tagPattern
+                } |
+                Sort-Object -Property @{ Expression = { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'publishedAt')" } } -Descending)
+        if ($matching.Count -gt 0) {
+            $release = $matching[0]
+        }
+    }
+    else {
+        # latestRelease already excludes drafts and prereleases, matching the
+        # full job's isLatest selection.
+        $release = Get-WingetGraphQlFieldValue -InputObject $Repository -Name 'latestRelease'
+    }
+
+    if ($null -eq $release) {
+        return $null
+    }
+
+    $tag = [string](Get-WingetGraphQlFieldValue -InputObject $release -Name 'tagName')
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        return $null
+    }
+
+    if ($versionSource -eq 'ReleaseName') {
+        $releaseName = [string](Get-WingetGraphQlFieldValue -InputObject $release -Name 'name')
+        if ([string]::IsNullOrWhiteSpace($releaseName)) {
+            return $null
+        }
+        return $releaseName.Trim()
+    }
+
+    if ($url -match '\{ARPVERSION\}') {
+        $assetsValue = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $release -Name 'releaseAssets') -Name 'nodes'
+        $assetNodes = if ($null -eq $assetsValue) { @() } else { @($assetsValue) }
+        # A full first page could mean truncated results; fail open then.
+        if ($assetNodes.Count -eq 0 -or $assetNodes.Count -ge 100) {
+            return $null
+        }
+        # Same URL-derived regexes as Get-LatestARPVersion.
+        $assetRegexes = @($url.Split(' ') -replace '{ARPVERSION}', '(.+?)' -replace '{TAG}', [Regex]::Escape($tag))
+        foreach ($assetNode in $assetNodes) {
+            $downloadUrl = [string](Get-WingetGraphQlFieldValue -InputObject $assetNode -Name 'downloadUrl')
+            foreach ($assetRegex in $assetRegexes) {
+                if ($downloadUrl -match $assetRegex) {
+                    return $matches[1]
+                }
+            }
+        }
+        return $null
+    }
+
+    return Remove-GHTagPrefixes -Tag $tag
+}
+
 function Select-GitHubPackagesNeedingUpdate {
     <#
     .SYNOPSIS
@@ -103,7 +190,10 @@ function Select-GitHubPackagesNeedingUpdate {
     .DESCRIPTION
         Uses batched GraphQL queries (instead of one REST round-trip per package)
         to read every repository's latest release tag and every package's published
-        winget-pkgs versions, then compares them. Packages whose latest release is
+        winget-pkgs versions, then compares them. Packages whose version needs
+        more than the latest tag (tagPattern, versionSource=ReleaseName,
+        {ARPVERSION} URLs) are resolved from release metadata in an extra
+        batched query. Packages whose latest release is
         already published are skipped; every ambiguous case is included so a
         precheck miss can never suppress a real update (fail-open).
 
@@ -160,6 +250,7 @@ function Select-GitHubPackagesNeedingUpdate {
     $include = [System.Collections.Generic.List[object]]::new()
     $skipped = [System.Collections.Generic.List[object]]::new()
     $comparable = [System.Collections.Generic.List[object]]::new()
+    $resolvable = [System.Collections.Generic.List[object]]::new()
 
     foreach ($package in $Packages) {
         $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
@@ -176,9 +267,19 @@ function Select-GitHubPackagesNeedingUpdate {
             (-not [string]::IsNullOrWhiteSpace($versionSource) -and $versionSource -ne 'Tag') -or
             -not [string]::IsNullOrWhiteSpace($overridePack) -or
             $url -match '\{ARPVERSION\}') {
-            # Version determination goes beyond "latest release tag", so the
-            # cheap precheck cannot predict it. Always run the full job.
-            $include.Add([PSCustomObject]@{ Package = $package; Reason = 'UnpredictableVersionSource' })
+            # Version determination goes beyond "latest release tag". Most such
+            # cases can still be resolved here from release metadata (release
+            # name, asset URLs, tag pattern); the rest always run the full job.
+            $isResolvable = [string]::IsNullOrWhiteSpace($overridePack) -and
+                ([string]::IsNullOrWhiteSpace($versionSource) -or $versionSource -in @('Tag', 'ReleaseName')) -and
+                $repo -match '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$' -and
+                -not (-not [string]::IsNullOrWhiteSpace($tagPattern) -and $url -match '\{ARPVERSION\}')
+            if ($isResolvable) {
+                $resolvable.Add($package)
+            }
+            else {
+                $include.Add([PSCustomObject]@{ Package = $package; Reason = 'UnpredictableVersionSource' })
+            }
         }
         elseif ($repo -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
             $include.Add([PSCustomObject]@{ Package = $package; Reason = 'InvalidRepoFormat' })
@@ -188,7 +289,7 @@ function Select-GitHubPackagesNeedingUpdate {
         }
     }
 
-    if ($comparable.Count -eq 0) {
+    if ($comparable.Count -eq 0 -and $resolvable.Count -eq 0) {
         return [PSCustomObject]@{ Include = @($include); Skipped = @($skipped) }
     }
 
@@ -213,35 +314,10 @@ function Select-GitHubPackagesNeedingUpdate {
         }
     }
 
-    # Pass 2: published versions per package from microsoft/winget-pkgs, batched
-    # as multiple object() fields under a single repository field.
-    $publishedEntriesByPackageId = @{}
-    $comparableArray = @($comparable)
-    for ($offset = 0; $offset -lt $comparableArray.Count; $offset += $BatchSize) {
-        $packageSlice = @($comparableArray[$offset..([Math]::Min($offset + $BatchSize, $comparableArray.Count) - 1)])
-        $fields = for ($i = 0; $i -lt $packageSlice.Count; $i++) {
-            $packageId = Get-WingetPrecheckPackageField -Package $packageSlice[$i] -Name 'id'
-            $expression = 'master:' + (Get-WingetPackageRelativePath -PackageIdentifier $packageId)
-            "p$($i): object(expression: $(ConvertTo-WingetGraphQlStringLiteral -Value $expression)) { ... on Tree { entries { name type } } }"
-        }
-        $query = "query {`n  repository(owner: `"microsoft`", name: `"winget-pkgs`") {`n" +
-            (($fields | ForEach-Object { "    $_" }) -join "`n") +
-            "`n  }`n}"
-        $response = & $GraphQlInvoker $query
-        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
-        $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name 'repository'
-        if ($null -eq $repository) {
-            throw 'GitHub GraphQL update precheck could not read microsoft/winget-pkgs.'
-        }
-
-        for ($i = 0; $i -lt $packageSlice.Count; $i++) {
-            $packageId = Get-WingetPrecheckPackageField -Package $packageSlice[$i] -Name 'id'
-            $publishedEntriesByPackageId[$packageId] = Get-WingetGraphQlFieldValue -InputObject $repository -Name "p$i"
-        }
-    }
-
-    foreach ($package in $comparableArray) {
-        $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
+    # Candidates carry a package plus its resolved pending version; they feed
+    # the published-version comparison and the open-PR check below.
+    $candidates = [System.Collections.Generic.List[object]]::new()
+    foreach ($package in @($comparable)) {
         $repo = Get-WingetPrecheckPackageField -Package $package -Name 'repo'
 
         $latestTag = [string]$latestTagByRepo[$repo]
@@ -255,6 +331,83 @@ function Select-GitHubPackagesNeedingUpdate {
             $include.Add([PSCustomObject]@{ Package = $package; Reason = 'NoReleaseFound' })
             continue
         }
+
+        $candidates.Add([PSCustomObject]@{ Package = $package; Version = $version })
+    }
+
+    # Pass 1b: resolve versions for packages whose version needs release
+    # metadata beyond the latest tag (tagPattern / ReleaseName / {ARPVERSION}),
+    # batched with one aliased repository field per package. Any resolution
+    # failure includes the package unconditionally (fail-open).
+    $resolvableArray = @($resolvable)
+    for ($offset = 0; $offset -lt $resolvableArray.Count; $offset += $BatchSize) {
+        $packageSlice = @($resolvableArray[$offset..([Math]::Min($offset + $BatchSize, $resolvableArray.Count) - 1)])
+        $fields = for ($i = 0; $i -lt $packageSlice.Count; $i++) {
+            $slicePackage = $packageSlice[$i]
+            $owner, $name = (Get-WingetPrecheckPackageField -Package $slicePackage -Name 'repo').Split('/', 2)
+            $sliceTagPattern = Get-WingetPrecheckPackageField -Package $slicePackage -Name 'tagPattern'
+            $sliceVersionSource = Get-WingetPrecheckPackageField -Package $slicePackage -Name 'versionSource'
+            $sliceUrl = Get-WingetPrecheckPackageField -Package $slicePackage -Name 'url'
+
+            $selection = if (-not [string]::IsNullOrWhiteSpace($sliceTagPattern)) {
+                'releases(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { tagName name isDraft isPrerelease publishedAt } }'
+            }
+            else {
+                $releaseFields = 'tagName'
+                if ($sliceVersionSource -eq 'ReleaseName') { $releaseFields += ' name' }
+                if ($sliceUrl -match '\{ARPVERSION\}') { $releaseFields += ' releaseAssets(first: 100) { nodes { downloadUrl } }' }
+                "latestRelease { $releaseFields }"
+            }
+            "u$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { $selection }"
+        }
+        $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
+        $response = & $GraphQlInvoker $query
+        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
+
+        for ($i = 0; $i -lt $packageSlice.Count; $i++) {
+            $slicePackage = $packageSlice[$i]
+            $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "u$i"
+            $resolvedVersion = Resolve-WingetPrecheckReleaseVersion -Package $slicePackage -Repository $repository
+            if ([string]::IsNullOrWhiteSpace([string]$resolvedVersion)) {
+                $include.Add([PSCustomObject]@{ Package = $slicePackage; Reason = 'UnpredictableVersionSource' })
+            }
+            else {
+                $candidates.Add([PSCustomObject]@{ Package = $slicePackage; Version = [string]$resolvedVersion })
+            }
+        }
+    }
+
+    # Pass 2: published versions per package from microsoft/winget-pkgs, batched
+    # as multiple object() fields under a single repository field.
+    $publishedEntriesByPackageId = @{}
+    $candidatesArray = @($candidates)
+    for ($offset = 0; $offset -lt $candidatesArray.Count; $offset += $BatchSize) {
+        $candidateSlice = @($candidatesArray[$offset..([Math]::Min($offset + $BatchSize, $candidatesArray.Count) - 1)])
+        $fields = for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
+            $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
+            $expression = 'master:' + (Get-WingetPackageRelativePath -PackageIdentifier $packageId)
+            "p$($i): object(expression: $(ConvertTo-WingetGraphQlStringLiteral -Value $expression)) { ... on Tree { entries { name type } } }"
+        }
+        $query = "query {`n  repository(owner: `"microsoft`", name: `"winget-pkgs`") {`n" +
+            (($fields | ForEach-Object { "    $_" }) -join "`n") +
+            "`n  }`n}"
+        $response = & $GraphQlInvoker $query
+        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
+        $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name 'repository'
+        if ($null -eq $repository) {
+            throw 'GitHub GraphQL update precheck could not read microsoft/winget-pkgs.'
+        }
+
+        for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
+            $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
+            $publishedEntriesByPackageId[$packageId] = Get-WingetGraphQlFieldValue -InputObject $repository -Name "p$i"
+        }
+    }
+
+    foreach ($candidate in $candidatesArray) {
+        $package = $candidate.Package
+        $version = [string]$candidate.Version
+        $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
 
         $treeObject = $publishedEntriesByPackageId[$packageId]
         if ($null -eq $treeObject) {

--- a/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+++ b/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
@@ -52,6 +52,27 @@ $result = & $module {
         param([string] $Query)
         $script:queries.Add($Query)
 
+        if ($Query -match 'u\d+: repository') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(u\d+): repository\(owner: "[^"]+", name: "([^"]+)"\)')) {
+                $data[$alias.Groups[1].Value] = switch ($alias.Groups[2].Value) {
+                    'tagged' {
+                        @{ releases = @{ nodes = @(
+                            @{ tagName = 'v2.0.0'; name = 'v2'; isDraft = $false; isPrerelease = $false; publishedAt = '2026-05-01T00:00:00Z' },
+                            @{ tagName = 'v1.9.0'; name = 'v1.9 pre'; isDraft = $false; isPrerelease = $true; publishedAt = '2026-04-20T00:00:00Z' },
+                            @{ tagName = 'v1.4.0'; name = 'v1.4'; isDraft = $false; isPrerelease = $false; publishedAt = '2026-03-01T00:00:00Z' },
+                            @{ tagName = 'v1.5.0'; name = 'v1.5'; isDraft = $false; isPrerelease = $false; publishedAt = '2026-04-01T00:00:00Z' }
+                        ) } }
+                    }
+                    'arpurl' {
+                        @{ latestRelease = @{ tagName = 'v3.2.1'; releaseAssets = @{ nodes = @(@{ downloadUrl = 'https://example.com/3.2.1.exe' }) } } }
+                    }
+                    default { $null }
+                }
+            }
+            return @{ data = $data }
+        }
+
         if ($Query -notmatch 'winget-pkgs') {
             $data = @{}
             foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(owner: "[^"]+", name: "([^"]+)"\)')) {
@@ -78,6 +99,8 @@ $result = & $module {
                 'NoRelease'  { @(@{ name = '1.0.0'; type = 'tree' }) }
                 'TagSource'  { @(@{ name = '5.0'; type = 'tree' }) }
                 'AliasMatch' { @(@{ name = '1.2.0'; type = 'tree' }) }
+                'Tagged'     { @(@{ name = '1.5.0'; type = 'tree' }) }
+                'ArpUrl'     { @(@{ name = '1.0.0'; type = 'tree' }) }
                 default      { @() }
             }
             $repoData[$alias.Groups[1].Value] = if ($null -eq $entries) { $null } else { @{ entries = $entries } }
@@ -98,14 +121,14 @@ Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $selection 'Vendor.Publis
 Assert-Equal 'Include:NewVersion' (Get-ReasonFor $selection 'Vendor.Outdated') 'new release is included'
 Assert-Equal 'Skipped:PackageMissing' (Get-ReasonFor $selection 'Vendor.Missing') 'package missing from winget-pkgs is skipped'
 Assert-Equal 'Include:NoReleaseFound' (Get-ReasonFor $selection 'Vendor.NoRelease') 'repo without latest release is included'
-Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $selection 'Vendor.Tagged') 'tagPattern package is always included'
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $selection 'Vendor.Tagged') 'tagPattern package resolved from the release list is skipped when published'
 Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $selection 'Vendor.ArpSource') 'non-Tag versionSource is always included'
 Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $selection 'Vendor.TagSource') 'versionSource Tag with published RELEASE_ tag is skipped'
-Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $selection 'Vendor.ArpUrl') 'ARPVERSION url is always included'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $selection 'Vendor.ArpUrl') 'ARPVERSION url resolved from assets is included as a new version'
 Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $selection 'Vendor.Override') 'overridePack package is always included'
 Assert-Equal 'Include:InvalidRepoFormat' (Get-ReasonFor $selection 'Vendor.BadRepo') 'invalid repo format is included'
 Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $selection 'Vendor.AliasMatch') 'numeric alias match counts as published'
-Assert-Equal 2 $result.QueryCount 'one release query and one manifest query for small lists'
+Assert-Equal 3 $result.QueryCount 'one release query, one resolvable query and one manifest query for small lists'
 Assert-Equal 5 ($selection.Include.Count + $selection.Skipped.Count - 6) 'all eleven packages are accounted for'
 
 # 2) Included entries carry the original package objects unmodified.
@@ -347,6 +370,78 @@ $openPrCapped = & $module {
 Assert-Equal 1 $openPrCapped.TesterCalls 'live PR searches stop at MaxOpenPrChecks'
 Assert-Equal 1 $openPrCapped.SkippedCount 'checked candidate with open PR is skipped'
 Assert-Equal 2 $openPrCapped.IncludeCount 'capped candidates are included unchecked'
+
+# 10) Resolvable version sources (tagPattern / ReleaseName / {ARPVERSION}) are
+#     resolved in the precheck; every resolution failure falls back to include.
+$resolved = & $module {
+    $script:queries = [System.Collections.Generic.List[string]]::new()
+
+    $packages = @(
+        @{ id = 'Vendor.NameSource'; repo = 'vendor/namesource'; url = 'https://example.com/{VERSION}.exe'; versionSource = 'ReleaseName' },
+        @{ id = 'Vendor.NameNew'; repo = 'vendor/namenew'; url = 'https://example.com/{VERSION}.exe'; versionSource = 'ReleaseName' },
+        @{ id = 'Vendor.NameEmpty'; repo = 'vendor/nameempty'; url = 'https://example.com/{VERSION}.exe'; versionSource = 'ReleaseName' },
+        @{ id = 'Vendor.NoTagMatch'; repo = 'vendor/notagmatch'; url = 'https://example.com/{VERSION}.exe'; tagPattern = '^release-' },
+        @{ id = 'Vendor.NoAssetMatch'; repo = 'vendor/noassetmatch'; url = 'https://example.com/{ARPVERSION}.msi' },
+        @{ id = 'Vendor.AssetCap'; repo = 'vendor/assetcap'; url = 'https://example.com/{ARPVERSION}.msi' },
+        @{ id = 'Vendor.TagArpCombo'; repo = 'vendor/tagarp'; url = 'https://example.com/{ARPVERSION}.msi'; tagPattern = '^v' },
+        @{ id = 'Vendor.TagWithArp'; repo = 'vendor/tagwitharp'; url = 'https://github.com/x/y/releases/download/{TAG}/setup-{ARPVERSION}-x64.msi' }
+    )
+
+    $invoker = {
+        param([string] $Query)
+        $script:queries.Add($Query)
+
+        if ($Query -match 'u\d+: repository') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(u\d+): repository\(owner: "[^"]+", name: "([^"]+)"\)')) {
+                $data[$alias.Groups[1].Value] = switch ($alias.Groups[2].Value) {
+                    'namesource'   { @{ latestRelease = @{ tagName = 'namesource-2026'; name = ' 7.7.7 ' } } }
+                    'namenew'      { @{ latestRelease = @{ tagName = 'weekly-build'; name = '8.8.8' } } }
+                    'nameempty'    { @{ latestRelease = @{ tagName = 'v1'; name = '   ' } } }
+                    'notagmatch'   { @{ releases = @{ nodes = @(@{ tagName = 'v1.0'; name = 'v1'; isDraft = $false; isPrerelease = $false; publishedAt = '2026-01-01T00:00:00Z' }) } } }
+                    'noassetmatch' { @{ latestRelease = @{ tagName = 'v2.0'; releaseAssets = @{ nodes = @(@{ downloadUrl = 'https://example.com/other.zip' }) } } } }
+                    'assetcap'     { @{ latestRelease = @{ tagName = 'v4.0'; releaseAssets = @{ nodes = @(1..100 | ForEach-Object { @{ downloadUrl = "https://example.com/$_.msi" } }) } } } }
+                    'tagwitharp'   { @{ latestRelease = @{ tagName = 'v9.0'; releaseAssets = @{ nodes = @(@{ downloadUrl = 'https://github.com/x/y/releases/download/v9.0/setup-9.0.1234-x64.msi' }) } } } }
+                    default        { $null }
+                }
+            }
+            return @{ data = $data }
+        }
+
+        $repoData = @{}
+        foreach ($alias in [regex]::Matches($Query, '(p\d+): object\(expression: "master:manifests/[a-z0-9]/Vendor/([^"]+)"\)')) {
+            $entries = switch ($alias.Groups[2].Value) {
+                'NameSource' { @(@{ name = '7.7.7'; type = 'tree' }) }
+                'TagWithArp' { @(@{ name = '9.0.1234'; type = 'tree' }) }
+                default      { @() }
+            }
+            $repoData[$alias.Groups[1].Value] = @{ entries = $entries }
+        }
+        return @{ data = @{ repository = $repoData } }
+    }
+
+    $stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "openpr-resolved-$([guid]::NewGuid()).json"
+    $tester = { param([string] $PackageIdentifier, [string] $Version) $PackageIdentifier -eq 'Vendor.NameNew' -and $Version -eq '8.8.8' }
+
+    $selection = Select-GitHubPackagesNeedingUpdate -Packages $packages -GraphQlInvoker $invoker -StateFilePath $stateFile -OpenPrTester $tester -WarningAction SilentlyContinue
+    Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+
+    [PSCustomObject]@{
+        Selection         = $selection
+        ResolvableQueries = @($script:queries | Where-Object { $_ -match 'u\d+: repository' })
+        NameSourceVersion = @($selection.Skipped | Where-Object { $_.Package.id -eq 'Vendor.NameSource' })[0].Version
+    }
+}
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $resolved.Selection 'Vendor.NameSource') 'published release name version is skipped'
+Assert-Equal '7.7.7' $resolved.NameSourceVersion 'release name version is trimmed'
+Assert-Equal 'Skipped:OpenPrExists' (Get-ReasonFor $resolved.Selection 'Vendor.NameNew') 'resolved new version participates in the open-PR check'
+Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selection 'Vendor.NameEmpty') 'blank release name fails open'
+Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selection 'Vendor.NoTagMatch') 'tagPattern without a matching stable release fails open'
+Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selection 'Vendor.NoAssetMatch') 'ARPVERSION url without a matching asset fails open'
+Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selection 'Vendor.AssetCap') 'a full asset page fails open against truncation'
+Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selection 'Vendor.TagArpCombo') 'tagPattern plus ARPVERSION combination is not resolved'
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $resolved.Selection 'Vendor.TagWithArp') 'published ARPVERSION asset version is skipped'
+Assert-Equal $false ($resolved.ResolvableQueries -join ' ' -match 'tagarp') 'unsupported combination is never queried'
 
 if ($script:failures -gt 0) {
     Write-Host "$script:failures assertion(s) failed."


### PR DESCRIPTION
## Problem
Every run, packages with an "unpredictable" version source (Mullvad `tagPattern`, ILSpy `{ARPVERSION}` URL, RegionToShare `versionSource: ReleaseName`) were unconditionally included by the precheck, spawning generate jobs that ended in `VersionExists` — systematic waste on each scheduled run.

## Change
`Select-GitHubPackagesNeedingUpdate` now resolves those versions directly in the precheck via one extra batched GraphQL query:

- **tagPattern** → newest stable (non-draft, non-prerelease) release whose tag matches the pattern, from the latest 50 releases
- **ReleaseName** → trimmed `latestRelease.name`
- **{ARPVERSION} URL** → version captured from the matching `latestRelease` asset download URL (fails open if the asset page is full, guarding against truncation)

The logic mirrors `Get-LatestGHVersionTag` / `Get-LatestARPVersion` exactly. Resolved versions then flow through the existing AlreadyPublished / open-PR-cache checks like any comparable package. Any resolution failure (no matching tag, blank name, no asset match, tagPattern+ARPVERSION combo) keeps the previous fail-open behavior: include as `UnpredictableVersionSource`.

No workflow or state-file changes needed.

## Tests
- Test 1 decision matrix updated: `Vendor.Tagged` and `Vendor.ArpUrl` now resolve (skip when published / include as NewVersion)
- New section 10 covers ReleaseName trim, blank-name fail-open, tagPattern no-match, ARPVERSION no-asset-match, 100-asset truncation guard, tagPattern+ARPVERSION exclusion, `{TAG}`+`{ARPVERSION}` URL, and open-PR check applying to resolved versions

All module test files pass locally.