### PR TITLE
Pipeline noise reduction: URL preflight, safety-question soft-fail, superseded-PR cleanup, config health

### DIFF
--- a/.github/workflows-data/update-github-packages-1-z.packages.json
+++ b/.github/workflows-data/update-github-packages-1-z.packages.json
@@ -3913,54 +3913,6 @@
     "url": "https://github.com/OpenHV/OpenHV/releases/download/{VERSION}/OpenHV-{VERSION}-x64.exe https://github.com/OpenHV/OpenHV/releases/download/{VERSION}/OpenHV-{VERSION}-x86.exe"
   },
   {
-    "id": "OpenJS.Electron.33",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v33\\."
-  },
-  {
-    "id": "OpenJS.Electron.34",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v34\\."
-  },
-  {
-    "id": "OpenJS.Electron.35",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v35\\."
-  },
-  {
-    "id": "OpenJS.Electron.36",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v36\\."
-  },
-  {
-    "id": "OpenJS.Electron.37",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v37\\."
-  },
-  {
-    "id": "OpenJS.Electron.38",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v38\\."
-  },
-  {
-    "id": "OpenJS.Electron.39",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v39\\."
-  },
-  {
-    "id": "OpenJS.Electron.40",
-    "repo": "electron/electron",
-    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
-    "tagPattern": "^v40\\."
-  },
-  {
     "id": "OpenJS.Electron.41",
     "repo": "electron/electron",
     "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
@@ -3971,6 +3923,12 @@
     "repo": "electron/electron",
     "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
     "tagPattern": "^v42\\."
+  },
+  {
+    "id": "OpenJS.Electron.43",
+    "repo": "electron/electron",
+    "url": "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip",
+    "tagPattern": "^v43\\."
   },
   {
     "id": "OpenOrienteering.Mapper",

--- a/.github/workflows-data/update-github-packages-1-z.packages.json
+++ b/.github/workflows-data/update-github-packages-1-z.packages.json
@@ -3439,7 +3439,8 @@
   {
     "id": "melon-masou.MonMouse",
     "repo": "melon-masou/MonMouse",
-    "url": "https://github.com/melon-masou/MonMouse/releases/download/v{VERSION}/monmouse-v{VERSION}-windows.zip"
+    "url": "https://github.com/melon-masou/MonMouse/releases/download/v{VERSION}/monmouse-v{VERSION}-windows.zip",
+    "allowStructuralRewrite": true
   },
   {
     "id": "mentebinaria.dz6",
@@ -4009,7 +4010,8 @@
   {
     "id": "orbatschow.kontext",
     "repo": "orbatschow/kontext",
-    "url": "https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_x86_64.zip https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_arm64.zip"
+    "url": "https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_x86_64.zip https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_arm64.zip|arm64",
+    "allowStructuralRewrite": true
   },
   {
     "id": "Orthogonal.APM",
@@ -4264,7 +4266,7 @@
   {
     "id": "RimSort.RimSort",
     "repo": "RimSort/RimSort",
-    "url": "https://github.com/RimSort/RimSort/releases/download/v{VERSION}/RimSort-v{VERSION}-Windows_x86_64.msi"
+    "url": "https://github.com/RimSort/RimSort/releases/download/v{VERSION}/RimSort-v{VERSION}-Windows_x86_64.msi|x64"
   },
   {
     "id": "Ripose.Memento",

--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -180,6 +180,42 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record needs-decision marker
+        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.id }}
+          MATRIX_PACKAGENAME: ${{ matrix.id }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR_CODE: ${{ steps.generate.outputs.error-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./needs-decision | Out-Null
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            errorCode = "$env:STEPS_GENERATE_OUTPUTS_ERROR_CODE"
+            error     = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          } | ConvertTo-Json | Out-File -FilePath ./needs-decision/question.json -Encoding utf8
+
+          Get-Content -Path ./needs-decision/question.json
+
+      - name: Upload needs-decision marker
+        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: needs-decision__${{ matrix.id }}
+          path: ./needs-decision
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Record generation failure
         if: failure()
         shell: pwsh
@@ -286,6 +322,55 @@ jobs:
         with:
           pattern: generate-failure__*
           path: ./generate-failures
+
+      - name: Download needs-decision markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: needs-decision__*
+          path: ./needs-decisions
+
+      - name: Summarize packages needing a decision
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./needs-decisions -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No packages are waiting on a safety-question decision."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :warning: Packages waiting on a safety-question decision ($($rows.Count))"
+            ""
+            "The generator stopped at a fail-closed safety question. Review each package's"
+            "matrix entry (URL architecture hints, ``overridePack``, ``allowStructuralRewrite``)."
+            ""
+            "| Package | Version | Question | Detail |"
+            "| --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.package, $row.version, $row.errorCode, $row.error) | ForEach-Object {
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) package(s) needing a decision in the job summary."
 
       - name: Summarize failed generations
         if: always()
@@ -847,6 +932,29 @@ jobs:
             }
 
             ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+            # A freshly submitted version supersedes any still-open older PR of
+            # the same package; close those immediately so moderators never see
+            # both. Best-effort: a failure here never fails the submission.
+            $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
+            if ($forkRepository -match '^(?<Owner>[A-Za-z0-9_.-]+)/') {
+              $newPrNumber = 0
+              if (-not [int]::TryParse("$($result.PrNumber)", [ref] $newPrNumber)) { $newPrNumber = 0 }
+              $superseded = Close-SupersededWingetPrs `
+                -PackageId "$env:MATRIX_PACKAGENAME" `
+                -Version "$env:MATRIX_VERSION" `
+                -BotLogin $Matches['Owner'] `
+                -NewPrNumber $newPrNumber `
+                -NewPrUrl "$($result.PrUrl)" `
+                -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
+              foreach ($warning in @($superseded.Warnings)) {
+                Write-Warning $warning
+              }
+              if (@($superseded.ClosedPrNumbers).Count -gt 0) {
+                "**Closed superseded PR(s):** $(@($superseded.ClosedPrNumbers | ForEach-Object { "#$_" }) -join ', ')" |
+                  Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+              }
+            }
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/.github/workflows/config-health.yml
+++ b/.github/workflows/config-health.yml
@@ -1,0 +1,43 @@
+name: Config Health
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1" # weekly, Monday 05:17 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: config-health
+  cancel-in-progress: false
+
+jobs:
+  check-monitored-config:
+    name: Check monitored package URLs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Report-only: verifies that every monitored package's release-asset URL
+      # template still matches a real asset, so broken templates surface here
+      # instead of as failed generations or upstream URL-Validation-Error PRs.
+      - name: Check release-asset URL templates
+        id: check
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          MONITORED_PACKAGES_FILE: .github/workflows-data/update-github-packages-1-z.packages.json
+        run: ./scripts/Test-MonitoredPackageAssets.ps1
+
+      - name: Upload report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: config-health-report
+          path: ./config-health-report.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/update-github-packages-1-z.yml
+++ b/.github/workflows/update-github-packages-1-z.yml
@@ -199,6 +199,42 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record needs-decision marker
+        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.id }}
+          MATRIX_PACKAGENAME: ${{ matrix.id }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR_CODE: ${{ steps.generate.outputs.error-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./needs-decision | Out-Null
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            errorCode = "$env:STEPS_GENERATE_OUTPUTS_ERROR_CODE"
+            error     = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          } | ConvertTo-Json | Out-File -FilePath ./needs-decision/question.json -Encoding utf8
+
+          Get-Content -Path ./needs-decision/question.json
+
+      - name: Upload needs-decision marker
+        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: needs-decision__${{ matrix.id }}
+          path: ./needs-decision
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Record generation failure
         if: failure()
         shell: pwsh
@@ -305,6 +341,55 @@ jobs:
         with:
           pattern: generate-failure__*
           path: ./generate-failures
+
+      - name: Download needs-decision markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: needs-decision__*
+          path: ./needs-decisions
+
+      - name: Summarize packages needing a decision
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./needs-decisions -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No packages are waiting on a safety-question decision."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :warning: Packages waiting on a safety-question decision ($($rows.Count))"
+            ""
+            "The generator stopped at a fail-closed safety question. Review each package's"
+            "matrix entry (URL architecture hints, ``overridePack``, ``allowStructuralRewrite``)."
+            ""
+            "| Package | Version | Question | Detail |"
+            "| --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.package, $row.version, $row.errorCode, $row.error) | ForEach-Object {
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) package(s) needing a decision in the job summary."
 
       - name: Summarize failed generations
         if: always()
@@ -879,6 +964,29 @@ jobs:
             }
 
             ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+            # A freshly submitted version supersedes any still-open older PR of
