### PR TITLE
Gate stale GitHub release assets

### DIFF
--- a/.github/workflows/config-health.yml
+++ b/.github/workflows/config-health.yml
@@ -6,7 +6,7 @@ on:
     - cron: "17 5 * * 1" # weekly, Monday 05:17 UTC
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: config-health
@@ -16,15 +16,17 @@ jobs:
   check-monitored-config:
     name: Check monitored package URLs
     runs-on: ubuntu-latest
+    concurrency:
+      group: package-state-write
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
-      # Report-only: verifies that every monitored package's release-asset URL
-      # template still matches a real asset, so broken templates surface here
-      # instead of as failed generations or upstream URL-Validation-Error PRs.
+      # Verifies every monitored package's release-asset URL template, then
+      # persists only definitive failures as per-package submission blocks.
       - name: Check release-asset URL templates
         id: check
         shell: pwsh
@@ -34,7 +36,34 @@ jobs:
           MONITORED_PACKAGES_FILE: .github/workflows-data/update-github-packages-1-z.packages.json
         run: ./scripts/Test-MonitoredPackageAssets.ps1
 
+      - name: Persist definitive Config Health blocks
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          Import-Module ./modules/WingetMaintainerModule/WingetMaintainerModule.psd1 -Force
+
+          $stateFile = Join-Path $env:GITHUB_WORKSPACE 'data/package-state.json'
+          $results = @(Get-Content -LiteralPath ./config-health-report.json -Raw | ConvertFrom-Json)
+          $sync = Update-PackageStateConfigHealth -StateFilePath $stateFile -Results $results
+
+          $summary = @(
+            '## Config Health submission gate'
+            ''
+            "Definitive blocks: **$($sync.Blocked)**; updated: $($sync.Updated); cleared: $($sync.Cleared)."
+          ) -join "`n"
+          Write-Host $summary
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+          if ($sync.Changed) {
+            gh auth setup-git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            Save-PackageState -StateFilePath $stateFile -RepoPath $env:GITHUB_WORKSPACE
+          }
+
       - name: Upload report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: config-health-report

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -93,7 +93,10 @@ jobs:
         run: |
           ./tests/Save-PackageState.Tests.ps1
           ./tests/PackageStateOpenPr.Tests.ps1
+          ./tests/PackageStateConfigHealth.Tests.ps1
           ./tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+          ./tests/SelectPackagesNeedingUpdateScript.Tests.ps1
+          ./tests/TestMonitoredPackageAssets.Tests.ps1
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1

--- a/modules/WingetMaintainerModule/Public/Get-PackageStateConfigHealthBlocks.ps1
+++ b/modules/WingetMaintainerModule/Public/Get-PackageStateConfigHealthBlocks.ps1
@@ -1,0 +1,48 @@
+function Get-PackageStateConfigHealthBlocks {
+    <#
+    .SYNOPSIS
+        Reads definitive Config Health blocks from package state.
+
+    .DESCRIPTION
+        Returns package identifiers whose latest Config Health result is a
+        definitive GitHub release-asset failure. These markers are consumed by
+        the update precheck before packages enter the generation matrix.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.IDictionary])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $StateFilePath
+    )
+
+    $stateData = Get-PackageState -StateFilePath $StateFilePath
+    $blocks = [ordered]@{}
+    if ($null -eq $stateData) {
+        return $blocks
+    }
+
+    foreach ($packageId in @($stateData.Keys)) {
+        $entry = $stateData[$packageId]
+        if ($entry -isnot [System.Collections.IDictionary]) {
+            throw "Package state entry '$packageId' must be an object."
+        }
+        if (-not $entry.Contains('configHealth')) {
+            continue
+        }
+
+        $health = $entry['configHealth']
+        if ($null -eq $health) {
+            continue
+        }
+        if ($health -isnot [System.Collections.IDictionary]) {
+            throw "Config Health state for '$packageId' must be an object."
+        }
+
+        $status = [string]$health['status']
+        if ($status -in @('AssetMissing', 'RepoMissing')) {
+            $blocks[$packageId] = $health
+        }
+    }
+
+    return $blocks
+}

