### PR TITLE
P1: make QuestionsRequired stops green and restore needs-decision markers

### DIFF
--- a/.github/workflows-templates/github-releases.yml
+++ b/.github/workflows-templates/github-releases.yml
@@ -181,7 +181,7 @@ jobs:
           if-no-files-found: error
 
       - name: Record needs-decision marker
-        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
         shell: pwsh
         env:
           JOB_NAME: Generate ${{ matrix.id }}
@@ -207,7 +207,7 @@ jobs:
           Get-Content -Path ./needs-decision/question.json
 
       - name: Upload needs-decision marker
-        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
@@ -217,7 +217,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Record generation failure
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         shell: pwsh
         env:
           JOB_NAME: Generate ${{ matrix.id }}
@@ -248,7 +248,7 @@ jobs:
           Get-Content -Path ./generate-failure/failure.json
 
       - name: Upload generation failure marker
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
@@ -973,7 +973,9 @@ jobs:
         submit-pr,
       ]
     runs-on: ubuntu-latest
-    if: always() && failure() && vars.NTFY_URL != ''
+    # Run on every failure - even without NTFY_URL - so the missing-variable
+    # warning below is visible instead of the job being silently skipped.
+    if: always() && failure()
 
     steps:
       - name: Checkout
@@ -981,7 +983,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Warn when NTFY_URL is not configured
+        if: vars.NTFY_URL == ''
+        shell: pwsh
+        run: |
+          Write-Host "::warning::NTFY_URL not configured — failure notifications disabled"
+
       - name: Send failure notification
+        if: vars.NTFY_URL != ''
         shell: pwsh
         run: |
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-github-packages-1-z.yml
+++ b/.github/workflows/update-github-packages-1-z.yml
@@ -200,7 +200,7 @@ jobs:
           if-no-files-found: error
 
       - name: Record needs-decision marker
-        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
         shell: pwsh
         env:
           JOB_NAME: Generate ${{ matrix.id }}
@@ -226,7 +226,7 @@ jobs:
           Get-Content -Path ./needs-decision/question.json
 
       - name: Upload needs-decision marker
-        if: steps.generate.outputs.reason == 'QuestionsRequired'
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
@@ -236,7 +236,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Record generation failure
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         shell: pwsh
         env:
           JOB_NAME: Generate ${{ matrix.id }}
@@ -267,7 +267,7 @@ jobs:
           Get-Content -Path ./generate-failure/failure.json
 
       - name: Upload generation failure marker
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
@@ -1005,7 +1005,9 @@ jobs:
         submit-pr,
       ]
     runs-on: ubuntu-latest
-    if: always() && failure() && vars.NTFY_URL != ''
+    # Run on every failure - even without NTFY_URL - so the missing-variable
+    # warning below is visible instead of the job being silently skipped.
+    if: always() && failure()
 
     steps:
       - name: Checkout
@@ -1013,7 +1015,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Warn when NTFY_URL is not configured
+        if: vars.NTFY_URL == ''
+        shell: pwsh
+        run: |
+          Write-Host "::warning::NTFY_URL not configured — failure notifications disabled"
+
       - name: Send failure notification
+        if: vars.NTFY_URL != ''
         shell: pwsh
         run: |
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
+++ b/modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1
@@ -50,6 +50,30 @@ function Update-WingetPackage {
         Reason       = $null
     }
 