+            # the same package; close those immediately so moderators never see
+            # both. Best-effort: a failure here never fails the submission.
+            $forkRepository = "$env:WINGET_PKGS_FORK_REPO".Trim()
+            if ($forkRepository -match '^(?<Owner>[A-Za-z0-9_.-]+)/') {
+              $newPrNumber = 0
+              if (-not [int]::TryParse("$($result.PrNumber)", [ref] $newPrNumber)) { $newPrNumber = 0 }
+              $superseded = Close-SupersededWingetPrs `
+                -PackageId "$env:MATRIX_PACKAGENAME" `
+                -Version "$env:MATRIX_VERSION" `
+                -BotLogin $Matches['Owner'] `
+                -NewPrNumber $newPrNumber `
+                -NewPrUrl "$($result.PrUrl)" `
+                -Repository "$env:WINGET_PKGS_SUBMISSION_REPOSITORY"
+              foreach ($warning in @($superseded.Warnings)) {
+                Write-Warning $warning
+              }
+              if (@($superseded.ClosedPrNumbers).Count -gt 0) {
+                "**Closed superseded PR(s):** $(@($superseded.ClosedPrNumbers | ForEach-Object { "#$_" }) -join ', ')" |
+                  Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+              }
+            }
           } else {
             Write-Host "Failed to submit PR: $($result.Error)" -ForegroundColor Red
             exit 1

--- a/.github/workflows/upstream-pr-hygiene.yml
+++ b/.github/workflows/upstream-pr-hygiene.yml
@@ -1,0 +1,40 @@
+name: Upstream PR Hygiene
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan only; do not close anything"
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    - cron: "41 6 * * *" # daily, 06:41 UTC
+
+permissions: {}
+
+concurrency:
+  group: upstream-pr-hygiene
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep superseded upstream PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Closes this bot's own open upstream PRs that are superseded by a newer
+      # open PR or whose version is already published; everything else is only
+      # reported (grouped by validation labels) in the job summary.
+      - name: Sweep open upstream PRs
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_UPSTREAM_READ_TOKEN: ${{ secrets.WINGET_PAT }}
+          WINGET_PKGS_FORK_REPO: ${{ vars.WINGET_PKGS_FORK_REPO }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        run: ./scripts/Invoke-UpstreamPrHygiene.ps1

--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ merged PRs while ignoring closed-unmerged PRs. Search/API response failures
 and incomplete result pages fail closed rather than being treated as no
 duplicate.
 
+## Pipeline noise reduction
+
+Four mechanisms keep the scheduled runs green and the upstream review queue
+clean:
+
+- **Installer URL preflight (submit gate).** Immediately before submission,
+  every `InstallerUrl` in the validated manifest is probed (HEAD, ranged-GET
+  fallback). A definitive HTTP 404/410 blocks the submission - the release
+  asset was deleted after generation and the PR would only earn an upstream
+  `URL-Validation-Error`. All other outcomes (403/405/429/5xx, network
+  errors) fail open with a warning; upstream validation stays authoritative.
+- **Safety questions do not fail runs.** When WinMatsch stops at a
+  fail-closed safety question (exit code 4: `ARCH_CONFLICT`, `MAP_REMOVED`,
+  `MAP_STRUCTURAL_REWRITE`, ...), the generate job succeeds and the package is
+  listed in a dedicated *needs-decision* run-summary table instead of failing
+  the workflow. Real generator/infrastructure errors still fail the job.
+  Answer the question by editing the package's matrix entry (URL architecture
+  hints like `...msi|x64`, `overridePack`, or `allowStructuralRewrite`).
+- **Superseded PRs are closed automatically.** After a successful submission,
+  any still-open older-version PR of the same package by the bot is closed
+  with a comment pointing at the successor. The daily `Upstream PR Hygiene`
+  workflow additionally sweeps all open bot PRs: it closes PRs superseded by a
+  newer open PR or whose exact version is already published, and reports the
+  remaining PRs grouped by validation-error labels. Title parsing is strict -
+  anything that does not match this tool's own title format is never touched.
+- **Config health report.** The weekly `Config Health` workflow re-resolves
+  every monitored package's release and verifies each URL template against
+  the real asset list (tagPattern streams are resolved to their own stream).
+  Broken templates (renamed assets, deleted releases, vanished repositories)
+  land in a report instead of producing doomed generation attempts.
+
 ## Package-specific WinMatsch overrides
 
 Keep safety questions enabled by default. When a package has reviewed, stable

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -2495,38 +2495,46 @@
           - id: "OpenHV.OpenHV"
             repo: "OpenHV/OpenHV"
             url: "https://github.com/OpenHV/OpenHV/releases/download/{VERSION}/OpenHV-{VERSION}-x64.exe https://github.com/OpenHV/OpenHV/releases/download/{VERSION}/OpenHV-{VERSION}-x86.exe"
-          - id: "OpenJS.Electron.33"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v33\.'
-          - id: "OpenJS.Electron.34"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v34\.'
-          - id: "OpenJS.Electron.35"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v35\.'
-          - id: "OpenJS.Electron.36"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v36\.'
-          - id: "OpenJS.Electron.37"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v37\.'
-          - id: "OpenJS.Electron.38"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v38\.'
-          - id: "OpenJS.Electron.39"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v39\.'
-          - id: "OpenJS.Electron.40"
-            repo: "electron/electron"
-            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
-            tagPattern: '^v40\.'
+#          OpenJS.Electron.33 is excluded: v33 is end-of-life upstream and its final patch 33.4.11 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.33"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v33\.'
+#          OpenJS.Electron.34 is excluded: v34 is end-of-life upstream and its final patch 34.5.8 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.34"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v34\.'
+#          OpenJS.Electron.35 is excluded: v35 is end-of-life upstream and its final patch 35.7.5 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.35"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v35\.'
+#          OpenJS.Electron.36 is excluded: v36 is end-of-life upstream and its final patch 36.9.5 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.36"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v36\.'
+#          OpenJS.Electron.37 is excluded: v37 is end-of-life upstream and its final patch 37.10.3 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.37"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v37\.'
+#          OpenJS.Electron.38 is excluded: v38 is end-of-life upstream and its final patch 38.8.6 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.38"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v38\.'
+#          OpenJS.Electron.39 is excluded: v39 is end-of-life upstream and its final patch 39.8.10 is already published in winget; the stream's releases fell out of the 30-release window Get-LatestGHVersionTag scans, so every run would fail to resolve it.
+#          - id: "OpenJS.Electron.39"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v39\.'
+#          OpenJS.Electron.40 is excluded: v40 is end-of-life upstream and its final patch 40.10.6 is already published in winget; the stream's releases will shortly fall out of the 30-release window Get-LatestGHVersionTag scans, after which every run would fail to resolve it.
+#          - id: "OpenJS.Electron.40"
+#            repo: "electron/electron"
+#            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+#            tagPattern: '^v40\.'
           - id: "OpenJS.Electron.41"
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
@@ -2535,6 +2543,10 @@
             repo: "electron/electron"
             url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
             tagPattern: '^v42\.'
+          - id: "OpenJS.Electron.43"
+            repo: "electron/electron"
+            url: "https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-ia32.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-x64.zip https://github.com/electron/electron/releases/download/v{VERSION}/electron-v{VERSION}-win32-arm64.zip"
+            tagPattern: '^v43\.'
           - id: "OpenOrienteering.Mapper"
             repo: "OpenOrienteering/mapper"
             url: "https://github.com/OpenOrienteering/mapper/releases/download/v{VERSION}/OpenOrienteering-Mapper-{VERSION}-Windows-x86.exe https://github.com/OpenOrienteering/mapper/releases/download/v{VERSION}/OpenOrienteering-Mapper-{VERSION}-Windows-x64.exe"

--- a/github-releases-monitored.yml
+++ b/github-releases-monitored.yml
@@ -2199,7 +2199,12 @@
             url: "https://github.com/recherchesolutions/mdreader/releases/download/v{VERSION}/mdreader-setup-{VERSION}.exe"
           - id: "melon-masou.MonMouse"
             repo: "melon-masou/MonMouse"
+            # The published 0.2.0 manifest declares x86 for an x64 payload; the
+            # approved rewrite emits x64 plus the VCRedist dependency detected from
+            # the binaries (reviewed 2026-08; drop the approval once a corrected
+            # version is published).
             url: "https://github.com/melon-masou/MonMouse/releases/download/v{VERSION}/monmouse-v{VERSION}-windows.zip"
+            allowStructuralRewrite: true
           - id: "mentebinaria.dz6"
             repo: "mentebinaria/dz6"
             url: "https://github.com/mentebinaria/dz6/releases/download/v{VERSION}/dz6-x86_64-pc-windows-msvc.zip"
@@ -2553,7 +2558,12 @@
             url: "https://github.com/oras-project/oras/releases/download/v{VERSION}/oras_{VERSION}_windows_amd64.zip"
           - id: "orbatschow.kontext"
             repo: "orbatschow/kontext"
-            url: "https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_x86_64.zip https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_arm64.zip"
+            # The published 1.6.0 manifest mislabels the arm64 zip as 'arm'; the arm64
+            # hint plus the structural-rewrite approval lets WinMatsch replace that
+            # stale entry with a correct arm64 installer (reviewed 2026-08; the
+            # approval can be dropped once a corrected version is published).
+            url: "https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_x86_64.zip https://github.com/orbatschow/kontext/releases/download/v{VERSION}/kontext_Windows_arm64.zip|arm64"
+            allowStructuralRewrite: true
           - id: "Orthogonal.APM"
             repo: "orthogonalhq/apm"
             url: "https://github.com/orthogonalhq/apm/releases/download/v{VERSION}/apm-v{VERSION}-x86_64-pc-windows-msvc.zip"
@@ -2710,7 +2720,9 @@
             url: "https://github.com/RikkiGibson/DreamPotato/releases/download/v{VERSION}/DreamPotato-Windows-x64-v{VERSION}.zip"
           - id: "RimSort.RimSort"
             repo: "RimSort/RimSort"
-            url: "https://github.com/RimSort/RimSort/releases/download/v{VERSION}/RimSort-v{VERSION}-Windows_x86_64.msi"
+            # The MSI carries ambiguous embedded architecture evidence; the explicit
+            # x64 hint answers WinMatsch's ARCH_CONFLICT question (reviewed 2026-08).
+            url: "https://github.com/RimSort/RimSort/releases/download/v{VERSION}/RimSort-v{VERSION}-Windows_x86_64.msi|x64"
           - id: "Ripose.Memento"
             repo: "ripose-jp/Memento"
             url: "https://github.com/ripose-jp/Memento/releases/download/v{VERSION}/Memento_Windows_x86_64_Installer.exe"

--- a/modules/WingetMaintainerModule/Private/Test-WingetInstallerUrlsAlive.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-WingetInstallerUrlsAlive.ps1
@@ -1,0 +1,136 @@
+function Test-WingetInstallerUrlsAlive {
+    <#
+    .SYNOPSIS
+        Verifies that every InstallerUrl in a manifest set still resolves before submission.
+
+    .DESCRIPTION
+        Installer downloads happen at generation time; sandbox validation can run
+        much later, and publishers occasionally delete or re-cut release assets in
+        between. Submitting such a manifest produces an upstream
+        URL-Validation-Error pull request that only a human can clean up.
+
+        This preflight probes every InstallerUrl with an HTTP HEAD request
+        (falling back to a single-byte ranged GET when HEAD is rejected) and
+        classifies the outcome:
+          - 2xx/3xx: alive.
+          - 404/410: definitively dead - the submission must be blocked.
+          - Anything else (401/403/405/429/5xx, network errors): inconclusive.
+            The check fails open with a warning so a CDN quirk or transient
+            outage can never block an otherwise valid submission; upstream
+            validation remains the authority for those cases.
+
+    .OUTPUTS
+        PSCustomObject with properties:
+        - Valid: $false only when at least one URL is definitively dead.
+        - DeadUrls: URLs that returned HTTP 404 or 410.
+        - Warnings: human-readable notes for inconclusive probes.
+        - CheckedCount: number of unique URLs probed.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Path')]
+        [string] $ManifestPath,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Urls')]
+        [AllowEmptyCollection()]
+        [string[]] $InstallerUrls,
+
+        # Injectable for tests: receives ($Url, $Method), returns the final
+        # integer HTTP status code after redirects. Throw for transport errors.
+        [Parameter()]
+        [scriptblock] $HttpProbe,
+
+        [Parameter()]
+        [ValidateRange(1, 5)]
+        [int] $MaxAttempts = 3,
+
+        [Parameter()]
+        [scriptblock] $Sleep = { param([int]$Seconds) Start-Sleep -Seconds $Seconds }
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq 'Path') {
+        $installerManifest = Get-ChildItem -Path $ManifestPath -Filter '*.installer.yaml' -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($null -eq $installerManifest) {
+            return [PSCustomObject]@{
+                Valid        = $true
+                DeadUrls     = @()
+                Warnings     = @("No installer manifest found under '$ManifestPath'; skipping the installer URL preflight.")
+                CheckedCount = 0
+            }
+        }
+
+        $InstallerUrls = @(Get-InstallerManifestEntries -Path $installerManifest.FullName |
+                ForEach-Object { $_.InstallerUrl })
+    }
+
+    if ($null -eq $HttpProbe) {
+        $HttpProbe = {
+            param([string] $Url, [string] $Method)
+
+            $parameters = @{
+                Uri                = $Url
+                Method             = $Method
+                MaximumRedirection = 10
+                TimeoutSec         = 30
+                SkipHttpErrorCheck = $true
+                UseBasicParsing    = $true
+                ErrorAction        = 'Stop'
+                Headers            = @{ 'User-Agent' = 'winget-pkgs-updates' }
+            }
+            if ($Method -eq 'Get') {
+                # A ranged GET keeps the fallback cheap on servers that reject HEAD.
+                $parameters.Headers['Range'] = 'bytes=0-0'
+            }
+
+            $response = Invoke-WebRequest @parameters
+            return [int]$response.StatusCode
+        }
+    }
+
+    $deadUrls = [System.Collections.Generic.List[string]]::new()
+    $warnings = [System.Collections.Generic.List[string]]::new()
+    $uniqueUrls = @($InstallerUrls | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique)
+
+    foreach ($url in $uniqueUrls) {
+        $classification = $null
+
+        for ($attempt = 1; $attempt -le $MaxAttempts -and $null -eq $classification; $attempt++) {
+            $statusCode = $null
+            $probeError = $null
+            try {
+                $statusCode = [int](& $HttpProbe $url 'Head')
+                # Some servers reject HEAD outright; retry once with a ranged GET.
+                if ($statusCode -in 400, 403, 405, 501) {
+                    $statusCode = [int](& $HttpProbe $url 'Get')
+                }
+            }
+            catch {
+                $probeError = $_.Exception.Message
+            }
+
+            if ($null -ne $statusCode -and $statusCode -ge 200 -and $statusCode -lt 400) {
+                $classification = 'alive'
+            }
+            elseif ($statusCode -in 404, 410) {
+                $classification = 'dead'
+                $deadUrls.Add($url)
+            }
+            elseif ($attempt -lt $MaxAttempts) {
+                & $Sleep ($attempt * 2)
+            }
+            else {
+                $detail = if ($probeError) { "probe failed: $probeError" } else { "HTTP $statusCode" }
+                $warnings.Add("Installer URL preflight was inconclusive for $url ($detail); continuing because only HTTP 404/410 block submission.")
+                $classification = 'inconclusive'
+            }
+        }
+    }
+
+    return [PSCustomObject]@{
+        Valid        = $deadUrls.Count -eq 0
+        DeadUrls     = @($deadUrls)
+        Warnings     = @($warnings)
+        CheckedCount = $uniqueUrls.Count
+    }
+}