--- a/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
+++ b/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
@@ -221,6 +221,11 @@ function Select-GitHubPackagesNeedingUpdate {
         [Parameter()]
         [string] $StateFilePath,
 
+        # Optional preloaded Config Health blocks. Supplying this lets callers
+        # retain definitive URL blocks even when the GraphQL precheck fails open.
+        [Parameter()]
+        [System.Collections.IDictionary] $ConfigHealthBlocks,
+
         [Parameter()]
         [ValidateRange(1, 8760)]
         [int] $OpenPrTtlHours = 24,
@@ -245,6 +250,14 @@ function Select-GitHubPackagesNeedingUpdate {
     if ($openPrCheckEnabled -and $null -eq $OpenPrTester) {
         $OpenPrTester = { param([string] $PackageIdentifier, [string] $Version) Test-ExistingPRs -Version $Version -PackageIdentifier $PackageIdentifier -OnlyOpen }
     }
+    if ($null -eq $ConfigHealthBlocks) {
+        $ConfigHealthBlocks = if ($openPrCheckEnabled) {
+            Get-PackageStateConfigHealthBlocks -StateFilePath $StateFilePath
+        }
+        else {
+            @{}
+        }
+    }
     $openPrChecksUsed = 0
 
     $include = [System.Collections.Generic.List[object]]::new()
@@ -260,7 +273,17 @@ function Select-GitHubPackagesNeedingUpdate {
         $versionSource = Get-WingetPrecheckPackageField -Package $package -Name 'versionSource'
         $overridePack = Get-WingetPrecheckPackageField -Package $package -Name 'overridePack'
 
-        if ([string]::IsNullOrWhiteSpace($packageId) -or [string]::IsNullOrWhiteSpace($repo)) {
+        if ($ConfigHealthBlocks.Contains($packageId)) {
+            $health = $ConfigHealthBlocks[$packageId]
+            $skipped.Add([PSCustomObject]@{
+                    Package      = $package
+                    Reason       = 'ConfigHealthBlocked'
+                    HealthStatus = [string]$health['status']
+                    Detail       = [string]$health['detail']
+                    CheckedAt    = [string]$health['checkedAt']
+                })
+        }
+        elseif ([string]::IsNullOrWhiteSpace($packageId) -or [string]::IsNullOrWhiteSpace($repo)) {
             $include.Add([PSCustomObject]@{ Package = $package; Reason = 'IncompleteConfiguration' })
         }
         elseif (-not [string]::IsNullOrWhiteSpace($tagPattern) -or

--- a/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
@@ -250,11 +250,36 @@ function Resolve-WingetMonitoredAssetStatus {
     $totalCountValue = Get-WingetGraphQlFieldValue -InputObject $assetsObject -Name 'totalCount'
     $assetsTruncated = $null -ne $totalCountValue -and [int]$totalCountValue -gt $assetUrls.Count
 
-    $missing = [System.Collections.Generic.List[string]]::new()
-
     $installerValues = @($url -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $assetTemplates = [System.Collections.Generic.List[string]]::new()
+    $deferredTemplates = [System.Collections.Generic.List[string]]::new()
+    $releasePrefix = "https://github.com/$repo/releases/"
+    $escapedRepo = [regex]::Escape($repo)
+    $latestDownloadPattern = "^(?i:https://github\.com/$escapedRepo/releases/latest/download/)"
     foreach ($entry in @(Get-InstallerUrlEntries -InstallerValues $installerValues)) {
-        $template = $entry.InstallerUrl
+        $template = $entry.InstallerUrl -replace '[?#].*$', ''
+        if ($template -notlike "$releasePrefix*") {
+            $deferredTemplates.Add($entry.InstallerUrl)
+            continue
+        }
+
+        $latestDownloadMatch = [regex]::Match($template, $latestDownloadPattern)
+        if ($latestDownloadMatch.Success) {
+            $template = "$releasePrefix`download/$tag/" + $template.Substring($latestDownloadMatch.Length)
+        }
+        if ($template -notlike "$releasePrefix`download/*") {
+            $deferredTemplates.Add($entry.InstallerUrl)
+            continue
+        }
+        $assetTemplates.Add($template)
+    }
+
+    if ($assetTemplates.Count -eq 0) {
+        return & $newResult 'Skipped' 'No GitHub release-asset URL template to verify; final installer URL preflight remains responsible.' $tag
+    }
+
+    $missing = [System.Collections.Generic.List[string]]::new()
+    foreach ($template in $assetTemplates) {
         if ($template -match '\{ARPVERSION\}') {
             $assetRegex = [regex]::Escape($template).
                 Replace('\{ARPVERSION}', '(.+?)').
@@ -280,5 +305,11 @@ function Resolve-WingetMonitoredAssetStatus {
         return & $newResult 'AssetMissing' "No release asset matches: $($missing -join ' ')" $tag
     }
 
-    return & $newResult 'OK' "All URL templates resolve against release $tag." $tag
+    $deferredNote = if ($deferredTemplates.Count -gt 0) {
+        " $($deferredTemplates.Count) external URL template(s) remain covered by submission preflight."
+    }
+    else {
+        ''
+    }
+    return & $newResult 'OK' "All GitHub release-asset URL templates resolve against release ${tag}.$deferredNote" $tag
 }

--- a/modules/WingetMaintainerModule/Public/Update-PackageStateConfigHealth.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-PackageStateConfigHealth.ps1
@@ -1,0 +1,124 @@
+function Update-PackageStateConfigHealth {
+    <#
+    .SYNOPSIS
+        Synchronizes definitive Config Health findings into package state.
+
+    .DESCRIPTION
+        Stores a nested configHealth marker for AssetMissing and RepoMissing
+        results. A later non-blocking result clears that marker, allowing a
+        recovered package back into the update matrix. Existing validation and
+        open-PR state is preserved.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $StateFilePath,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]] $Results,
+
+        [Parameter()]
+        [datetime] $CheckedAt = (Get-Date).ToUniversalTime()
+    )
+
+    function Get-ConfigHealthResultField {
+        param(
+            [Parameter(Mandatory = $true)] $Result,
+            [Parameter(Mandatory = $true)] [string] $Name
+        )
+
+        if ($Result -is [System.Collections.IDictionary]) {
+            return $Result[$Name]
+        }
+
+        $property = $Result.PSObject.Properties[$Name]
+        if ($null -eq $property) {
+            return $null
+        }
+        return $property.Value
+    }
+
+    $stateData = @{}
+    if (Test-Path -Path $StateFilePath -PathType Leaf) {
+        $stateData = Get-Content -Path $StateFilePath -Raw -ErrorAction Stop |
+            ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    }
+
+    $blocked = 0
+    $updated = 0
+    $cleared = 0
+    $changed = $false
+    $checkedAtText = $CheckedAt.ToUniversalTime().ToString('o')
+
+    foreach ($result in $Results) {
+        $packageId = [string](Get-ConfigHealthResultField -Result $result -Name 'PackageId')
+        if ([string]::IsNullOrWhiteSpace($packageId)) {
+            continue
+        }
+
+        $status = [string](Get-ConfigHealthResultField -Result $result -Name 'Status')
+        $shouldBlock = $status -in @('AssetMissing', 'RepoMissing')
+        $entryExists = $stateData.ContainsKey($packageId)
+        $entry = if ($entryExists) { $stateData[$packageId] } else { @{} }
+        if ($entry -isnot [System.Collections.IDictionary]) {
+            throw "Package state entry '$packageId' must be an object."
+        }
+
+        if ($shouldBlock) {
+            $blocked++
+            $detail = [string](Get-ConfigHealthResultField -Result $result -Name 'Detail')
+            $tag = [string](Get-ConfigHealthResultField -Result $result -Name 'Tag')
+            $existingHealth = if ($entry.Contains('configHealth')) { $entry['configHealth'] } else { $null }
+            if ($null -ne $existingHealth -and $existingHealth -isnot [System.Collections.IDictionary]) {
+                throw "Config Health state for '$packageId' must be an object."
+            }
+
+            $isUnchanged = $null -ne $existingHealth -and
+                [string]$existingHealth['status'] -eq $status -and
+                [string]$existingHealth['detail'] -eq $detail -and
+                [string]$existingHealth['tag'] -eq $tag
+            if ($isUnchanged) {
+                continue
+            }
+
+            $entry['configHealth'] = [ordered]@{
+                status    = $status
+                detail    = $detail
+                tag       = $tag
+                checkedAt = $checkedAtText
+            }
+            $stateData[$packageId] = $entry
+            $updated++
+            $changed = $true
+            continue
+        }
+
+        if ($entry.Contains('configHealth')) {
+            $entry.Remove('configHealth')
+            if ($entry.Count -eq 0) {
+                $stateData.Remove($packageId)
+            }
+            else {
+                $stateData[$packageId] = $entry
+            }
+            $cleared++
+            $changed = $true
+        }
+    }
+
+    if ($changed) {
+        $directory = Split-Path -Path $StateFilePath -Parent
+        if (-not (Test-Path -Path $directory -PathType Container)) {
+            New-Item -Path $directory -ItemType Directory -Force | Out-Null
+        }
+        $stateData | ConvertTo-Json -Depth 10 | Set-Content -Path $StateFilePath -Encoding utf8 -Force
+    }
+
+    return [PSCustomObject]@{
+        Blocked = $blocked
+        Updated = $updated
+        Cleared = $cleared
+        Changed = $changed
+    }
+}

--- a/scripts/Select-PackagesNeedingUpdate.ps1
+++ b/scripts/Select-PackagesNeedingUpdate.ps1
@@ -38,14 +38,52 @@ if ($packages.Count -eq 0) {
     throw 'The monitored package list is empty.'
 }
 
+$stateFilePath = $env:PACKAGE_STATE_FILE
+if ([string]::IsNullOrWhiteSpace($stateFilePath)) {
+    $stateFilePath = Join-Path $PSScriptRoot '..' 'data' 'package-state.json'
+}
+elseif (-not [System.IO.Path]::IsPathRooted($stateFilePath)) {
+    $stateFilePath = Join-Path $PSScriptRoot '..' $stateFilePath
+}
+
+# Health blocks are a safety control, but a corrupt cache must not take down
+# every healthy package. The final installer URL preflight still blocks
+# definitive dead URLs when this cache cannot be read.
+try {
+    $configHealthBlocks = Get-PackageStateConfigHealthBlocks -StateFilePath $stateFilePath
+}
+catch {
+    Write-Warning "Could not load Config Health blocks from '$stateFilePath': $($_.Exception.Message). Continuing without cached blocks; final installer URL preflight remains active."
+    $configHealthBlocks = @{}
+}
+
+function New-ConfigHealthSkippedEntry {
+    param(
+        [Parameter(Mandatory = $true)] $Package,
+        [Parameter(Mandatory = $true)] [System.Collections.IDictionary] $Health
+    )
+
+    return [PSCustomObject]@{
+        Package      = $Package
+        Reason       = 'ConfigHealthBlocked'
+        HealthStatus = [string]$Health['status']
+        Detail       = [string]$Health['detail']
+        CheckedAt    = [string]$Health['checkedAt']
+    }
+}
+
 $include = $packages
+$skipped = @()
 
 try {
-    $stateFilePath = Join-Path $PSScriptRoot '..' 'data' 'package-state.json'
-    $result = Select-GitHubPackagesNeedingUpdate -Packages $packages -StateFilePath $stateFilePath
+    $result = Select-GitHubPackagesNeedingUpdate `
+        -Packages $packages `
+        -StateFilePath $stateFilePath `
+        -ConfigHealthBlocks $configHealthBlocks
     $include = @($result.Include | ForEach-Object { $_.Package })
+    $skipped = @($result.Skipped)
 
-    $skippedGroups = @($result.Skipped | Group-Object -Property Reason)
+    $skippedGroups = @($skipped | Group-Object -Property Reason)
     foreach ($group in $skippedGroups) {
         Write-Host "Skipping $($group.Count) package(s) [$($group.Name)]: $(@($group.Group | ForEach-Object { $_.Package.id }) -join ', ')"
     }
@@ -56,8 +94,41 @@ try {
     }
 }
 catch {
-    Write-Warning "Update precheck failed: $($_.Exception.Message). Falling back to processing all $($packages.Count) monitored packages."
-    $include = $packages
+    Write-Warning "Update precheck failed: $($_.Exception.Message). Falling back to all packages except known Config Health blocks."
+    $fallbackInclude = [System.Collections.Generic.List[object]]::new()
+    $fallbackSkipped = [System.Collections.Generic.List[object]]::new()
+    foreach ($package in $packages) {
+        $packageId = [string]$package.id
+        if ($configHealthBlocks.Contains($packageId)) {
+            $fallbackSkipped.Add((New-ConfigHealthSkippedEntry -Package $package -Health $configHealthBlocks[$packageId]))
+            continue
+        }
+        $fallbackInclude.Add($package)
+    }
+    $include = @($fallbackInclude)
+    $skipped = @($fallbackSkipped)
+}
+
+$healthBlocked = @($skipped | Where-Object { $_.Reason -eq 'ConfigHealthBlocked' })
+if ($healthBlocked.Count -gt 0) {
+    Write-Warning "Config Health blocked $($healthBlocked.Count) package(s) with known stale GitHub release assets."
+    $summary = @(
+        '## Config Health submission gate'
+        ''
+        "Blocked **$($healthBlocked.Count)** package(s) with a definitive stale GitHub release asset:"
+        ''
+        '| Package | Status | Detail | Checked UTC |'
+        '| --- | --- | --- | --- |'
+    )
+    foreach ($entry in ($healthBlocked | Sort-Object { $_.Package.id })) {
+        $detail = ("$($entry.Detail)" -replace '\s*[\r\n]+\s*', ' ').Replace('|', '\|')
+        $summary += "| $($entry.Package.id) | ``$($entry.HealthStatus)`` | $detail | $($entry.CheckedAt) |"
+    }
+    $summaryText = $summary -join "`n"
+    Write-Host $summaryText
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+    }
 }
 
 # Two separate limits apply here:
@@ -99,4 +170,5 @@ Write-Host "Selected $(@($include).Count) of $($packages.Count) monitored packag
 if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
     Add-Content -Path $env:GITHUB_OUTPUT -Value "include=$includeJson"
     Add-Content -Path $env:GITHUB_OUTPUT -Value "any=$any"
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "health_blocked_count=$($healthBlocked.Count)"
 }

--- a/scripts/Test-MonitoredPackageAssets.ps1
+++ b/scripts/Test-MonitoredPackageAssets.ps1
@@ -12,8 +12,8 @@
 #   GITHUB_STEP_SUMMARY      Markdown summary target (optional).
 #   GITHUB_OUTPUT            Receives broken_count / checked_count (optional).
 #
-# The script always exits 0: it is a report, not a gate. The workflow
-# publishes the summary and the JSON report artifact.
+# The script always exits 0: it produces the report consumed by the workflow,
+# which persists definitive findings as per-package submission blocks.
 $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot '..' 'modules' 'WingetMaintainerModule' 'WingetMaintainerModule.psd1') -Force

--- a/tests/PackageStateConfigHealth.Tests.ps1
+++ b/tests/PackageStateConfigHealth.Tests.ps1
@@ -1,0 +1,73 @@
+# Tests for the Config Health package-state blocklist.
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -WarningAction SilentlyContinue
+
+$script:failures = 0
+
+function Assert-Equal {
+    param($Expected, $Actual, [string] $Name)
+
+    if ("$Expected" -ne "$Actual") {
+        $script:failures++
+        Write-Host "FAIL: $Name (expected '$Expected', got '$Actual')"
+    }
+    else {
+        Write-Host "PASS: $Name"
+    }
+}
+
+$stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "packagestate-config-health-$([guid]::NewGuid()).json"
+
+try {
+    Set-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Version '1.0.0' -ManifestHash 'hash1' -InstallerHashes @('abc') -State 'VALIDATION_PASSED'
+    Set-PackageStateOpenPr -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated' -Version '2.0.0'
+
+    $results = @(
+        [PSCustomObject]@{ PackageId = 'Vendor.Validated'; Status = 'AssetMissing'; Detail = 'Expected setup.exe is absent.'; Tag = 'v2.0.0' },
+        [PSCustomObject]@{ PackageId = 'Vendor.Missing'; Status = 'RepoMissing'; Detail = 'Repository no longer exists.'; Tag = $null },
+        [PSCustomObject]@{ PackageId = 'Vendor.Unknown'; Status = 'Inconclusive'; Detail = 'Asset list is truncated.'; Tag = 'v3.0.0' }
+    )
+
+    $sync = Update-PackageStateConfigHealth -StateFilePath $stateFile -Results $results -CheckedAt ([datetime]'2026-08-18T00:00:00Z')
+    $blocks = Get-PackageStateConfigHealthBlocks -StateFilePath $stateFile
+    $validated = Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated'
+
+    Assert-Equal 2 $sync.Blocked 'definitive Config Health results are counted as blocks'
+    Assert-Equal 2 $sync.Updated 'new Config Health blocks are persisted'
+    Assert-Equal $true $sync.Changed 'new Config Health blocks change state'
+    Assert-Equal 'AssetMissing' $blocks['Vendor.Validated']['status'] 'asset failure is blocklisted'
+    Assert-Equal 'RepoMissing' $blocks['Vendor.Missing']['status'] 'missing repository is blocklisted'
+    Assert-Equal $false $blocks.Contains('Vendor.Unknown') 'inconclusive health result is not blocklisted'
+    Assert-Equal 'VALIDATION_PASSED' $validated['state'] 'validation state survives Config Health block'
+    Assert-Equal '2.0.0' $validated['openPr']['version'] 'open PR state survives Config Health block'
+
+    $unchanged = Update-PackageStateConfigHealth -StateFilePath $stateFile -Results $results -CheckedAt ([datetime]'2026-08-19T00:00:00Z')
+    Assert-Equal $false $unchanged.Changed 'identical Config Health findings do not churn state'
+
+    $recovery = Update-PackageStateConfigHealth -StateFilePath $stateFile -Results @(
+        [PSCustomObject]@{ PackageId = 'Vendor.Validated'; Status = 'OK'; Detail = 'Asset now resolves.'; Tag = 'v2.0.1' },
+        [PSCustomObject]@{ PackageId = 'Vendor.Missing'; Status = 'Inconclusive'; Detail = 'Asset list is truncated.'; Tag = $null }
+    )
+    $blocks = Get-PackageStateConfigHealthBlocks -StateFilePath $stateFile
+    $validated = Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Validated'
+
+    Assert-Equal 2 $recovery.Cleared 'non-blocking health results clear prior blocks'
+    Assert-Equal $false $blocks.Contains('Vendor.Validated') 'recovered package is unblocked'
+    Assert-Equal $false $blocks.Contains('Vendor.Missing') 'inconclusive package is unblocked'
+    Assert-Equal 'VALIDATION_PASSED' $validated['state'] 'clearing health state preserves validation state'
+    Assert-Equal '2.0.0' $validated['openPr']['version'] 'clearing health state preserves open PR state'
+    Assert-Equal '' "$(Get-PackageState -StateFilePath $stateFile -PackageIdentifier 'Vendor.Missing')" 'marker-only entry is removed after recovery'
+}
+finally {
+    Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:failures -gt 0) {
+    Write-Host "$script:failures assertion(s) failed."
+    exit 1
+}
+
+Write-Host 'All PackageStateConfigHealth tests passed.'

--- a/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+++ b/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
@@ -371,7 +371,59 @@ Assert-Equal 1 $openPrCapped.TesterCalls 'live PR searches stop at MaxOpenPrChec
 Assert-Equal 1 $openPrCapped.SkippedCount 'checked candidate with open PR is skipped'
 Assert-Equal 2 $openPrCapped.IncludeCount 'capped candidates are included unchecked'
 
-# 10) Resolvable version sources (tagPattern / ReleaseName / {ARPVERSION}) are
+# 10) Definitive Config Health blocks bypass GraphQL and prevent a package from
+#     entering the generation matrix.
+$healthBlocked = & $module {
+    $stateFile = Join-Path ([System.IO.Path]::GetTempPath()) "config-health-state-$([guid]::NewGuid()).json"
+    @{
+        'Vendor.AssetMissing' = @{
+            configHealth = @{
+                status    = 'AssetMissing'
+                detail    = 'Expected setup.exe is absent.'
+                checkedAt = '2026-08-18T00:00:00Z'
+            }
+        }
+        'Vendor.RepoMissing' = @{
+            configHealth = @{
+                status    = 'RepoMissing'
+                detail    = 'Repository no longer exists.'
+                checkedAt = '2026-08-18T00:00:00Z'
+            }
+        }
+    } | ConvertTo-Json -Depth 5 | Set-Content -Path $stateFile -Encoding utf8
+
+    $script:queries = [System.Collections.Generic.List[string]]::new()
+    $invoker = {
+        param([string] $Query)
+        $script:queries.Add($Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            return @{ data = @{ r0 = @{ latestRelease = @{ tagName = 'v2.0.0' } } } }
+        }
+        return @{ data = @{ repository = @{ p0 = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) } } } }
+    }
+
+    try {
+        $selection = Select-GitHubPackagesNeedingUpdate -Packages @(
+            @{ id = 'Vendor.AssetMissing'; repo = 'vendor/assetmissing'; url = 'https://example.com/{VERSION}.exe' },
+            @{ id = 'Vendor.RepoMissing'; repo = 'vendor/repomissing'; url = 'https://example.com/{VERSION}.exe' },
+            @{ id = 'Vendor.Healthy'; repo = 'vendor/healthy'; url = 'https://example.com/{VERSION}.exe' }
+        ) -GraphQlInvoker $invoker -StateFilePath $stateFile -OpenPrTester { $false }
+    }
+    finally {
+        Remove-Item -Path $stateFile -Force -ErrorAction SilentlyContinue
+    }
+
+    [PSCustomObject]@{
+        Selection = $selection
+        Queries  = @($script:queries)
+    }
+}
+Assert-Equal 'Skipped:ConfigHealthBlocked' (Get-ReasonFor $healthBlocked.Selection 'Vendor.AssetMissing') 'missing asset block skips package'
+Assert-Equal 'Skipped:ConfigHealthBlocked' (Get-ReasonFor $healthBlocked.Selection 'Vendor.RepoMissing') 'missing repository block skips package'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $healthBlocked.Selection 'Vendor.Healthy') 'healthy package remains eligible'
+Assert-Equal $false (($healthBlocked.Queries -join ' ') -match 'assetmissing|repomissing') 'blocked packages are omitted from GraphQL queries'
+
+# 11) Resolvable version sources (tagPattern / ReleaseName / {ARPVERSION}) are
 #     resolved in the precheck; every resolution failure falls back to include.
 $resolved = & $module {
     $script:queries = [System.Collections.Generic.List[string]]::new()

--- a/tests/SelectPackagesNeedingUpdateScript.Tests.ps1
+++ b/tests/SelectPackagesNeedingUpdateScript.Tests.ps1
@@ -14,12 +14,17 @@ function Invoke-PrecheckScript {
         [Parameter(Mandatory = $false)]
         [string] $BatchSize,
         [Parameter(Mandatory = $false)]
-        [switch] $ViaFile
+        [switch] $ViaFile,
+        [Parameter(Mandatory = $false)]
+        [System.Collections.IDictionary] $PackageState,
+        [Parameter(Mandatory = $false)]
+        [string] $PackageStateContent
     )
 
     $outputFile = Join-Path ([System.IO.Path]::GetTempPath()) ("precheck-output-" + [guid]::NewGuid().ToString('N') + ".txt")
     New-Item -Path $outputFile -ItemType File -Force | Out-Null
     $packagesFile = $null
+    $stateFile = $null
     try {
         $batchSizeLine = if ([string]::IsNullOrWhiteSpace($BatchSize)) {
             "`$env:UPDATE_BATCH_SIZE = `$null"
@@ -49,37 +54,60 @@ function Invoke-PrecheckScript {
             )
         }
 
+        $hasPackageState = $PSBoundParameters.ContainsKey('PackageState')
+        $hasPackageStateContent = $PSBoundParameters.ContainsKey('PackageStateContent')
+        if ($hasPackageState -or $hasPackageStateContent) {
+            $stateFile = Join-Path ([System.IO.Path]::GetTempPath()) ("precheck-state-" + [guid]::NewGuid().ToString('N') + ".json")
+            if ($hasPackageStateContent) {
+                Set-Content -LiteralPath $stateFile -Value $PackageStateContent -Encoding utf8
+            }
+            else {
+                $PackageState | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $stateFile -Encoding utf8
+            }
+            $stateLines = @("`$env:PACKAGE_STATE_FILE = '$stateFile'")
+        }
+        else {
+            $stateLines = @("`$env:PACKAGE_STATE_FILE = `$null")
+        }
+
         # No tokens: the precheck GraphQL call fails, exercising the fail-open path.
         $psi = @(
             "`$env:WINGET_UPSTREAM_READ_TOKEN = `$null",
             "`$env:GITHUB_TOKEN = `$null",
             "`$env:GH_TOKEN = `$null",
             $batchSizeLine
-        ) + $packageLines + @(
+        ) + $stateLines + $packageLines + @(
             "`$env:GITHUB_OUTPUT = '$outputFile'",
             "& '$scriptPath'"
         ) -join [Environment]::NewLine
-        $null = & pwsh -NoProfile -Command $psi 2>&1
+        $childOutput = @(& pwsh -NoProfile -Command $psi 2>&1)
         if ($LASTEXITCODE -ne 0) {
-            throw "Precheck script exited with code $LASTEXITCODE."
+            throw "Precheck script exited with code ${LASTEXITCODE}: $($childOutput -join "`n")"
         }
 
         $outputContent = Get-Content -LiteralPath $outputFile -Raw
         $includeLine = ($outputContent -split "`r?`n") | Where-Object { $_ -like 'include=*' } | Select-Object -First 1
         $anyLine = ($outputContent -split "`r?`n") | Where-Object { $_ -like 'any=*' } | Select-Object -First 1
-        if (-not $includeLine -or -not $anyLine) {
-            throw "GITHUB_OUTPUT is missing include=/any= lines: $outputContent"
+        $healthBlockedLine = ($outputContent -split "`r?`n") | Where-Object { $_ -like 'health_blocked_count=*' } | Select-Object -First 1
+        if (-not $includeLine -or -not $anyLine -or -not $healthBlockedLine) {
+            throw "GITHUB_OUTPUT is missing include=/any=/health_blocked_count= lines: $outputContent"
         }
 
         return [PSCustomObject]@{
-            Include = @(($includeLine.Substring('include='.Length)) | ConvertFrom-Json)
-            Any     = $anyLine.Substring('any='.Length)
+            Include            = @(($includeLine.Substring('include='.Length)) | ConvertFrom-Json)
+            Any                = $anyLine.Substring('any='.Length)
+            HealthBlockedCount = [int]$healthBlockedLine.Substring('health_blocked_count='.Length)
+            ChildOutput        = ($childOutput | ForEach-Object { "$_" }) -join "`n"
+            StateContent       = if ($stateFile) { Get-Content -LiteralPath $stateFile -Raw } else { '' }
         }
     }
     finally {
         Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
         if ($packagesFile) {
             Remove-Item -LiteralPath $packagesFile -Force -ErrorAction SilentlyContinue
+        }
+        if ($stateFile) {
+            Remove-Item -LiteralPath $stateFile -Force -ErrorAction SilentlyContinue
         }
     }
 }