+    # Every terminating error below - own throws as well as ones bubbling out of
+    # helper functions such as Test-GeneratedInstallerArchitecture - must surface a
+    # structured failure payload first, otherwise the workflow's generate-failure
+    # marker steps have no details to render. The GeneratorFailed branch writes a
+    # richer payload itself and sets $failurePayloadWritten so this trap skips it.
+    $failurePayloadWritten = $false
+    trap {
+        if ($env:GITHUB_OUTPUT -and -not $failurePayloadWritten) {
+            $trapGeneratorVariable = Get-Variable -Name EffectiveWith -ErrorAction SilentlyContinue
+            $trapGenerator = if ($trapGeneratorVariable) { $trapGeneratorVariable.Value } else { $With }
+            $trapVersion = if ($result.Version) { $result.Version } else { $latestVersion }
+            # GITHUB_OUTPUT key=value entries are line based, so flatten the message.
+            $trapError = ("$_" -replace '\r?\n', ' ').Trim()
+            "generated=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "reason=UnhandledError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "package-id=$WingetPackage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "version=$trapVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "generator=$trapGenerator" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            "error=$trapError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        }
+        # Rethrow the original error so the step still fails.
+        break
+    }
+
     # Custom validation
     if (-not $IsTemplateUpdate -and -not $WebsiteURL -and (-not $latestVersion -or -not $latestVersionURL)) {
         throw "Either WebsiteURL or both latestVersion and latestVersionURL are required."
@@ -307,6 +331,12 @@ function Update-WingetPackage {
                         "error=$generatorError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
                     }
 
+                    # The GitHub runner's pwsh step epilogue runs
+                    # `if (Test-Path variable:\LASTEXITCODE) { exit $LASTEXITCODE }`,
+                    # so winmatsch's leftover exit code 4 would fail the step even
+                    # though this benign stop returns without throwing. Reset it so
+                    # the job stays green and the needs-decision steps can run.
+                    $global:LASTEXITCODE = 0
                     return $result
                 }
 
@@ -322,6 +352,7 @@ function Update-WingetPackage {
                     "generator-exit-code=$generatorExitCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
                     "error-code=$generatorErrorCode" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
                     "error=$generatorError" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                    $failurePayloadWritten = $true
                 }
 
                 throw "$EffectiveWith update failed for $wingetPackage $($Latest.Version) with exit code $generatorExitCode. $generatorError"

--- a/tests/Update-WingetPackage.Tests.ps1
+++ b/tests/Update-WingetPackage.Tests.ps1
@@ -366,10 +366,12 @@ $questionsRequiredResult = & $module {
             -With 'WinMatsch' `
             -latestVersion '1.0.0' `
             -latestVersionURL 'https://example.invalid/app.zip'
+        $exitCodeAfterUpdate = $LASTEXITCODE
 
         [PSCustomObject]@{
-            Result        = $result
-            OutputContent = (Get-Content -LiteralPath $outputFile -Raw)
+            Result              = $result
+            ExitCodeAfterUpdate = $exitCodeAfterUpdate
+            OutputContent       = (Get-Content -LiteralPath $outputFile -Raw)
         }
     }
     finally {
@@ -382,6 +384,9 @@ if ($questionsRequiredResult.Result.Generated -or $questionsRequiredResult.Resul
 }
 if ($questionsRequiredResult.OutputContent -notmatch '(?m)^reason=QuestionsRequired\s*$') {
     throw "The QuestionsRequired reason was not written to GITHUB_OUTPUT: $($questionsRequiredResult.OutputContent)"
+}
+if ($questionsRequiredResult.ExitCodeAfterUpdate -ne 0) {
+    throw "QuestionsRequired left LASTEXITCODE=$($questionsRequiredResult.ExitCodeAfterUpdate); the GitHub runner pwsh epilogue (exit `$LASTEXITCODE) would fail the step."
 }
 
 Write-Host 'TEST: non-question WinMatsch failures still throw as GeneratorFailed'
@@ -408,20 +413,144 @@ $generatorFailedResult = & $module {
         $global:LASTEXITCODE = 5
     }
 
+    $originalGitHubOutput = $env:GITHUB_OUTPUT
+    $outputFile = Join-Path ([IO.Path]::GetTempPath()) "winget-generator-failed-$([guid]::NewGuid().ToString('N')).txt"
+    $env:GITHUB_OUTPUT = $outputFile
     try {
-        Update-WingetPackage `
-            -WingetPackage 'Test.Package' `
-            -With 'WinMatsch' `
-            -latestVersion '1.0.0' `
-            -latestVersionURL 'https://example.invalid/app.zip' | Out-Null
-        [PSCustomObject]@{ Threw = $false; Message = $null }
+        $threw = $false
+        $message = $null
+        try {
+            Update-WingetPackage `
+                -WingetPackage 'Test.Package' `
+                -With 'WinMatsch' `
+                -latestVersion '1.0.0' `
+                -latestVersionURL 'https://example.invalid/app.zip' | Out-Null
+        }
+        catch {
+            $threw = $true
+            $message = $_.Exception.Message
+        }
+        [PSCustomObject]@{
+            Threw         = $threw
+            Message       = $message
+            OutputContent = (Get-Content -LiteralPath $outputFile -Raw)
+        }
     }
-    catch {
-        [PSCustomObject]@{ Threw = $true; Message = $_.Exception.Message }
+    finally {
+        $env:GITHUB_OUTPUT = $originalGitHubOutput
+        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
     }
 }
 if (-not $generatorFailedResult.Threw -or $generatorFailedResult.Message -notmatch 'exit code 5') {
     throw "A real generator failure no longer fails the job: $($generatorFailedResult | ConvertTo-Json -Compress)"
+}
+if ($generatorFailedResult.OutputContent -notmatch '(?m)^reason=GeneratorFailed\s*$') {
+    throw "The GeneratorFailed reason was not written to GITHUB_OUTPUT: $($generatorFailedResult.OutputContent)"
+}
+if ($generatorFailedResult.OutputContent -match '(?m)^reason=UnhandledError\s*$') {
+    throw "The trap overwrote the GeneratorFailed payload: $($generatorFailedResult.OutputContent)"
+}
+
+Write-Host 'TEST: architecture-validation failures write the failure payload before throwing'
+$archValidationResult = & $module {
+    function Test-GitHubToken { 'test-token' }
+    function Test-PackageAndVersionInGithub {
+        [PSCustomObject]@{
+            PackageExists          = $true
+            ShouldGenerate         = $true
+            VersionExists          = $false
+            CanonicalVersion       = '1.0.0'
+            PublishedVersion       = $null
+            LatestPublishedVersion = $null
+        }
+    }
+    function Test-ExistingPRs { $false }
+    function Install-WinMatsch {}
+    function winmatsch {
+        $global:LASTEXITCODE = 0
+    }
+    function Test-GeneratedInstallerArchitecture {
+        throw "Installer architecture validation failed for Test.Package 1.0.0:`n - Generated architecture mismatch for https://example.invalid/app.zip: expected x86, got [x64]"
+    }
+
+    $originalGitHubOutput = $env:GITHUB_OUTPUT
+    $outputFile = Join-Path ([IO.Path]::GetTempPath()) "winget-arch-failure-$([guid]::NewGuid().ToString('N')).txt"
+    $env:GITHUB_OUTPUT = $outputFile
+    try {
+        $threw = $false
+        $message = $null
+        try {
+            Update-WingetPackage `
+                -WingetPackage 'Test.Package' `
+                -With 'WinMatsch' `
+                -latestVersion '1.0.0' `
+                -latestVersionURL 'https://example.invalid/app.zip' | Out-Null
+        }
+        catch {
+            $threw = $true
+            $message = $_.Exception.Message
+        }
+        [PSCustomObject]@{
+            Threw         = $threw
+            Message       = $message
+            OutputContent = (Get-Content -LiteralPath $outputFile -Raw)
+        }
+    }
+    finally {
+        $env:GITHUB_OUTPUT = $originalGitHubOutput
+        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+    }
+}
+if (-not $archValidationResult.Threw -or $archValidationResult.Message -notmatch 'architecture validation failed') {
+    throw "The architecture-validation failure no longer propagates: $($archValidationResult | ConvertTo-Json -Compress)"
+}
+if ($archValidationResult.OutputContent -notmatch '(?m)^reason=UnhandledError\s*$') {
+    throw "The architecture-validation failure did not write the failure payload: $($archValidationResult.OutputContent)"
+}
+if ($archValidationResult.OutputContent -notmatch '(?m)^package-id=Test\.Package\s*$') {
+    throw "The failure payload is missing the package id: $($archValidationResult.OutputContent)"
+}
+if ($archValidationResult.OutputContent -notmatch '(?m)^version=1\.0\.0\s*$') {
+    throw "The failure payload is missing the version: $($archValidationResult.OutputContent)"
+}
+if ($archValidationResult.OutputContent -notmatch '(?m)^error=.*architecture validation failed.*Generated architecture mismatch.*$') {
+    throw "The failure payload did not flatten the error message onto one line: $($archValidationResult.OutputContent)"
+}
+
+Write-Host 'TEST: early validation failures write the failure payload before throwing'
+$earlyValidationResult = & $module {
+    $originalGitHubOutput = $env:GITHUB_OUTPUT
+    $outputFile = Join-Path ([IO.Path]::GetTempPath()) "winget-early-failure-$([guid]::NewGuid().ToString('N')).txt"
+    $env:GITHUB_OUTPUT = $outputFile
+    try {
+        $threw = $false
+        $message = $null
+        try {
+            Update-WingetPackage -WingetPackage 'Test.Package' -With 'WinMatsch' | Out-Null
+        }
+        catch {
+            $threw = $true
+            $message = $_.Exception.Message
+        }
+        [PSCustomObject]@{
+            Threw         = $threw
+            Message       = $message
+            OutputContent = (Get-Content -LiteralPath $outputFile -Raw)
+        }
+    }
+    finally {
+        $env:GITHUB_OUTPUT = $originalGitHubOutput
+        Remove-Item -LiteralPath $outputFile -Force -ErrorAction SilentlyContinue
+    }
+}
+if (-not $earlyValidationResult.Threw -or $earlyValidationResult.Message -notmatch 'WebsiteURL') {
+    throw "The early validation failure no longer propagates: $($earlyValidationResult | ConvertTo-Json -Compress)"
+}
+if ($earlyValidationResult.OutputContent -notmatch '(?m)^reason=UnhandledError\s*$') {
+    throw "The early validation failure did not write the failure payload: $($earlyValidationResult.OutputContent)"
+}
+if ($earlyValidationResult.OutputContent -notmatch '(?m)^package-id=Test\.Package\s*$') {
+    throw "The early failure payload is missing the package id: $($earlyValidationResult.OutputContent)"
 }
 
 Write-Host 'All Update-WingetPackage regression tests passed.' -ForegroundColor Green


### PR DESCRIPTION
## Problem

winmatsch exit 4 (`QuestionsRequired`) is a structured, benign "needs human decision" stop, but in practice **every safety question turned the job red and the needs-decision markers never ran** (verified on run 32231781528 / job "Generate Faster3ck.Converseen"):

1. The exit-4 branch in `Update-WingetPackage.ps1` writes `reason=QuestionsRequired` and returns without throwing — but `$LASTEXITCODE` stays 4, and the GitHub runner's pwsh step epilogue (`if (Test-Path variable:\LASTEXITCODE) { exit $LASTEXITCODE }`) fails the step anyway.
2. With the generate step failed, the needs-decision marker steps (implicit `success()`) skip, and the `if: failure()` generate-failure steps run instead — so QuestionsRequired stops produced `generate-failure__*` artifacts and zero `needs-decision__*` artifacts.
3. The `notify-failure` job is gated on `vars.NTFY_URL != ''`, which is unset in this repo, so it has been silently skipped on every failure ever.

## Fix

**`modules/WingetMaintainerModule/Public/Update-WingetPackage.ps1`**
- QuestionsRequired branch resets `$global:LASTEXITCODE = 0` before returning, with a comment explaining the runner epilogue behavior.
- **P5.4:** a scope-wide `trap` now guarantees *every* terminating error — architecture-validation throws from `Test-GeneratedInstallerArchitecture`, early parameter validation, any helper throw — writes the structured failure payload (`generated`, `reason=UnhandledError`, `package-id`, `version`, `generator`, single-line `error`) to `GITHUB_OUTPUT` before the error propagates. The GeneratorFailed branch keeps its richer payload (incl. `generator-exit-code`, `error-code`) via a `$failurePayloadWritten` flag so the trap doesn't overwrite it. Keys match exactly what the workflow marker steps consume.

**`.github/workflows/update-github-packages-1-z.yml` + `.github/workflows-templates/github-releases.yml`** (kept byte-identical in the shared blocks; the generated file is produced verbatim from the template by `scripts/orchestrate_gh-packages.py`)
- Both needs-decision marker steps: `if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}` (defense in depth).
- Both generate-failure steps: `if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}`.
- `notify-failure` now runs on every failure (`always() && failure()`); the send step is gated on `vars.NTFY_URL != ''` and a new step emits `::warning::NTFY_URL not configured — failure notifications disabled` when it's empty, so the gap is visible instead of the job being silently skipped. No secrets/variables were touched.

`update-script-packages.yml` has the same silent NTFY gate but is a separate pipeline (not generated from this template, no QuestionsRequired handling) — left untouched to keep this diff surgical; noted as follow-up.

## Verification

- **Acceptance (static):** a QuestionsRequired-only run now ends green (LASTEXITCODE reset, no throw), the needs-decision steps' conditions evaluate true, `needs-decision__*` uploads, and the existing summary job renders the table. A genuine crash still fails the job (trap rethrows via `break`) and uploads `generate-failure__*` with full details.
- **Tests** (`tests/Update-WingetPackage.Tests.ps1`, plain-script suite, extended):
  - exit-4 test now also asserts `$LASTEXITCODE -eq 0` after the call (the exact epilogue failure mode);
  - new: architecture-validation throw writes the full payload (incl. multiline error flattened to one `error=` line) before propagating;
  - new: early parameter-validation throw writes the payload;
  - exit-5 test now also asserts `reason=GeneratorFailed` is written and *not* overwritten by the trap.
- All CI suites from `module-tests.yml` pass locally: 14 plain-script suites exit 0; the 3 non-CI plain suites also pass. The Pester suites show 8 failures in `Submit-WingetPackage`-related tests that reproduce **identically on the pristine base** (pre-existing local-environment failures, unrelated files) — my diff introduces zero new failures.
- Both workflow YAMLs parse (`yaml.safe_load`); changed blocks verified byte-identical between template and generated workflow.
- No workflows dispatched; microsoft/winget-pkgs untouched.