--- a/modules/WingetMaintainerModule/Private/WingetPrSupersession.ps1
+++ b/modules/WingetMaintainerModule/Private/WingetPrSupersession.ps1
@@ -1,0 +1,234 @@
+function Get-WingetPrTitlePackageVersion {
+    <#
+    .SYNOPSIS
+        Extracts the package identifier and version from one of this tool's own
+        pull request titles.
+
+    .DESCRIPTION
+        Only the exact title shapes this repository has ever produced are
+        parsed ("Update version: <id> version <version>" plus the legacy
+        combined "Add version: ... - Update version: ..." form). Anything else
+        returns $null so hygiene decisions are never made from a title whose
+        meaning is uncertain.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Title
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        return $null
+    }
+
+    # The legacy combined form ends with the current form, so matching the
+    # final occurrence covers both.
+    $match = [regex]::Match(
+        $Title.Trim(),
+        '(?:^|\s-\s)(?:Update|Add) version:\s+(?<Package>[A-Za-z0-9._+-]+)\s+version\s+(?<Version>[A-Za-z0-9._+-]+)$')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        PackageIdentifier = $match.Groups['Package'].Value
+        Version           = $match.Groups['Version'].Value
+    }
+}
+
+function Select-WingetSupersededOpenPrs {
+    <#
+    .SYNOPSIS
+        Selects this tool's own open pull requests that are superseded by a
+        newly submitted version of the same package.
+
+    .DESCRIPTION
+        Pure decision logic: given the bot's open upstream pull requests and a
+        freshly submitted package/version, returns the strictly older PRs for
+        the same package that should be closed. PRs whose titles cannot be
+        parsed, that belong to other packages, that carry the same or a newer
+        version, or that are the new PR itself are never selected.
+
+    .OUTPUTS
+        Objects with Number, Title, Version and Reason properties.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]] $OpenPrs,
+
+        [Parameter(Mandatory = $true)]
+        [string] $PackageIdentifier,
+
+        [Parameter(Mandatory = $true)]
+        [string] $NewVersion,
+
+        [Parameter()]
+        [int] $NewPrNumber = 0
+    )
+
+    $newVersionKey = Get-WingetSortableVersionKey -Version $NewVersion
+    $selected = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($pr in $OpenPrs) {
+        if ($null -eq $pr) { continue }
+
+        $number = 0
+        if (-not [int]::TryParse("$($pr.number)", [ref] $number) -or $number -le 0) { continue }
+        if ($NewPrNumber -gt 0 -and $number -eq $NewPrNumber) { continue }
+
+        $parsed = Get-WingetPrTitlePackageVersion -Title "$($pr.title)"
+        if ($null -eq $parsed) { continue }
+        if ($parsed.PackageIdentifier -ine $PackageIdentifier) { continue }
+
+        $versionKey = Get-WingetSortableVersionKey -Version $parsed.Version
+        if ([string]::IsNullOrWhiteSpace($versionKey) -or $versionKey -ge $newVersionKey) { continue }
+
+        $selected.Add([PSCustomObject]@{
+                Number  = $number
+                Title   = "$($pr.title)"
+                Version = $parsed.Version
+                Reason  = "superseded by $PackageIdentifier $NewVersion"
+            })
+    }
+
+    return @($selected)
+}
+
+function Select-WingetHygienePrActions {
+    <#
+    .SYNOPSIS
+        Plans hygiene actions for this tool's own open upstream pull requests.
+
+    .DESCRIPTION
+        Pure decision logic for the scheduled PR hygiene sweep. For every
+        parsable open PR of the bot it decides:
+          - close-superseded: an open PR for the same package carries a newer
+            version (ties are kept: equal versions are left for the duplicate
+            detection in the submission path).
+          - close-published: the PR's exact version is already published in
+            winget-pkgs (the PR itself is open, so it was closed/rejected
+            upstream or someone else shipped the version first).
+          - keep: everything else, annotated with the PR's validation labels so
+            the sweep summary can group attention-needing PRs.
+        Unparsable titles are always kept untouched.
+
+    .OUTPUTS
+        Objects with Action (close-superseded | close-published | keep),
+        Number, Title, PackageIdentifier, Version, Reason and Labels.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        # Objects with number, title and optionally labels (names or objects with a name property).
+        [object[]] $OpenPrs,
+
+        # Receives a package identifier, returns the published version strings
+        # for that package (empty array when the package does not exist).
+        # Optional: when omitted, the published check is skipped entirely.
+        [Parameter()]
+        [scriptblock] $PublishedVersionsResolver
+    )
+
+    $actions = [System.Collections.Generic.List[object]]::new()
+    $parsedPrs = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($pr in $OpenPrs) {
+        if ($null -eq $pr) { continue }
+
+        $number = 0
+        if (-not [int]::TryParse("$($pr.number)", [ref] $number) -or $number -le 0) { continue }
+
+        $labels = @()
+        $labelsProperty = $pr.PSObject.Properties['labels']
+        if ($null -ne $labelsProperty -and $null -ne $labelsProperty.Value) {
+            $labels = @($labelsProperty.Value | ForEach-Object {
+                    if ($_ -is [string]) { $_ } else { [string]$_.name }
+                } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        }
+
+        $parsed = Get-WingetPrTitlePackageVersion -Title "$($pr.title)"
+        if ($null -eq $parsed) {
+            $actions.Add([PSCustomObject]@{
+                    Action            = 'keep'
+                    Number            = $number
+                    Title             = "$($pr.title)"
+                    PackageIdentifier = $null
+                    Version           = $null
+                    Reason            = 'title not parsable; never touched'
+                    Labels            = $labels
+                })
+            continue
+        }
+
+        $parsedPrs.Add([PSCustomObject]@{
+                Number            = $number
+                Title             = "$($pr.title)"
+                PackageIdentifier = $parsed.PackageIdentifier
+                Version           = $parsed.Version
+                VersionKey        = Get-WingetSortableVersionKey -Version $parsed.Version
+                Labels            = $labels
+            })
+    }
+
+    $publishedCache = @{}
+
+    foreach ($group in ($parsedPrs | Group-Object -Property { $_.PackageIdentifier.ToLowerInvariant() })) {
+        # Newest version first; ties resolved toward the higher PR number so
+        # exactly one PR per package survives the supersession pass.
+        $ordered = @($group.Group | Sort-Object -Property @{ Expression = { $_.VersionKey } }, @{ Expression = { $_.Number } } -Descending)
+        $newest = $ordered[0]
+
+        foreach ($pr in $ordered) {
+            if ($pr.Number -ne $newest.Number -and $pr.VersionKey -lt $newest.VersionKey) {
+                $actions.Add([PSCustomObject]@{
+                        Action            = 'close-superseded'
+                        Number            = $pr.Number
+                        Title             = $pr.Title
+                        PackageIdentifier = $pr.PackageIdentifier
+                        Version           = $pr.Version
+                        Reason            = "superseded by open PR #$($newest.Number) ($($newest.PackageIdentifier) $($newest.Version))"
+                        Labels            = $pr.Labels
+                    })
+                continue
+            }
+
+            $publishedMatch = $false
+            if ($null -ne $PublishedVersionsResolver) {
+                $cacheKey = $pr.PackageIdentifier.ToLowerInvariant()
+                if (-not $publishedCache.ContainsKey($cacheKey)) {
+                    $publishedCache[$cacheKey] = @(& $PublishedVersionsResolver $pr.PackageIdentifier)
+                }
+                $publishedMatch = @($publishedCache[$cacheKey]) -contains $pr.Version
+            }
+
+            if ($publishedMatch) {
+                $actions.Add([PSCustomObject]@{
+                        Action            = 'close-published'
+                        Number            = $pr.Number
+                        Title             = $pr.Title
+                        PackageIdentifier = $pr.PackageIdentifier
+                        Version           = $pr.Version
+                        Reason            = "version $($pr.Version) is already published in winget-pkgs"
+                        Labels            = $pr.Labels
+                    })
+            }
+            else {
+                $actions.Add([PSCustomObject]@{
+                        Action            = 'keep'
+                        Number            = $pr.Number
+                        Title             = $pr.Title
+                        PackageIdentifier = $pr.PackageIdentifier
+                        Version           = $pr.Version
+                        Reason            = 'open and current'
+                        Labels            = $pr.Labels
+                    })
+            }
+        }
+    }
+
+    return @($actions | Sort-Object -Property Number)
+}

--- a/modules/WingetMaintainerModule/Public/Close-SupersededWingetPrs.ps1
+++ b/modules/WingetMaintainerModule/Public/Close-SupersededWingetPrs.ps1
@@ -1,0 +1,139 @@
+function Close-SupersededWingetPrs {
+    <#
+    .SYNOPSIS
+        Closes this tool's own older open upstream PRs after a newer version of
+        the same package was submitted.
+
+    .DESCRIPTION
+        When version N+1 is submitted while the bot's version-N pull request is
+        still open, the older PR can never merge and only costs moderator
+        attention. This function searches the bot's open pull requests for the
+        package, selects the strictly older ones via
+        Select-WingetSupersededOpenPrs, and closes each with a short comment
+        pointing at the successor.
+
+        The operation is strictly best-effort and fail-open: any search or
+        close failure is reported as a warning and never fails the caller,
+        because the new PR - the thing that matters - already exists.
+
+    .PARAMETER BotLogin
+        The GitHub login whose PRs may be closed. Only PRs authored by this
+        login are ever considered.
+
+    .PARAMETER MaxCloses
+        Upper bound of closes per invocation; a safety valve against runaway
+        title parsing.
+
+    .OUTPUTS
+        PSCustomObject with ClosedPrNumbers, SkippedCount and Warnings.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Version,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $BotLogin,
+
+        [Parameter()]
+        [int] $NewPrNumber = 0,
+
+        [Parameter()]
+        [string] $NewPrUrl,
+
+        [Parameter(Mandatory = $false)]
+        [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+        [string] $Repository = 'microsoft/winget-pkgs',
+
+        [Parameter()]
+        [ValidateRange(1, 20)]
+        [int] $MaxCloses = 5,
+
+        # Injectable for tests: returns objects with number and title for the
+        # bot's open PRs mentioning the package.
+        [Parameter()]
+        [scriptblock] $SearchInvoker,
+
+        # Injectable for tests: receives ($Number, $Comment); performs the close.
+        [Parameter()]
+        [scriptblock] $CloseInvoker
+    )
+
+    $warnings = [System.Collections.Generic.List[string]]::new()
+    $closed = [System.Collections.Generic.List[int]]::new()
+
+    if ($null -eq $SearchInvoker) {
+        $SearchInvoker = {
+            $query = "repo:$Repository is:pr is:open author:$BotLogin in:title `"$PackageId`""
+            $raw = Invoke-GhCliWithRetry -OperationName "superseded-PR search for $PackageId" -ScriptBlock {
+                gh api --paginate -X GET 'search/issues' -f q=$query --jq '[.items[] | {number: .number, title: .title}]'
+            }
+            $json = (@($raw) -join "`n").Trim()
+            if ([string]::IsNullOrWhiteSpace($json)) { return @() }
+            # --paginate can emit one JSON array per page; normalize to objects.
+            return @($json -split "(?<=\])\s*(?=\[)" | ForEach-Object { $_ | ConvertFrom-Json } | ForEach-Object { $_ })
+        }
+    }
+
+    if ($null -eq $CloseInvoker) {
+        $CloseInvoker = {
+            param([int] $Number, [string] $Comment)
+            Invoke-GhCliWithRetry -OperationName "close superseded PR #$Number" -ScriptBlock {
+                gh pr close $Number --repo $Repository --comment $Comment
+            } | Out-Null
+        }
+    }
+
+    try {
+        $openPrs = @(& $SearchInvoker)
+    }
+    catch {
+        $warnings.Add("Superseded-PR search failed for ${PackageId}: $($_.Exception.Message)")
+        return [PSCustomObject]@{
+            ClosedPrNumbers = @()
+            SkippedCount    = 0
+            Warnings        = @($warnings)
+        }
+    }
+
+    $candidates = @(Select-WingetSupersededOpenPrs `
+            -OpenPrs $openPrs `
+            -PackageIdentifier $PackageId `
+            -NewVersion $Version `
+            -NewPrNumber $NewPrNumber)
+
+    $skipped = 0
+    foreach ($candidate in $candidates) {
+        if ($closed.Count -ge $MaxCloses) {
+            $skipped++
+            continue
+        }
+
+        $successor = if (-not [string]::IsNullOrWhiteSpace($NewPrUrl)) { $NewPrUrl } else { "$PackageId $Version" }
+        $comment = "Superseded by $successor. Closing this older automated update to keep the review queue clean."
+        try {
+            & $CloseInvoker $candidate.Number $comment
+            $closed.Add($candidate.Number)
+            Write-Host "Closed superseded PR #$($candidate.Number) ($($candidate.Title))."
+        }
+        catch {
+            $warnings.Add("Could not close superseded PR #$($candidate.Number): $($_.Exception.Message)")
+        }
+    }
+
+    if ($skipped -gt 0) {
+        $warnings.Add("Skipped $skipped superseded candidate(s) beyond the MaxCloses=$MaxCloses safety cap.")
+    }
+
+    return [PSCustomObject]@{
+        ClosedPrNumbers = @($closed)
+        SkippedCount    = $skipped
+        Warnings        = @($warnings)
+    }
+}