@@ -147,6 +175,45 @@ if (@($fileResult.Include).Count -ne 7) {
 }
 if ($fileResult.Any -ne 'true') {
     $failures += "A file-supplied list must report any=true, got '$($fileResult.Any)'."
+}
+
+# --- Definitive Config Health blocks survive GraphQL precheck fallback. ---
+$healthState = @{
+    'Package.Blocked' = @{
+        configHealth = @{
+            status    = 'AssetMissing'
+            detail    = 'Expected setup.exe is absent.'
+            checkedAt = '2026-08-18T00:00:00Z'
+        }
+    }
+}
+$healthPackages = @(
+    [PSCustomObject]@{ id = 'Package.Blocked'; repo = 'owner/blocked'; url = 'https://example.invalid/blocked' },
+    [PSCustomObject]@{ id = 'Package.Healthy'; repo = 'owner/healthy'; url = 'https://example.invalid/healthy' }
+)
+$healthResult = Invoke-PrecheckScript -Packages $healthPackages -PackageState $healthState
+if (@($healthResult.Include).Count -ne 1 -or $healthResult.Include[0].id -ne 'Package.Healthy') {
+    $failures += "Config Health block must remain excluded when GraphQL precheck falls back. State: $($healthResult.StateContent) Child output: $($healthResult.ChildOutput)"
+}
+if ($healthResult.HealthBlockedCount -ne 1) {
+    $failures += "Expected one Config Health block in fallback, got $($healthResult.HealthBlockedCount). State: $($healthResult.StateContent) Child output: $($healthResult.ChildOutput)"
+}
+if ($healthResult.Any -ne 'true') {
+    $failures += "Fallback with one healthy package must report any=true, got '$($healthResult.Any)'."
+}
+
+$allBlockedResult = Invoke-PrecheckScript -Packages @($healthPackages[0]) -PackageState $healthState
+if (@($allBlockedResult.Include).Count -ne 0 -or $allBlockedResult.Any -ne 'false') {
+    $failures += 'All Config Health-blocked packages must suppress the generation matrix.'
+}
+
+# --- A corrupt health cache is loud but does not halt healthy packages. ---
+$corruptStateResult = Invoke-PrecheckScript -Packages $healthPackages -PackageStateContent '{not-json'
+if (@($corruptStateResult.Include).Count -ne 2 -or $corruptStateResult.Any -ne 'true') {
+    $failures += 'A corrupt Config Health cache must fall back to processing all packages.'
+}
+if ($corruptStateResult.HealthBlockedCount -ne 0) {
+    $failures += "A corrupt Config Health cache must report zero trusted blocks, got $($corruptStateResult.HealthBlockedCount)."
 }
 
 # --- A missing package file must fail loudly instead of silently doing nothing ---

