### PR TITLE
Pin versioned packages to their own release stream

### DIFF
--- a/.github/workflows-data/update-github-packages-1-z.packages.json
+++ b/.github/workflows-data/update-github-packages-1-z.packages.json
@@ -3282,36 +3282,6 @@
     "url": "https://github.com/longbridge/longbridge-terminal/releases/download/v{VERSION}/longbridge-terminal-windows-amd64.zip"
   },
   {
-    "id": "LookupFoundation.RevitLookup.2021",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
-    "id": "LookupFoundation.RevitLookup.2022",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
-    "id": "LookupFoundation.RevitLookup.2023",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
-    "id": "LookupFoundation.RevitLookup.2024",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
-    "id": "LookupFoundation.RevitLookup.2025",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
-    "id": "LookupFoundation.RevitLookup.2026",
-    "repo": "lookup-foundation/RevitLookup",
-    "url": "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-  },
-  {
     "id": "loreste.mako",
     "repo": "loreste/mako",
     "url": "https://github.com/loreste/mako/releases/download/v{VERSION}/mako-x86_64-pc-windows-msvc.zip"
@@ -3944,52 +3914,62 @@
   {
     "id": "OpenJS.Electron.33",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v33\\."
   },
   {
     "id": "OpenJS.Electron.34",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v34\\."
   },
   {
     "id": "OpenJS.Electron.35",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v35\\."
   },
   {
     "id": "OpenJS.Electron.36",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v36\\."
   },
   {
     "id": "OpenJS.Electron.37",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v37\\."
   },
   {
     "id": "OpenJS.Electron.38",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v38\\."
   },
   {
     "id": "OpenJS.Electron.39",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v39\\."
   },
   {
     "id": "OpenJS.Electron.40",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v40\\."
   },
   {
     "id": "OpenJS.Electron.41",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v41\\."
   },
   {
     "id": "OpenJS.Electron.42",
     "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v42\\."
   },
   {
     "id": "OpenOrienteering.Mapper",

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -2080,24 +2080,30 @@
           - id: "Longbridge.LongbridgeTerminal"
             repo: "longbridge/longbridge-terminal"
             url: "https://github.com/longbridge/longbridge-terminal/releases/download/v{VERSION}/longbridge-terminal-windows-amd64.zip"
-          - id: "LookupFoundation.RevitLookup.2021"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-          - id: "LookupFoundation.RevitLookup.2022"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-          - id: "LookupFoundation.RevitLookup.2023"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-          - id: "LookupFoundation.RevitLookup.2024"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-          - id: "LookupFoundation.RevitLookup.2025"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
-          - id: "LookupFoundation.RevitLookup.2026"
-            repo: "lookup-foundation/RevitLookup"
-            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2021 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2021"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2022 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2022"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2023 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2023"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2024 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2024"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2025 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2025"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
+#          LookupFoundation.RevitLookup.2026 is excluded: upstream ships one MSI per Revit year inside a single release (tag 2027.0.3 contains RevitLookup-2021.5.3-*.msi), so the release tag is not the package version.
+#          - id: "LookupFoundation.RevitLookup.2026"
+#            repo: "lookup-foundation/RevitLookup"
+#            url: "https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-SingleUser.msi https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.3/RevitLookup-{VERSION}-MultiUser.msi"
           - id: "loreste.mako"
             repo: "loreste/mako"
             url: "https://github.com/loreste/mako/releases/download/v{VERSION}/mako-x86_64-pc-windows-msvc.zip"
@@ -2487,33 +2493,43 @@
           - id: "OpenJS.Electron.33"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v33\.'
           - id: "OpenJS.Electron.34"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v34\.'
           - id: "OpenJS.Electron.35"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v35\.'
           - id: "OpenJS.Electron.36"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v36\.'
           - id: "OpenJS.Electron.37"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v37\.'
           - id: "OpenJS.Electron.38"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v38\.'
           - id: "OpenJS.Electron.39"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v39\.'
           - id: "OpenJS.Electron.40"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v40\.'
           - id: "OpenJS.Electron.41"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v41\.'
           - id: "OpenJS.Electron.42"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v42\.'
           - id: "OpenOrienteering.Mapper"
             repo: "OpenOrienteering/mapper"
             url: "https://github.com/OpenOrienteering/mapper/releases/download/v{VERSION}/OpenOrienteering-Mapper-{VERSION}-Windows-x86.exe https://github.com/OpenOrienteering/mapper/releases/download/v{VERSION}/OpenOrienteering-Mapper-{VERSION}-Windows-x64.exe"


### PR DESCRIPTION
## Problem

`OpenJS.Electron.33`–`.42` and `LookupFoundation.RevitLookup.2021`–`.2026` each pointed at the same upstream repo with no version-stream filter, so every one of them resolved to that repo's *latest* release. That's why `OpenJS.Electron.39` and `OpenJS.Electron.41` both submitted **43.4.0** and got flagged `Possible-Duplicate` upstream.

## Fix

**Electron** — each major now carries a `tagPattern` (`^v39\.` etc.), a field the pipeline already supported end to end (`Get-LatestGHVersionTag -TagPattern` → `Select-GitHubPackagesNeedingUpdate` → workflow matrix). Verified resolution:

| package | before | after |
| --- | --- | --- |
| OpenJS.Electron.39 | 43.4.0 | v39.8.10 |
| OpenJS.Electron.41 | 43.4.0 | v41.10.5 |
| OpenJS.Electron.42 | 43.4.0 | v42.9.1 |

**RevitLookup** — parked (commented out with an `is excluded:` reason, per the repo convention). One upstream release ships an MSI per Revit year, each with its own version: tag `2027.0.3` contains `RevitLookup-2021.5.3-*.msi`. The release tag is therefore never the package version, and no `tagPattern` can express that — it needs asset-name-derived versioning, which the pipeline doesn't have.

`.github/workflows-data/update-github-packages-1-z.packages.json` regenerated via `scripts/orchestrate_gh-packages.py`.

## Validation

- `tests/GitHubReleaseMonitoringConfiguration.Tests.ps1` ✅
- `tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1` ✅
- `tests/SubmissionWorkflowAuthorization.Tests.ps1` ✅
- Re-scanned the whole config for repos with multiple entries and no `tagPattern`: the 18 remaining are legitimate (same release, different artifacts — e.g. `Ollama.Ollama` / `.Portable`).

Note: `GH Packages 1-Z` is still disabled and needs manual re-enabling.