--- a/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Submit-WingetPackage.ps1
@@ -213,6 +213,26 @@ function Submit-WingetPackage {
         }
         $submitReadySnapshot = Get-SubmittedManifestSnapshot -ManifestPath $fullManifestPath
 
+        # Publishers occasionally delete or re-cut release assets between
+        # generation and submission; a dead InstallerUrl would produce an
+        # upstream URL-Validation-Error PR that only a human can clean up.
+        # Only definitive HTTP 404/410 block the submission (fail-open otherwise).
+        $urlPreflight = Test-WingetInstallerUrlsAlive -ManifestPath $fullManifestPath
+        foreach ($urlWarning in $urlPreflight.Warnings) {
+            Write-Warning $urlWarning
+        }
+        if (-not $urlPreflight.Valid) {
+            return @{
+                Success  = $false
+                Error    = "Installer URL preflight failed; the following installer URL(s) no longer exist (HTTP 404/410): $($urlPreflight.DeadUrls -join ', '). The release asset was likely removed after manifest generation."
+                PrUrl    = $null
+                PrNumber = $null
+            }
+        }
+        if ($urlPreflight.CheckedCount -gt 0) {
+            Write-Host "Installer URL preflight passed for $($urlPreflight.CheckedCount) URL(s)." -ForegroundColor Gray
+        }
+
         switch ($With) {
             "WinMatsch" {
                 # Ensure WinMatsch is installed

--- a/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
@@ -104,42 +104,59 @@ function Test-MonitoredPackageAssets {
         }
     }
 
-    # Pass 2: tagPattern packages need the recent release list to pick their stream.
+    # Pass 2: tagPattern packages need the recent release list to pick their
+    # stream. Multiple packages often share one repository (e.g. every
+    # Electron major), so the release list is fetched once per unique repo -
+    # asset-heavy repositories make the per-package form time out server-side.
     $tagPatternArray = @($withTagPattern)
-    for ($offset = 0; $offset -lt $tagPatternArray.Count; $offset += $TagPatternBatchSize) {
-        $slice = @($tagPatternArray[$offset..([Math]::Min($offset + $TagPatternBatchSize, $tagPatternArray.Count) - 1)])
+    $releaseNodesByRepo = @{}
+    $repoMissingByRepo = @{}
+    $uniqueTagPatternRepos = @($tagPatternArray |
+            ForEach-Object { Get-WingetPrecheckPackageField -Package $_ -Name 'repo' } |
+            Sort-Object -Unique)
+
+    for ($offset = 0; $offset -lt $uniqueTagPatternRepos.Count; $offset += $TagPatternBatchSize) {
+        $slice = @($uniqueTagPatternRepos[$offset..([Math]::Min($offset + $TagPatternBatchSize, $uniqueTagPatternRepos.Count) - 1)])
         $fields = for ($i = 0; $i -lt $slice.Count; $i++) {
-            $owner, $name = (Get-WingetPrecheckPackageField -Package $slice[$i] -Name 'repo').Split('/', 2)
-            "t$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { releases(first: 60, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { isDraft isPrerelease publishedAt $releaseSelection } } }"
+            $owner, $name = $slice[$i].Split('/', 2)
+            "t$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { releases(first: 40, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { isDraft isPrerelease publishedAt $releaseSelection } } }"
         }
         $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
         $response = & $GraphQlInvoker $query
         $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
 
         for ($i = 0; $i -lt $slice.Count; $i++) {
-            $slicePackage = $slice[$i]
             $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "t$i"
-            $release = $null
-
-            if ($null -ne $repository) {
-                $tagPattern = Get-WingetPrecheckPackageField -Package $slicePackage -Name 'tagPattern'
-                $releasesValue = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $repository -Name 'releases') -Name 'nodes'
-                $releaseNodes = if ($null -eq $releasesValue) { @() } else { @($releasesValue) }
-                $matching = @($releaseNodes |
-                        Where-Object {
-                            $null -ne $_ -and
-                            -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isDraft') -and
-                            -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isPrerelease') -and
-                            "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'tagName')" -match $tagPattern
-                        } |
-                        Sort-Object -Property @{ Expression = { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'publishedAt')" } } -Descending)
-                if ($matching.Count -gt 0) {
-                    $release = $matching[0]
-                }
+            if ($null -eq $repository) {
+                $repoMissingByRepo[$slice[$i]] = $true
+                continue
             }
-
-            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $slicePackage -Repository $repository -Release $release -NoReleaseStatus 'NoMatchingRelease'))
+            $releasesValue = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $repository -Name 'releases') -Name 'nodes'
+            $releaseNodesByRepo[$slice[$i]] = if ($null -eq $releasesValue) { @() } else { @($releasesValue) }
         }
+    }
+
+    foreach ($package in $tagPatternArray) {
+        $repo = Get-WingetPrecheckPackageField -Package $package -Name 'repo'
+
+        if ($repoMissingByRepo.ContainsKey($repo)) {
+            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $package -Repository $null -Release $null -NoReleaseStatus 'NoMatchingRelease'))
+            continue
+        }
+
+        $tagPattern = Get-WingetPrecheckPackageField -Package $package -Name 'tagPattern'
+        $releaseNodes = @($releaseNodesByRepo[$repo])
+        $matching = @($releaseNodes |
+                Where-Object {
+                    $null -ne $_ -and
+                    -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isDraft') -and
+                    -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isPrerelease') -and
+                    "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'tagName')" -match $tagPattern
+                } |
+                Sort-Object -Property @{ Expression = { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'publishedAt')" } } -Descending)
+        $release = if ($matching.Count -gt 0) { $matching[0] } else { $null }
+
+        $results.Add((Resolve-WingetMonitoredAssetStatus -Package $package -Repository ([PSCustomObject]@{ present = $true }) -Release $release -NoReleaseStatus 'NoMatchingRelease'))
     }
 
     return @($results | Sort-Object -Property PackageId)

--- a/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
@@ -1,0 +1,237 @@
+function Test-MonitoredPackageAssets {
+    <#
+    .SYNOPSIS
+        Verifies that every monitored package's release-asset URL template still
+        matches a real asset on the package's current GitHub release.
+
+    .DESCRIPTION
+        Publishers rename assets, change naming schemes, delete releases, or
+        archive repositories. Any of those turns a monitored package into a
+        permanent source of failed generations or, worse, upstream
+        URL-Validation-Error pull requests. This function performs a read-only
+        sweep over the monitored configuration using batched GraphQL queries
+        (mirroring the update precheck's query shapes) and reports one status
+        per package:
+
+          - OK: every URL template resolves to an existing release asset.
+          - RepoMissing: the GitHub repository no longer exists (or is private).
+          - NoRelease: the repository has no published stable release.
+          - NoMatchingRelease: no stable release matches the tagPattern.
+          - VersionUnresolved: versionSource=ReleaseName and the release has no
+            usable name.
+          - AssetMissing: at least one URL template matches no asset on the
+            resolved release (details list the missing URLs).
+          - Inconclusive: the release carries more than 100 assets, so a missed
+            match cannot be distinguished from truncation.
+          - Skipped: the entry has no repo/url pair to check.
+
+    .OUTPUTS
+        One PSCustomObject per package: PackageId, Repo, Status, Detail, Tag.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]] $Packages,
+
+        # Injectable for tests: receives the GraphQL query string, returns the parsed response.
+        [Parameter()]
+        [scriptblock] $GraphQlInvoker,
+
+        [Parameter()]
+        [ValidateRange(1, 100)]
+        [int] $BatchSize = 40,
+
+        [Parameter()]
+        [ValidateRange(1, 20)]
+        [int] $TagPatternBatchSize = 5
+    )
+
+    if ($null -eq $GraphQlInvoker) {
+        $GraphQlInvoker = { param([string] $Query) Invoke-WingetPrecheckGraphQlRequest -Query $Query }
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    $simple = [System.Collections.Generic.List[object]]::new()
+    $withTagPattern = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($package in $Packages) {
+        $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
+        $repo = Get-WingetPrecheckPackageField -Package $package -Name 'repo'
+        $url = Get-WingetPrecheckPackageField -Package $package -Name 'url'
+        $tagPattern = Get-WingetPrecheckPackageField -Package $package -Name 'tagPattern'
+
+        if ([string]::IsNullOrWhiteSpace($packageId) -or
+            [string]::IsNullOrWhiteSpace($repo) -or
+            [string]::IsNullOrWhiteSpace($url) -or
+            $repo -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+            $results.Add([PSCustomObject]@{
+                    PackageId = $packageId
+                    Repo      = $repo
+                    Status    = 'Skipped'
+                    Detail    = 'No checkable repo/url template.'
+                    Tag       = $null
+                })
+            continue
+        }
+
+        if ([string]::IsNullOrWhiteSpace($tagPattern)) {
+            $simple.Add($package)
+        }
+        else {
+            $withTagPattern.Add($package)
+        }
+    }
+
+    $releaseSelection = 'tagName name releaseAssets(first: 100) { totalCount nodes { downloadUrl } }'
+
+    # Pass 1: packages that follow the repository's latest stable release.
+    $simpleArray = @($simple)
+    for ($offset = 0; $offset -lt $simpleArray.Count; $offset += $BatchSize) {
+        $slice = @($simpleArray[$offset..([Math]::Min($offset + $BatchSize, $simpleArray.Count) - 1)])
+        $fields = for ($i = 0; $i -lt $slice.Count; $i++) {
+            $owner, $name = (Get-WingetPrecheckPackageField -Package $slice[$i] -Name 'repo').Split('/', 2)
+            "a$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { latestRelease { $releaseSelection } }"
+        }
+        $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
+        $response = & $GraphQlInvoker $query
+        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
+
+        for ($i = 0; $i -lt $slice.Count; $i++) {
+            $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "a$i"
+            $release = Get-WingetGraphQlFieldValue -InputObject $repository -Name 'latestRelease'
+            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $slice[$i] -Repository $repository -Release $release))
+        }
+    }
+
+    # Pass 2: tagPattern packages need the recent release list to pick their stream.
+    $tagPatternArray = @($withTagPattern)
+    for ($offset = 0; $offset -lt $tagPatternArray.Count; $offset += $TagPatternBatchSize) {
+        $slice = @($tagPatternArray[$offset..([Math]::Min($offset + $TagPatternBatchSize, $tagPatternArray.Count) - 1)])
+        $fields = for ($i = 0; $i -lt $slice.Count; $i++) {
+            $owner, $name = (Get-WingetPrecheckPackageField -Package $slice[$i] -Name 'repo').Split('/', 2)
+            "t$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { releases(first: 60, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { isDraft isPrerelease publishedAt $releaseSelection } } }"
+        }
+        $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
+        $response = & $GraphQlInvoker $query
+        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
+
+        for ($i = 0; $i -lt $slice.Count; $i++) {
+            $slicePackage = $slice[$i]
+            $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "t$i"
+            $release = $null
+
+            if ($null -ne $repository) {
+                $tagPattern = Get-WingetPrecheckPackageField -Package $slicePackage -Name 'tagPattern'
+                $releasesValue = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $repository -Name 'releases') -Name 'nodes'
+                $releaseNodes = if ($null -eq $releasesValue) { @() } else { @($releasesValue) }
+                $matching = @($releaseNodes |
+                        Where-Object {
+                            $null -ne $_ -and
+                            -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isDraft') -and
+                            -not [bool](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'isPrerelease') -and
+                            "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'tagName')" -match $tagPattern
+                        } |
+                        Sort-Object -Property @{ Expression = { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'publishedAt')" } } -Descending)
+                if ($matching.Count -gt 0) {
+                    $release = $matching[0]
+                }
+            }
+
+            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $slicePackage -Repository $repository -Release $release -NoReleaseStatus 'NoMatchingRelease'))
+        }
+    }
+
+    return @($results | Sort-Object -Property PackageId)
+}
+
+function Resolve-WingetMonitoredAssetStatus {
+    <#
+    .SYNOPSIS
+        Classifies one monitored package against its resolved GitHub release.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter()] $Repository,
+        [Parameter()] $Release,
+        [Parameter()] [string] $NoReleaseStatus = 'NoRelease'
+    )
+
+    $packageId = Get-WingetPrecheckPackageField -Package $Package -Name 'id'
+    $repo = Get-WingetPrecheckPackageField -Package $Package -Name 'repo'
+    $url = Get-WingetPrecheckPackageField -Package $Package -Name 'url'
+    $versionSource = Get-WingetPrecheckPackageField -Package $Package -Name 'versionSource'
+
+    $newResult = {
+        param([string] $Status, [string] $Detail, [string] $Tag)
+        [PSCustomObject]@{
+            PackageId = $packageId
+            Repo      = $repo
+            Status    = $Status
+            Detail    = $Detail
+            Tag       = $Tag
+        }
+    }
+
+    if ($null -eq $Repository) {
+        return & $newResult 'RepoMissing' 'The GitHub repository does not exist or is not readable.' $null
+    }
+    if ($null -eq $Release) {
+        return & $newResult $NoReleaseStatus 'No published stable release resolves for this package.' $null
+    }
+
+    $tag = [string](Get-WingetGraphQlFieldValue -InputObject $Release -Name 'tagName')
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        return & $newResult $NoReleaseStatus 'The resolved release has no tag.' $null
+    }
+
+    $version = if ($versionSource -eq 'ReleaseName') {
+        [string](Get-WingetGraphQlFieldValue -InputObject $Release -Name 'name')
+    }
+    else {
+        Remove-GHTagPrefixes -Tag $tag
+    }
+    if ([string]::IsNullOrWhiteSpace($version)) {
+        return & $newResult 'VersionUnresolved' 'The resolved release has no usable version (empty release name).' $tag
+    }
+    $version = $version.Trim()
+
+    $assetsObject = Get-WingetGraphQlFieldValue -InputObject $Release -Name 'releaseAssets'
+    $assetNodesValue = Get-WingetGraphQlFieldValue -InputObject $assetsObject -Name 'nodes'
+    $assetNodes = if ($null -eq $assetNodesValue) { @() } else { @($assetNodesValue) }
+    $assetUrls = @($assetNodes | ForEach-Object { [string](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'downloadUrl') })
+    $totalCountValue = Get-WingetGraphQlFieldValue -InputObject $assetsObject -Name 'totalCount'
+    $assetsTruncated = $null -ne $totalCountValue -and [int]$totalCountValue -gt $assetUrls.Count
+
+    $missing = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($entry in @(Get-InstallerUrlEntries -InstallerValues @($url.Split(' ')))) {
+        $template = $entry.InstallerUrl
+        if ($template -match '\{ARPVERSION\}') {
+            $assetRegex = [regex]::Escape($template).
+                Replace('\{ARPVERSION}', '(.+?)').
+                Replace('\{TAG}', [regex]::Escape($tag)).
+                Replace('\{VERSION}', [regex]::Escape($version))
+            $matched = @($assetUrls | Where-Object { $_ -match $assetRegex }).Count -gt 0
+            if (-not $matched) {
+                $missing.Add($template)
+            }
+            continue
+        }
+
+        $expectedUrl = $template.Replace('{TAG}', $tag).Replace('{VERSION}', $version)
+        if (-not (@($assetUrls | Where-Object { $_ -ieq $expectedUrl }).Count -gt 0)) {
+            $missing.Add($expectedUrl)
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        if ($assetsTruncated) {
+            return & $newResult 'Inconclusive' "The release lists more than $($assetUrls.Count) assets; unmatched URL(s) may exist beyond the first page: $($missing -join ' ')" $tag
+        }
+        return & $newResult 'AssetMissing' "No release asset matches: $($missing -join ' ')" $tag
+    }
+
+    return & $newResult 'OK' "All URL templates resolve against release $tag." $tag
+}

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -286,6 +286,30 @@ function Update-WingetPackage {
                     $generatorError = Get-GeneratorFailureMessage -GeneratorOutput $generatorOutput
                 }
 
