### PR TITLE
Handle whitespace in Config Health URL templates

### DIFF
--- a/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
@@ -252,7 +252,8 @@ function Resolve-WingetMonitoredAssetStatus {
 
     $missing = [System.Collections.Generic.List[string]]::new()
 
-    foreach ($entry in @(Get-InstallerUrlEntries -InstallerValues @($url.Split(' ')))) {
+    $installerValues = @($url -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    foreach ($entry in @(Get-InstallerUrlEntries -InstallerValues $installerValues)) {
         $template = $entry.InstallerUrl
         if ($template -match '\{ARPVERSION\}') {
             $assetRegex = [regex]::Escape($template).

--- a/tests/TestMonitoredPackageAssets.Tests.ps1
+++ b/tests/TestMonitoredPackageAssets.Tests.ps1
@@ -58,6 +58,20 @@ if ($results[0].Status -ne 'OK') {
     throw "Expected OK, got: $($results[0] | ConvertTo-Json -Compress)"
 }
 
+Write-Host 'TEST: URL templates with repeated whitespace are accepted'
+$whitespacePackages = @([PSCustomObject]@{
+        id   = 'Test.Whitespace'
+        repo = 'owner/whitespace'
+        url  = '  https://github.com/owner/whitespace/releases/download/v{VERSION}/app-{VERSION}-x64.msi|x64   '
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/whitespace/releases/download/v1.2.3/app-1.2.3-x64.msi')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $whitespacePackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK') {
+    throw "Expected whitespace-delimited URL template to resolve, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
 Write-Host 'TEST: renamed asset reports AssetMissing with the expected URL'
 $invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
     'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/renamed.msi')) }


### PR DESCRIPTION
A post-merge Config Health run failed because a space-delimited URL field included blank entries, which the installer URL parser rejects. Filter whitespace-only entries before parsing and cover the case with a regression test.