--- a/tests/TestMonitoredPackageAssets.Tests.ps1
+++ b/tests/TestMonitoredPackageAssets.Tests.ps1
@@ -72,6 +72,47 @@ if ($results[0].Status -ne 'OK') {
     throw "Expected whitespace-delimited URL template to resolve, got: $($results[0] | ConvertTo-Json -Compress)"
 }
 
+Write-Host 'TEST: latest release URLs and query strings normalize to release assets'
+$latestPackages = @([PSCustomObject]@{
+        id   = 'Test.Latest'
+        repo = 'owner/latest'
+        url  = 'https://github.com/OWNER/LATEST/releases/latest/download/setup-{VERSION}.exe'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/latest/releases/download/v1.2.3/setup-1.2.3.exe')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $latestPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK') {
+    throw "Expected latest/download URL to resolve, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+$queryPackages = @([PSCustomObject]@{
+        id   = 'Test.Query'
+        repo = 'owner/query'
+        url  = 'https://github.com/owner/query/releases/download/{TAG}/setup-{VERSION}.exe?download=1'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/query/releases/download/v1.2.3/setup-1.2.3.exe')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $queryPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'OK') {
+    throw "Expected query-string URL to resolve, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: external download URLs are left to submission preflight'
+$externalPackages = @([PSCustomObject]@{
+        id   = 'Test.External'
+        repo = 'owner/external'
+        url  = 'https://downloads.example.invalid/setup-{VERSION}.exe'
+    })
+$invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
+    'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/external/releases/download/v1.2.3/setup-1.2.3.exe')) }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $externalPackages -GraphQlInvoker $invoker)
+if ($results[0].Status -ne 'Skipped') {
+    throw "Expected external download URL to be skipped, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
 Write-Host 'TEST: renamed asset reports AssetMissing with the expected URL'
 $invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
     'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/renamed.msi')) }


### PR DESCRIPTION
Persist definitive Config Health findings (AssetMissing and RepoMissing) in package state and exclude those packages from generation, including when the GraphQL precheck falls back. Normalize latest/download URLs and query suffixes, defer external hosts to the existing final URL preflight, and add state, selector, script, and health-check regressions.