+                # WinMatsch exit code 4 means the run stopped at a fail-closed
+                # safety question (ARCH_CONFLICT, MAP_REMOVED, ...). That is the
+                # tool working as designed - a human has to review the package
+                # config - so it must not fail the scheduled run like an
+                # infrastructure error would. The workflow renders these
+                # packages in a dedicated needs-decision summary instead.
+                if ($EffectiveWith -eq 'WinMatsch' -and $generatorExitCode -eq 4) {
+                    $result.Reason = "QuestionsRequired"
+                    Write-Warning "$EffectiveWith stopped at a safety question for $wingetPackage $($Latest.Version): $generatorError Review the package's matrix entry (URL architecture hints, overridePack, allowStructuralRewrite)."
+
+                    if ($env:GITHUB_OUTPUT) {
+                        "generated=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "reason=QuestionsRequired" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "package-id=$wingetPackage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "version=$($Latest.Version)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "generator=$EffectiveWith" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "generator-exit-code=$generatorExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "error-code=$generatorErrorCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                        "error=$generatorError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    }
+
+                    return $result
+                }
+
                 $result.Reason = "GeneratorFailed"
 
                 # Surface the failure details so the workflow can render them in the run summary.

--- a/scripts/Invoke-UpstreamPrHygiene.ps1
+++ b/scripts/Invoke-UpstreamPrHygiene.ps1
@@ -1,0 +1,142 @@
+# Scheduled hygiene sweep over this bot's own open microsoft/winget-pkgs
+# pull requests.
+#
+# Two situations produce noise the moderators should never see:
+#   * an older-version PR stays open after a newer version was submitted, and
+#   * a PR stays open although its exact version is already published.
+# Both are closed here (with a short comment); everything else is only
+# reported, grouped by validation labels, so stuck PRs stay visible without
+# any risky automation.
+#
+# Inputs (environment):
+#   GH_TOKEN                    Token used by gh for search and closing (the
+#                               PRs belong to this token's account).
+#   WINGET_PKGS_REPOSITORY      Target repository (default microsoft/winget-pkgs).
+#   BOT_LOGIN                   GitHub login whose PRs are swept. Required.
+#   DRY_RUN                     'true' plans but never closes.
+#   MAX_CLOSES                  Per-run close cap (default 10).
+#   GITHUB_STEP_SUMMARY         Markdown summary target (optional).
+$ErrorActionPreference = 'Stop'
+
+$module = Import-Module (Join-Path $PSScriptRoot '..' 'modules' 'WingetMaintainerModule' 'WingetMaintainerModule.psd1') -Force -PassThru
+
+$repository = if ([string]::IsNullOrWhiteSpace($env:WINGET_PKGS_REPOSITORY)) { 'microsoft/winget-pkgs' } else { $env:WINGET_PKGS_REPOSITORY.Trim() }
+$botLogin = "$env:BOT_LOGIN".Trim()
+if ([string]::IsNullOrWhiteSpace($botLogin) -and "$env:WINGET_PKGS_FORK_REPO".Trim() -match '^(?<Owner>[A-Za-z0-9_.-]+)/') {
+    # The fork owner is the account whose PAT opens the upstream PRs.
+    $botLogin = $Matches['Owner']
+}
+if ([string]::IsNullOrWhiteSpace($botLogin)) {
+    throw 'BOT_LOGIN (or WINGET_PKGS_FORK_REPO) is required so the sweep can never touch anyone else''s pull requests.'
+}
+$dryRun = "$env:DRY_RUN" -eq 'true'
+$maxCloses = 10
+if (-not [string]::IsNullOrWhiteSpace($env:MAX_CLOSES) -and [int]::TryParse($env:MAX_CLOSES.Trim(), [ref] $maxCloses)) {
+    $maxCloses = [Math]::Max(0, $maxCloses)
+}
+
+Write-Host "Sweeping open PRs by $botLogin in $repository (dry run: $dryRun, close cap: $maxCloses)."
+
+$openPrsJson = gh pr list --repo $repository --author $botLogin --state open --limit 200 --json number,title,url,labels
+if ($LASTEXITCODE -ne 0) {
+    throw "gh pr list failed with exit code $LASTEXITCODE."
+}
+$openPrs = @($openPrsJson | ConvertFrom-Json)
+Write-Host "Found $($openPrs.Count) open PR(s)."
+
+# The published-version resolver runs inside the module scope because the
+# GitHub helpers it needs are private module functions.
+$actions = @(& $module {
+        param($OpenPrs, $Repository)
+
+        # GetNewClosure pins $Repository for the resolver regardless of the
+        # dynamic scope it is eventually invoked from.
+        $resolver = {
+            param([string] $PackageIdentifier)
+            try {
+                $published = Get-WingetPublishedVersionsFromGitHub -PackageIdentifier $PackageIdentifier -Repository $Repository
+                if ($published.PackageExists) { @($published.Versions) } else { @() }
+            }
+            catch {
+                Write-Warning "Published-version lookup failed for ${PackageIdentifier}: $($_.Exception.Message); treating as not published."
+                @()
+            }
+        }.GetNewClosure()
+
+        Select-WingetHygienePrActions -OpenPrs $OpenPrs -PublishedVersionsResolver $resolver
+    } $openPrs $repository)
+
+$toClose = @($actions | Where-Object { $_.Action -in @('close-superseded', 'close-published') })
+$kept = @($actions | Where-Object { $_.Action -eq 'keep' })
+
+$closed = [System.Collections.Generic.List[object]]::new()
+$closeFailures = [System.Collections.Generic.List[string]]::new()
+
+foreach ($action in $toClose) {
+    if ($closed.Count -ge $maxCloses) {
+        Write-Warning "Close cap of $maxCloses reached; leaving PR #$($action.Number) for the next run."
+        continue
+    }
+
+    $comment = "Closing this automated update: $($action.Reason). This keeps the review queue free of superseded submissions."
+    if ($dryRun) {
+        Write-Host "[dry-run] Would close #$($action.Number) ($($action.Title)) - $($action.Reason)"
+        $closed.Add($action)
+        continue
+    }
+
+    gh pr close $action.Number --repo $repository --comment $comment
+    if ($LASTEXITCODE -ne 0) {
+        $closeFailures.Add("PR #$($action.Number) could not be closed (gh exit code $LASTEXITCODE).")
+        continue
+    }
+    Write-Host "Closed #$($action.Number) ($($action.Title)) - $($action.Reason)"
+    $closed.Add($action)
+}
+
+$attentionLabels = @('Validation-Executable-Error', 'Validation-Defender-Error', 'URL-Validation-Error', 'Internal-Error-Dynamic-Scan', 'Manifest-Metadata-Consistency', 'Needs-Attention', 'Needs-Author-Feedback', 'Validation-Certificate-Root')
+$needsAttention = @($kept | Where-Object { @($_.Labels | Where-Object { $_ -in $attentionLabels }).Count -gt 0 })
+
+$summary = [System.Collections.Generic.List[string]]::new()
+$summary.Add('## Upstream PR hygiene')
+$summary.Add('')
+$modeNote = if ($dryRun) { ' (dry run - nothing was closed)' } else { '' }
+$summary.Add("Open PRs: **$($openPrs.Count)** | closed this run: **$($closed.Count)**$modeNote | kept: $($kept.Count)")
+$summary.Add('')
+
+if ($closed.Count -gt 0) {
+    $summary.Add('### Closed as superseded/published')
+    $summary.Add('')
+    $summary.Add('| PR | Package | Version | Reason |')
+    $summary.Add('| --- | --- | --- | --- |')
+    foreach ($row in $closed) {
+        $summary.Add("| #$($row.Number) | $($row.PackageIdentifier) | $($row.Version) | $($row.Reason.Replace('|', '\|')) |")
+    }
+    $summary.Add('')
+}
+
+if ($needsAttention.Count -gt 0) {
+    $summary.Add('### :warning: Open PRs with validation errors (need a human or a retry)')
+    $summary.Add('')
+    $summary.Add('| PR | Package | Version | Labels |')
+    $summary.Add('| --- | --- | --- | --- |')
+    foreach ($row in ($needsAttention | Sort-Object -Property Number)) {
+        $labelText = (@($row.Labels | Where-Object { $_ -in $attentionLabels }) -join ', ')
+        $summary.Add("| #$($row.Number) | $($row.PackageIdentifier) | $($row.Version) | $labelText |")
+    }
+    $summary.Add('')
+}
+
+foreach ($failure in $closeFailures) {
+    $summary.Add(":x: $failure")
+}
+
+$summaryText = $summary -join "`n"
+Write-Host $summaryText
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+}
+
+if ($closeFailures.Count -gt 0) {
+    exit 1
+}

--- a/scripts/Test-MonitoredPackageAssets.ps1
+++ b/scripts/Test-MonitoredPackageAssets.ps1
@@ -1,0 +1,87 @@
+# Read-only health check for the monitored package configuration.
+#
+# Verifies that every active package's release-asset URL template still
+# matches a real asset on the package's current GitHub release, so broken
+# templates (renamed assets, deleted releases, archived repositories) are
+# caught in a weekly report instead of surfacing as failed generations or
+# upstream URL-Validation-Error pull requests.
+#
+# Inputs (environment):
+#   MONITORED_PACKAGES_FILE  Path to the generated packages JSON sidecar
+#                            (defaults to the 1-z sidecar).
+#   GITHUB_STEP_SUMMARY      Markdown summary target (optional).
+#   GITHUB_OUTPUT            Receives broken_count / checked_count (optional).
+#
+# The script always exits 0: it is a report, not a gate. The workflow
+# publishes the summary and the JSON report artifact.
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot '..' 'modules' 'WingetMaintainerModule' 'WingetMaintainerModule.psd1') -Force
+
+$packagesPath = $env:MONITORED_PACKAGES_FILE
+if ([string]::IsNullOrWhiteSpace($packagesPath)) {
+    $packagesPath = Join-Path $PSScriptRoot '..' '.github' 'workflows-data' 'update-github-packages-1-z.packages.json'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($packagesPath)) {
+    $packagesPath = Join-Path $PSScriptRoot '..' $packagesPath
+}
+
+if (-not (Test-Path -LiteralPath $packagesPath)) {
+    throw "Monitored packages file not found: $packagesPath"
+}
+
+$packages = @(Get-Content -LiteralPath $packagesPath -Raw | ConvertFrom-Json)
+Write-Host "Checking release-asset URL templates for $($packages.Count) monitored package(s)."
+
+$results = @(Test-MonitoredPackageAssets -Packages $packages)
+
+$broken = @($results | Where-Object { $_.Status -in @('RepoMissing', 'NoRelease', 'NoMatchingRelease', 'VersionUnresolved', 'AssetMissing') })
+$inconclusive = @($results | Where-Object { $_.Status -eq 'Inconclusive' })
+$ok = @($results | Where-Object { $_.Status -eq 'OK' })
+$skipped = @($results | Where-Object { $_.Status -eq 'Skipped' })
+
+$reportPath = './config-health-report.json'
+ConvertTo-Json -InputObject @($results) -Depth 4 | Set-Content -Path $reportPath -Encoding utf8
+Write-Host "Wrote $reportPath"
+
+$summary = [System.Collections.Generic.List[string]]::new()
+$summary.Add('## Monitored package config health')
+$summary.Add('')
+$summary.Add("Checked **$($results.Count)** package(s): $($ok.Count) OK, **$($broken.Count) broken**, $($inconclusive.Count) inconclusive, $($skipped.Count) skipped.")
+$summary.Add('')
+
+if ($broken.Count -gt 0) {
+    $summary.Add('### :x: Broken URL templates (fix or exclude these packages)')
+    $summary.Add('')
+    $summary.Add('| Package | Repo | Status | Detail |')
+    $summary.Add('| --- | --- | --- | --- |')
+    foreach ($row in $broken) {
+        $detail = ("$($row.Detail)" -replace '\s*[\r\n]+\s*', ' ').Replace('|', '\|')
+        $summary.Add("| $($row.PackageId) | $($row.Repo) | ``$($row.Status)`` | $detail |")
+    }
+    $summary.Add('')
+}
+
+if ($inconclusive.Count -gt 0) {
+    $summary.Add('### :grey_question: Inconclusive (asset list truncated)')
+    $summary.Add('')
+    foreach ($row in $inconclusive) {
+        $summary.Add("- **$($row.PackageId)** ($($row.Repo)): $($row.Detail)")
+    }
+    $summary.Add('')
+}
+
+if ($broken.Count -eq 0) {
+    $summary.Add(':white_check_mark: Every active URL template resolves to an existing release asset.')
+}
+
+$summaryText = $summary -join "`n"
+Write-Host $summaryText
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+    $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+}
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "broken_count=$($broken.Count)"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "checked_count=$($results.Count)"
+}

--- a/tests/Submit-WingetPackage.Tests.ps1
+++ b/tests/Submit-WingetPackage.Tests.ps1
@@ -75,6 +75,10 @@ ManifestVersion: 1.12.0
             Mock Install-WinMatsch {}
             Mock Test-ExistingPRs { $false }
             Mock Get-WingetPkgsPrUrl { $null }
+            # The URL preflight probes the network; tests stub it as alive.
+            Mock Test-WingetInstallerUrlsAlive {
+                [PSCustomObject]@{ Valid = $true; DeadUrls = @(); Warnings = @(); CheckedCount = 1 }
+            }
         }
     }
 
@@ -259,6 +263,34 @@ ManifestVersion: 1.12.0
                 }
                 Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 1 -Exactly -Scope It
                 Assert-MockCalled Test-ExistingPRs -Times 2 -Exactly -Scope It
+            }
+        }
+
+        It 'blocks submission when an installer URL is definitively dead' {
+            InModuleScope WingetMaintainerModule {
+                Mock Test-WingetInstallerUrlsAlive {
+                    [PSCustomObject]@{
+                        Valid        = $false
+                        DeadUrls     = @('https://downloads.example.invalid/test-package.zip')
+                        Warnings     = @()
+                        CheckedCount = 1
+                    }
+                }
+                Mock Invoke-WinMatschSubmitAttempt {}
+
+                $result = Submit-WingetPackage `
+                    -ManifestPath $global:SubmitWingetPackageTestManifestPath `
+                    -PackageId 'Test.Package' `
+                    -Version '1.0.0' `
+                    -Token 'test-token'
+
+                if ($result.Success -ne $false) {
+                    throw 'A dead installer URL unexpectedly reported success.'
+                }
+                if ($result.Error -notmatch 'Installer URL preflight failed' -or $result.Error -notmatch 'test-package\.zip') {
+                    throw "The dead-URL error did not name the URL: $($result.Error)"
+                }
+                Assert-MockCalled Invoke-WinMatschSubmitAttempt -Times 0 -Exactly -Scope It
             }
         }
     }

--- a/tests/TestMonitoredPackageAssets.Tests.ps1
+++ b/tests/TestMonitoredPackageAssets.Tests.ps1
@@ -1,0 +1,151 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force
+
+function New-FakeGraphQlInvoker {
+    param([hashtable] $RepositoriesByAlias)
+
+    # Replays a canned repository object per alias, ignoring the query text.
+    return {
+        param([string] $Query)
+
+        $aliases = @([regex]::Matches($Query, '(?m)^\s*(?<Alias>[at]\d+):') | ForEach-Object { $_.Groups['Alias'].Value })
+        $data = [ordered]@{}
+        foreach ($alias in $aliases) {
+            $data[$alias] = $RepositoriesByAlias[$alias]
+        }
+        [PSCustomObject]@{ data = [PSCustomObject]$data }
+    }.GetNewClosure()
+}
+
+function New-Release {
+    param(
+        [string] $Tag,
+        [string] $Name = '',
+        [string[]] $AssetUrls = @(),
+        [bool] $Draft = $false,
+        [bool] $Prerelease = $false,
+        [string] $PublishedAt = '2026-01-01T00:00:00Z',
+        [int] $TotalCount = -1
+    )
+
+    [PSCustomObject]@{
+        tagName       = $Tag
+        name          = $Name
+        isDraft       = $Draft
+        isPrerelease  = $Prerelease
+        publishedAt   = $PublishedAt
+        releaseAssets = [PSCustomObject]@{
+            totalCount = if ($TotalCount -ge 0) { $TotalCount } else { $AssetUrls.Count }
+            nodes      = @($AssetUrls | ForEach-Object { [PSCustomObject]@{ downloadUrl = $_ } })
+        }
+    }
+}
+
+Write-Host 'TEST: matching URL template reports OK (architecture hints are stripped)'
+$packages = @([PSCustomObject]@{
+        id   = 'Test.Ok'
+        repo = 'owner/ok'
+        url  = 'https://github.com/owner/ok/releases/download/v{VERSION}/app-{VERSION}-x64.msi|x64'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/app-1.2.3-x64.msi')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK') {
+    throw "Expected OK, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: renamed asset reports AssetMissing with the expected URL'
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/renamed.msi')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'AssetMissing' -or $results[0].Detail -notmatch 'app-1\.2\.3-x64\.msi') {
+    throw "Expected AssetMissing naming the URL, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: missing repository and missing release are classified'
+$twoPackages = @(
+    [PSCustomObject]@{ id = 'Test.NoRepo'; repo = 'owner/gone'; url = 'https://github.com/owner/gone/releases/download/v{VERSION}/x.exe' },
+    [PSCustomObject]@{ id = 'Test.NoRelease'; repo = 'owner/quiet'; url = 'https://github.com/owner/quiet/releases/download/v{VERSION}/x.exe' }
+)
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = $null
+    'a1' = [PSCustomObject]@{ latestRelease = $null }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $twoPackages -GraphQlInvoker $invoker)
+$byId = @{}
+foreach ($result in $results) { $byId[$result.PackageId] = $result }
+if ($byId['Test.NoRepo'].Status -ne 'RepoMissing' -or $byId['Test.NoRelease'].Status -ne 'NoRelease') {
+    throw "Expected RepoMissing and NoRelease, got: $($results | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: tagPattern packages check their own release stream'
+$streamPackages = @([PSCustomObject]@{
+        id         = 'Test.Stream39'
+        repo       = 'owner/multi'
+        url        = 'https://github.com/owner/multi/releases/download/{TAG}/app-{VERSION}.zip'
+        tagPattern = '^v39\.'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    't0' = [PSCustomObject]@{
+        releases = [PSCustomObject]@{
+            nodes = @(
+                (New-Release -Tag 'v43.0.0' -AssetUrls @('https://github.com/owner/multi/releases/download/v43.0.0/app-43.0.0.zip') -PublishedAt '2026-03-01T00:00:00Z'),
+                (New-Release -Tag 'v39.8.0' -AssetUrls @('https://github.com/owner/multi/releases/download/v39.8.0/app-39.8.0.zip') -PublishedAt '2026-02-01T00:00:00Z'),
+                (New-Release -Tag 'v39.9.0' -Prerelease $true -AssetUrls @() -PublishedAt '2026-02-15T00:00:00Z')
+            )
+        }
+    }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $streamPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK' -or $results[0].Tag -ne 'v39.8.0') {
+    throw "Expected the v39 stream release to be checked, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: tagPattern without a matching stable release reports NoMatchingRelease'
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    't0' = [PSCustomObject]@{
+        releases = [PSCustomObject]@{
+            nodes = @((New-Release -Tag 'v43.0.0' -AssetUrls @('https://github.com/owner/multi/releases/download/v43.0.0/app-43.0.0.zip')))
+        }
+    }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $streamPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'NoMatchingRelease') {
+    throw "Expected NoMatchingRelease, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: {ARPVERSION} templates match via regex against asset URLs'
+$arpPackages = @([PSCustomObject]@{
+        id   = 'Test.Arp'
+        repo = 'owner/arp'
+        url  = 'https://github.com/owner/arp/releases/download/{TAG}/setup-{ARPVERSION}.msi'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'build-77' -AssetUrls @('https://github.com/owner/arp/releases/download/build-77/setup-5.4.3.msi')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $arpPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK') {
+    throw "Expected ARPVERSION regex match, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: truncated asset lists downgrade a miss to Inconclusive'
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/other.msi') -TotalCount 150) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'Inconclusive') {
+    throw "Expected Inconclusive on truncated assets, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: entries without repo/url are skipped'
+$results = @(Test-MonitoredPackageAssets -Packages @([PSCustomObject]@{ id = 'Test.Script' }) -GraphQlInvoker (New-FakeGraphQlInvoker -RepositoriesByAlias @{}))
+if ($results[0].Status -ne 'Skipped') {
+    throw "Expected Skipped, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'All Test-MonitoredPackageAssets tests passed.'

--- a/tests/TestWingetInstallerUrlsAlive.Tests.ps1
+++ b/tests/TestWingetInstallerUrlsAlive.Tests.ps1
@@ -1,0 +1,121 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("winget-url-preflight-$([guid]::NewGuid().ToString('N'))")
+
+try {
+    New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+
+    Write-Host 'TEST: alive URLs pass'
+    $result = & $module {
+        param($Urls)
+        Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe { param($Url, $Method) 200 } -Sleep {}
+    } @('https://example.invalid/a.exe', 'https://example.invalid/b.exe')
+    if (-not $result.Valid -or $result.CheckedCount -ne 2 -or @($result.DeadUrls).Count -ne 0) {
+        throw "Expected two alive URLs, got: $($result | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'TEST: HTTP 404 blocks submission'
+    $result = & $module {
+        param($Urls)
+        Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe { param($Url, $Method) 404 } -Sleep {}
+    } @('https://example.invalid/gone.exe')
+    if ($result.Valid -or @($result.DeadUrls) -notcontains 'https://example.invalid/gone.exe') {
+        throw "Expected a dead 404 URL, got: $($result | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'TEST: HTTP 410 blocks submission'
+    $result = & $module {
+        param($Urls)
+        Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe { param($Url, $Method) 410 } -Sleep {}
+    } @('https://example.invalid/gone.exe')
+    if ($result.Valid) {
+        throw "Expected HTTP 410 to be treated as dead, got: $($result | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'TEST: HEAD 405 falls back to a ranged GET'
+    $result = & $module {
+        param($Urls)
+        $script:probeCalls = @()
+        $probe = {
+            param($Url, $Method)
+            $script:probeCalls += $Method
+            if ($Method -eq 'Head') { 405 } else { 206 }
+        }
+        $outcome = Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe $probe -Sleep {}
+        [PSCustomObject]@{ Outcome = $outcome; Calls = $script:probeCalls }
+    } @('https://example.invalid/no-head.exe')
+    if (-not $result.Outcome.Valid -or (@($result.Calls) -join ',') -ne 'Head,Get') {
+        throw "Expected Head then Get fallback, got: $($result | ConvertTo-Json -Compress -Depth 4)"
+    }
+
+    Write-Host 'TEST: transient failures retry and then fail open with a warning'
+    $result = & $module {
+        param($Urls)
+        $script:attempts = 0
+        $probe = { param($Url, $Method) $script:attempts++; throw 'connection reset' }
+        $outcome = Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe $probe -MaxAttempts 3 -Sleep {}
+        [PSCustomObject]@{ Outcome = $outcome; Attempts = $script:attempts }
+    } @('https://example.invalid/flaky.exe')
+    if (-not $result.Outcome.Valid -or @($result.Outcome.Warnings).Count -ne 1 -or $result.Attempts -ne 3) {
+        throw "Expected fail-open after 3 attempts with one warning, got: $($result | ConvertTo-Json -Compress -Depth 4)"
+    }
+
+    Write-Host 'TEST: HTTP 429 recovers on a later attempt'
+    $result = & $module {
+        param($Urls)
+        $script:attempts = 0
+        $probe = { param($Url, $Method) $script:attempts++; if ($script:attempts -lt 2) { 429 } else { 200 } }
+        Test-WingetInstallerUrlsAlive -InstallerUrls $Urls -HttpProbe $probe -Sleep {}
+    } @('https://example.invalid/limited.exe')
+    if (-not $result.Valid -or @($result.Warnings).Count -ne 0) {
+        throw "Expected recovery after a 429, got: $($result | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'TEST: manifest mode extracts InstallerUrls from the installer yaml'
+    $manifestDir = Join-Path $testRoot 'manifest'
+    New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+    @"
+PackageIdentifier: Test.Package
+PackageVersion: 1.0.0
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://example.invalid/pkg-x64.exe
+    InstallerSha256: 1111111111111111111111111111111111111111111111111111111111111111
+  - Architecture: arm64
+    InstallerUrl: https://example.invalid/pkg-arm64.exe
+    InstallerSha256: 2222222222222222222222222222222222222222222222222222222222222222
+ManifestType: installer
+ManifestVersion: 1.12.0
+"@ | Set-Content -LiteralPath (Join-Path $manifestDir 'Test.Package.installer.yaml')
+
+    $result = & $module {
+        param($Path)
+        $script:seenUrls = @()
+        $probe = { param($Url, $Method) $script:seenUrls += $Url; if ($Url -match 'arm64') { 404 } else { 200 } }
+        $outcome = Test-WingetInstallerUrlsAlive -ManifestPath $Path -HttpProbe $probe -Sleep {}
+        [PSCustomObject]@{ Outcome = $outcome; Seen = $script:seenUrls }
+    } $manifestDir
+    if (@($result.Seen).Count -ne 2 -or $result.Outcome.Valid -or @($result.Outcome.DeadUrls) -notcontains 'https://example.invalid/pkg-arm64.exe') {
+        throw "Expected both manifest URLs probed and the arm64 one dead, got: $($result | ConvertTo-Json -Compress -Depth 4)"
+    }
+
+    Write-Host 'TEST: a manifest folder without an installer yaml is skipped with a warning'
+    $emptyDir = Join-Path $testRoot 'empty'
+    New-Item -ItemType Directory -Path $emptyDir -Force | Out-Null
+    $result = & $module {
+        param($Path)
+        Test-WingetInstallerUrlsAlive -ManifestPath $Path -HttpProbe { param($Url, $Method) throw 'must not be called' } -Sleep {}
+    } $emptyDir
+    if (-not $result.Valid -or $result.CheckedCount -ne 0 -or @($result.Warnings).Count -ne 1) {
+        throw "Expected a skip with warning for a manifest without installer yaml, got: $($result | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'All Test-WingetInstallerUrlsAlive tests passed.'
+}
+finally {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -332,4 +332,96 @@ if (-not $publishedVersionLookupResult.Result.ShouldGenerate) {
     throw "The version lookup incorrectly suppressed a version missing from the selected repository: $($publishedVersionLookupResult.Result | ConvertTo-Json -Compress)"
 }
 
+Write-Host 'TEST: WinMatsch exit code 4 (safety question) soft-fails with QuestionsRequired'
+$questionsRequiredResult = & $module {
+    function Test-GitHubToken { 'test-token' }
+    function Test-PackageAndVersionInGithub {
+        [PSCustomObject]@{
+            PackageExists          = $true
+            ShouldGenerate         = $true
+            VersionExists          = $false
+            CanonicalVersion       = '1.0.0'
+            PublishedVersion       = $null
+            LatestPublishedVersion = $null
+        }
+    }
+    function Test-ExistingPRs { $false }
+    function Install-WinMatsch {}
+    function Test-GeneratedInstallerArchitecture { throw 'Architecture validation must not run after a safety question.' }
+    function winmatsch {
+        if ($args -contains '--help') {
+            $global:LASTEXITCODE = 0
+            return
+        }
+        Write-Output 'ARCH_CONFLICT : Select an architecture for this asset.'
+        $global:LASTEXITCODE = 4
+    }
+
+    $originalGitHubOutput = $env:GITHUB_OUTPUT
+    $outputFile = Join-Path ([IO.Path]::GetTempPath()) "winget-questions-required-$([guid]::NewGuid().ToString('N')).txt"
+    $env:GITHUB_OUTPUT = $outputFile
+    try {
+        $result = Update-WingetPackage `
+            -WingetPackage 'Test.Package' `
+            -With 'WinMatsch' `
+            -latestVersion '1.0.0' `
+            -latestVersionURL 'https://example.invalid/app.zip'
+
+        [PSCustomObject]@{
+            Result        = $result
+            OutputContent = (Get-Content -LiteralPath $outputFile -Raw)
+        }
+    }
+    finally {
+        $env:GITHUB_OUTPUT = $originalGitHubOutput
+        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+    }
+}
+if ($questionsRequiredResult.Result.Generated -or $questionsRequiredResult.Result.Reason -cne 'QuestionsRequired') {
+    throw "A WinMatsch safety question did not soft-fail with QuestionsRequired: $($questionsRequiredResult.Result | ConvertTo-Json -Compress)"
+}
+if ($questionsRequiredResult.OutputContent -notmatch '(?m)^reason=QuestionsRequired\s*$') {
+    throw "The QuestionsRequired reason was not written to GITHUB_OUTPUT: $($questionsRequiredResult.OutputContent)"
+}
+
+Write-Host 'TEST: non-question WinMatsch failures still throw as GeneratorFailed'
+$generatorFailedResult = & $module {
+    function Test-GitHubToken { 'test-token' }
+    function Test-PackageAndVersionInGithub {
+        [PSCustomObject]@{
+            PackageExists          = $true
+            ShouldGenerate         = $true
+            VersionExists          = $false
+            CanonicalVersion       = '1.0.0'
+            PublishedVersion       = $null
+            LatestPublishedVersion = $null
+        }
+    }
+    function Test-ExistingPRs { $false }
+    function Install-WinMatsch {}
+    function winmatsch {
+        if ($args -contains '--help') {
+            $global:LASTEXITCODE = 0
+            return
+        }
+        Write-Output 'OPERATION_FAILED : Something genuinely broke.'
+        $global:LASTEXITCODE = 5
+    }
+
+    try {
+        Update-WingetPackage `
+            -WingetPackage 'Test.Package' `
+            -With 'WinMatsch' `
+            -latestVersion '1.0.0' `
+            -latestVersionURL 'https://example.invalid/app.zip' | Out-Null
+        [PSCustomObject]@{ Threw = $false; Message = $null }
+    }
+    catch {
+        [PSCustomObject]@{ Threw = $true; Message = $_.Exception.Message }
+    }
+}
+if (-not $generatorFailedResult.Threw -or $generatorFailedResult.Message -notmatch 'exit code 5') {
+    throw "A real generator failure no longer fails the job: $($generatorFailedResult | ConvertTo-Json -Compress)"
+}
+
 Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green

--- a/tests/WingetPrSupersession.Tests.ps1
+++ b/tests/WingetPrSupersession.Tests.ps1
@@ -1,0 +1,158 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+
+Write-Host 'TEST: standard update title parses'
+$parsed = & $module { Get-WingetPrTitlePackageVersion -Title 'Update version: KeeperSecurity.Commander version 18.1.0' }
+if ($null -eq $parsed -or $parsed.PackageIdentifier -cne 'KeeperSecurity.Commander' -or $parsed.Version -cne '18.1.0') {
+    throw "Standard title parsing failed: $($parsed | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: legacy combined title parses'
+$parsed = & $module { Get-WingetPrTitlePackageVersion -Title 'Add version: Foo.Bar version 2.0.0 - Update version: Foo.Bar version 2.0.0' }
+if ($null -eq $parsed -or $parsed.PackageIdentifier -cne 'Foo.Bar' -or $parsed.Version -cne '2.0.0') {
+    throw "Legacy combined title parsing failed: $($parsed | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: foreign title shapes return null'
+foreach ($title in @('New package: Foo.Bar 1.0', 'Update Foo.Bar to 1.0', '', 'Update version: Foo.Bar version 1.0 extra words')) {
+    $parsed = & $module { param($Title) Get-WingetPrTitlePackageVersion -Title $Title } $title
+    if ($null -ne $parsed) {
+        throw "Expected null for title '$title', got: $($parsed | ConvertTo-Json -Compress)"
+    }
+}
+
+Write-Host 'TEST: superseded selection closes only strictly older versions of the same package'
+$openPrs = @(
+    [PSCustomObject]@{ number = 100; title = 'Update version: Foo.Bar version 1.0.0' },
+    [PSCustomObject]@{ number = 101; title = 'Update version: Foo.Bar version 1.2.0' },
+    [PSCustomObject]@{ number = 102; title = 'Update version: Foo.Bar version 2.0.0' },
+    [PSCustomObject]@{ number = 103; title = 'Update version: Foo.Baz version 0.5.0' },
+    [PSCustomObject]@{ number = 104; title = 'Something unrelated mentioning Foo.Bar 0.1' },
+    [PSCustomObject]@{ number = 105; title = 'Update version: Foo.Bar version 1.2.0' }
+)
+$selected = @(& $module {
+        param($OpenPrs)
+        Select-WingetSupersededOpenPrs -OpenPrs $OpenPrs -PackageIdentifier 'Foo.Bar' -NewVersion '1.2.0' -NewPrNumber 105
+    } $openPrs)
+if ((@($selected | ForEach-Object { $_.Number }) -join ',') -ne '100') {
+    throw "Expected only PR 100 selected, got: $($selected | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: version comparison is numeric, not lexicographic'
+$openPrs = @([PSCustomObject]@{ number = 200; title = 'Update version: Foo.Bar version 9.0.0' })
+$selected = @(& $module {
+        param($OpenPrs)
+        Select-WingetSupersededOpenPrs -OpenPrs $OpenPrs -PackageIdentifier 'Foo.Bar' -NewVersion '10.0.0'
+    } $openPrs)
+if (@($selected).Count -ne 1) {
+    throw "Expected 9.0.0 to be older than 10.0.0, got: $($selected | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: hygiene actions plan supersession, published closes, and keeps'
+$openPrs = @(
+    [PSCustomObject]@{ number = 300; title = 'Update version: Keeper.Commander version 18.1.0'; labels = @() },
+    [PSCustomObject]@{ number = 301; title = 'Update version: Keeper.Commander version 18.1.1'; labels = @([PSCustomObject]@{ name = 'Azure-Pipeline-Passed' }) },
+    [PSCustomObject]@{ number = 302; title = 'Update version: Shipped.App version 3.0.0'; labels = @([PSCustomObject]@{ name = 'Validation-Executable-Error' }) },
+    [PSCustomObject]@{ number = 303; title = 'Update version: Stuck.App version 1.0.0'; labels = @('Validation-Defender-Error') },
+    [PSCustomObject]@{ number = 304; title = 'Totally different title'; labels = @() }
+)
+$actions = @(& $module {
+        param($OpenPrs)
+        Select-WingetHygienePrActions -OpenPrs $OpenPrs -PublishedVersionsResolver {
+            param($PackageIdentifier)
+            if ($PackageIdentifier -eq 'Shipped.App') { @('2.9.0', '3.0.0') } else { @() }
+        }
+    } $openPrs)
+
+$byNumber = @{}
+foreach ($action in $actions) { $byNumber[$action.Number] = $action }
+if ($byNumber[300].Action -ne 'close-superseded' -or $byNumber[300].Reason -notmatch '#301') {
+    throw "Expected PR 300 superseded by #301, got: $($byNumber[300] | ConvertTo-Json -Compress)"
+}
+if ($byNumber[301].Action -ne 'keep') {
+    throw "Expected PR 301 kept, got: $($byNumber[301] | ConvertTo-Json -Compress)"
+}
+if ($byNumber[302].Action -ne 'close-published') {
+    throw "Expected PR 302 closed as published, got: $($byNumber[302] | ConvertTo-Json -Compress)"
+}
+if ($byNumber[303].Action -ne 'keep' -or @($byNumber[303].Labels) -notcontains 'Validation-Defender-Error') {
+    throw "Expected PR 303 kept with its label, got: $($byNumber[303] | ConvertTo-Json -Compress)"
+}
+if ($byNumber[304].Action -ne 'keep' -or $byNumber[304].Reason -notmatch 'not parsable') {
+    throw "Expected PR 304 kept as unparsable, got: $($byNumber[304] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: hygiene sweep works without a published-version resolver'
+$actions = @(& $module {
+        param($OpenPrs)
+        Select-WingetHygienePrActions -OpenPrs $OpenPrs
+    } @([PSCustomObject]@{ number = 400; title = 'Update version: Foo.Bar version 1.0.0'; labels = @() }))
+if (@($actions).Count -ne 1 -or $actions[0].Action -ne 'keep') {
+    throw "Expected a single keep action, got: $($actions | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: Close-SupersededWingetPrs closes selected PRs via the injected invokers'
+$closeResult = & $module {
+    $script:closedCalls = @()
+    Close-SupersededWingetPrs `
+        -PackageId 'Foo.Bar' `
+        -Version '2.0.0' `
+        -BotLogin 'test-bot' `
+        -NewPrNumber 999 `
+        -NewPrUrl 'https://github.com/microsoft/winget-pkgs/pull/999' `
+        -SearchInvoker {
+            @(
+                [PSCustomObject]@{ number = 500; title = 'Update version: Foo.Bar version 1.0.0' },
+                [PSCustomObject]@{ number = 501; title = 'Update version: Foo.Bar version 2.0.0' },
+                [PSCustomObject]@{ number = 999; title = 'Update version: Foo.Bar version 2.0.0' }
+            )
+        } `
+        -CloseInvoker {
+            param($Number, $Comment)
+            $script:closedCalls += [PSCustomObject]@{ Number = $Number; Comment = $Comment }
+        }
+}
+if ((@($closeResult.ClosedPrNumbers) -join ',') -ne '500') {
+    throw "Expected only PR 500 closed, got: $($closeResult | ConvertTo-Json -Compress)"
+}
+$closedCalls = & $module { $script:closedCalls }
+if (@($closedCalls).Count -ne 1 -or $closedCalls[0].Comment -notmatch 'pull/999') {
+    throw "Expected the close comment to reference the successor PR, got: $($closedCalls | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: Close-SupersededWingetPrs fails open when the search fails'
+$closeResult = & $module {
+    Close-SupersededWingetPrs `
+        -PackageId 'Foo.Bar' `
+        -Version '2.0.0' `
+        -BotLogin 'test-bot' `
+        -SearchInvoker { throw 'search exploded' } `
+        -CloseInvoker { throw 'must not be called' }
+}
+if (@($closeResult.ClosedPrNumbers).Count -ne 0 -or @($closeResult.Warnings).Count -ne 1) {
+    throw "Expected a warning and no closes on search failure, got: $($closeResult | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: Close-SupersededWingetPrs honors the MaxCloses cap'
+$closeResult = & $module {
+    Close-SupersededWingetPrs `
+        -PackageId 'Foo.Bar' `
+        -Version '9.0.0' `
+        -BotLogin 'test-bot' `
+        -MaxCloses 1 `
+        -SearchInvoker {
+            @(
+                [PSCustomObject]@{ number = 600; title = 'Update version: Foo.Bar version 1.0.0' },
+                [PSCustomObject]@{ number = 601; title = 'Update version: Foo.Bar version 2.0.0' }
+            )
+        } `
+        -CloseInvoker { param($Number, $Comment) }
+}
+if (@($closeResult.ClosedPrNumbers).Count -ne 1 -or $closeResult.SkippedCount -ne 1 -or @($closeResult.Warnings).Count -ne 1) {
+    throw "Expected the cap to close one and skip one, got: $($closeResult | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'All WingetPrSupersession tests passed.'


### PR DESCRIPTION
## Goal

Only clean, certain submissions reach microsoft/winget-pkgs; scheduled runs stay green unless something is actually broken; leftovers clean themselves up.

## Root-cause fixes (verified with local `winmatsch` dry-runs)

| Package | Question | Fix |
| --- | --- | --- |
| `RimSort.RimSort` | `ARCH_CONFLICT` (MSI carries ambiguous arch evidence) | explicit `\|x64` URL hint → clean manifest generated |
| `orbatschow.kontext` | `MAP_REMOVED` (published 1.6.0 mislabels the arm64 zip as `arm`) | `\|arm64` hint + `allowStructuralRewrite: true` → correct x64+arm64 manifest |
| `melon-masou.MonMouse` | `MAP_STRUCTURAL_REWRITE` (published 0.2.0 declares x86 for an x64 payload) | `allowStructuralRewrite: true` → x64 + payload-derived VCRedist dependency |

## New safeguards

- **Installer URL preflight (submit gate):** every `InstallerUrl` is probed (HEAD → ranged-GET fallback) right before submission. Definitive HTTP 404/410 blocks the submit — this is the class that produced the upstream `URL-Validation-Error` PRs (YallaVideo, EntraChecks, sqrail). Transient outcomes fail open with warnings.
- **Safety questions no longer fail runs:** WinMatsch exit 4 (`ARCH_CONFLICT`, `MAP_REMOVED`, …) becomes a green job + dedicated *needs-decision* table in the run summary. Real errors still fail. This removes the red `GH Packages 1-Z` runs caused by expected fail-closed questions.
- **Superseded-PR auto-close:** after each successful submission, the bot's own older-version open PRs for that package are closed with a pointer to the successor (the Commander 18.1.0/18.1.1 case can't recur).
- **Daily `Upstream PR Hygiene` workflow:** sweeps all own open PRs — closes ones superseded by a newer open PR or whose exact version is already published; reports the rest grouped by validation-error labels. Strict title parsing; anything unrecognized is never touched; per-run close cap.
- **Weekly `Config Health` workflow:** re-resolves every monitored package (tagPattern streams included) and verifies each URL template against the real release assets via batched GraphQL. Broken templates surface as a report instead of doomed generation attempts.

## Config cleanup discovered by the new health check

- **Electron majors 33–40 parked:** they are EOL upstream, their final patches are all published in winget already, and their stable releases have fallen (or are falling) out of the 30-release window `Get-LatestGHVersionTag` scans — once re-enabled each would have failed every 4-hour run. Streams 41/42 stay active and **43 (current stable, already in winget) is now monitored**.

## Validation

- Full Pester suite: **39/39 pass** (Pester 5.7.1, matching CI).
- New test files: `TestWingetInstallerUrlsAlive`, `WingetPrSupersession`, `TestMonitoredPackageAssets`; extended `Update-WingetPackage` (QuestionsRequired soft-fail + real failures still throw) and `Submit-WingetPackage` (dead-URL block) suites.
- zizmor: no findings on new/changed workflows.
- Config-health smoke run against live GitHub over an 8-package slice (incl. Electron streams): correct OK/AssetMissing/NoMatchingRelease classification.
- `scripts/orchestrate_gh-packages.py` regenerated workflow + packages sidecar.

Follow-up after merge: re-enable `GH Packages 1-Z` (currently `disabled_manually`).