### PR TITLE
P5: duplicate-PR search by manifest path, asset pagination, dual-arch drift relaxation

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -97,6 +97,7 @@ jobs:
           ./tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
           ./tests/SelectPackagesNeedingUpdateScript.Tests.ps1
           ./tests/TestMonitoredPackageAssets.Tests.ps1
+          ./tests/TestGeneratedInstallerArchitecture.Tests.ps1
           ./tests/Update-WingetPackage.Tests.ps1
           ./tests/GitHubApiCache.Tests.ps1
           ./tests/SubmissionWorkflowAuthorization.Tests.ps1

--- a/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
+++ b/modules/WingetMaintainerModule/Private/Test-GeneratedInstallerArchitecture.ps1
@@ -227,19 +227,40 @@ function Test-GeneratedInstallerArchitecture {
                     $previousEntriesByNormalizedUrl[$normalizedInstallerUrl].Add([string]$previousEntry.Architecture)
                 }
 
+                $generatedEntriesByNormalizedUrl = @{}
                 foreach ($generatedEntry in $generatedEntries) {
                     if ($hintedInstallerUrls -contains $generatedEntry.InstallerUrl) {
                         continue
                     }
 
                     $normalizedInstallerUrl = Get-NormalizedInstallerUrl -InstallerUrl $generatedEntry.InstallerUrl -KnownVersions $knownVersions
+                    if (-not $generatedEntriesByNormalizedUrl.ContainsKey($normalizedInstallerUrl)) {
+                        $generatedEntriesByNormalizedUrl[$normalizedInstallerUrl] = [PSCustomObject]@{
+                            InstallerUrl  = [string]$generatedEntry.InstallerUrl
+                            Architectures = [System.Collections.Generic.List[string]]::new()
+                        }
+                    }
+
+                    $generatedEntriesByNormalizedUrl[$normalizedInstallerUrl].Architectures.Add([string]$generatedEntry.Architecture)
+                }
+
+                # The generator legitimately emits one URL under several
+                # architectures (e.g. winmatsch publishing a dual-payload
+                # installer as both x86 and x64), so the generated set may be a
+                # superset of the previously published architectures. Genuine
+                # drift is a previously published architecture that disappears
+                # (or is replaced) for the same normalized URL.
+                foreach ($normalizedInstallerUrl in $generatedEntriesByNormalizedUrl.Keys) {
                     if (-not $previousEntriesByNormalizedUrl.ContainsKey($normalizedInstallerUrl)) {
                         continue
                     }
 
+                    $generatedGroup = $generatedEntriesByNormalizedUrl[$normalizedInstallerUrl]
                     $previousArchitectures = @($previousEntriesByNormalizedUrl[$normalizedInstallerUrl] | Sort-Object -Unique)
-                    if ($previousArchitectures.Count -eq 1 -and $previousArchitectures[0] -ne $generatedEntry.Architecture) {
-                        [void]$validationErrors.Add("Generated architecture drift detected for $($generatedEntry.InstallerUrl): expected $($previousArchitectures[0]) based on previous winget manifest, got $($generatedEntry.Architecture)")
+                    $generatedArchitectures = @($generatedGroup.Architectures | Sort-Object -Unique)
+                    $missingArchitectures = @($previousArchitectures | Where-Object { $generatedArchitectures -notcontains $_ })
+                    if ($missingArchitectures.Count -gt 0) {
+                        [void]$validationErrors.Add("Generated architecture drift detected for $($generatedGroup.InstallerUrl): previously published architecture(s) [$($missingArchitectures -join ', ')] missing from generated entries (previous winget manifest: [$($previousArchitectures -join ', ')]; generated: [$($generatedArchitectures -join ', ')])")
                     }
                 }
             }

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -23,6 +23,15 @@
     credential tier. API and response-shape failures are surfaced so callers
     fail closed instead of treating an uncertain result as no duplicate.
 
+    Title matching alone misses human-opened pull requests whose titles omit
+    the package identifier (verified: upstream #419315 'Submitting Godot
+    Launcher 1.11.1' raced the bot's duplicate #419629). When no title match
+    is found, a second stage searches open pull requests that mention the
+    version in their title and verifies their changed files against the
+    package's manifest path (manifests/<first letter>/<identifier as
+    directories>/<version>/) via the pull request files API. The second stage
+    only ever reads the upstream repository and covers open pull requests.
+
 .PARAMETER Version
     The version of the package to check for existing PRs. This parameter is mandatory.
 
@@ -62,169 +71,432 @@ function Test-ExistingPRs {
     $escapedVersion = $Version.Replace('"', '\"')
     $openOnlyQuery = if ($OnlyOpen) { ' is:open' } else { '' }
     $query = "repo:$Repository is:pr$openOnlyQuery in:title `"$escapedPackageIdentifier`" `"$escapedVersion`""
-    $encodedQuery = [uri]::EscapeDataString($query)
+    $titleCandidateEvaluator = {
+        param($existingPr)
 
+        $titleProperty = $existingPr.PSObject.Properties['title']
+        $stateProperty = $existingPr.PSObject.Properties['state']
+        if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
+            throw 'GitHub existing-PR search returned a candidate without a title or state.'
+        }
+
+        $state = "$($stateProperty.Value)".ToLowerInvariant()
+        if ($state -notin @('open', 'closed')) {
+            throw "GitHub existing-PR search returned an unrecognized PR state '$state'."
+        }
+
+        $pullRequestProperty = $existingPr.PSObject.Properties['pull_request']
+        $mergedAt = $null
+        if ($state -eq 'closed') {
+            if ($null -eq $pullRequestProperty -or $null -eq $pullRequestProperty.Value) {
+                throw 'GitHub existing-PR search returned a closed PR without pull request metadata.'
+            }
+
+            $mergedAtProperty = $pullRequestProperty.Value.PSObject.Properties['merged_at']
+            if ($null -eq $mergedAtProperty) {
+                throw 'GitHub existing-PR search returned a closed PR without merged_at metadata.'
+            }
+            $mergedAt = $mergedAtProperty.Value
+        }
+
+        if (-not (Test-WingetPkgsExistingPrTitle `
+                    -Title "$($titleProperty.Value)" `
+                    -PackageIdentifier $PackageIdentifier `
+                    -Version $Version)) {
+            return $false
+        }
+
+        return ($state -eq 'open' -or (-not $OnlyOpen -and -not [string]::IsNullOrWhiteSpace("$mergedAt")))
+    }
+
+    $titleMatch = Find-WingetPkgsExistingPrSearchMatch -Query $query -CandidateEvaluator $titleCandidateEvaluator
+    if ($null -ne $titleMatch) {
+        Write-Host "Found existing PR: $($titleMatch.title)"
+        Write-Host "-> $($titleMatch.html_url)"
+        return $true
+    }
+
+    # The title search misses human-opened PRs whose titles omit the package
+    # identifier. Search open PRs mentioning the version and compare their
+    # changed files against the package's manifest path before concluding
+    # that no duplicate exists.
+    $manifestPathMatch = Find-WingetPkgsOpenPrForManifestPath `
+        -Repository $Repository `
+        -PackageIdentifier $PackageIdentifier `
+        -Version $Version
+    if ($null -ne $manifestPathMatch) {
+        Write-Host "Found existing PR touching manifest path $($manifestPathMatch.ManifestPathPrefix): $($manifestPathMatch.Title)"
+        Write-Host "-> $($manifestPathMatch.Url)"
+        return $true
+    }
+
+    Write-Host "No matching PR found for $PackageIdentifier $Version in $Repository"
+    return $false
+}
+
+function Invoke-WingetPkgsUpstreamReadRequest {
+    <#
+    .SYNOPSIS
+        Performs one public upstream GitHub read with credential-tier failover.
+
+    .DESCRIPTION
+        Sends a GET request with the upstream read credential tiers
+        (WINGET_UPSTREAM_READ_TOKEN, WINGET_UPSTREAM_READ_FALLBACK_TOKEN,
+        anonymous), retrying transient HTTP 422 responses per tier and
+        rate-limited responses with header-aware backoff. Non-failover
+        failures surface to the caller so duplicate decisions fail closed.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Uri,
+        [Parameter(Mandatory = $true)] [string] $OperationName
+    )
+
+    $maximumTransientAttempts = 3
+    $response = $null
+    $requestSucceeded = $false
+    $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
+    for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
+        $tier = $credentialTiers[$tierIndex]
+        $headers = @{
+            Accept                 = 'application/vnd.github+json'
+            'X-GitHub-Api-Version' = '2022-11-28'
+            'User-Agent'           = 'winget-pkgs-updates'
+        }
+        if (-not [string]::IsNullOrWhiteSpace($tier.Token)) {
+            $headers.Authorization = "Bearer $($tier.Token)"
+        }
+        for ($attempt = 1; $attempt -le $maximumTransientAttempts; $attempt++) {
+            try {
+                $response = Invoke-WithGitHubRateLimitRetry `
+                    -OperationName $OperationName `
+                    -MaxAttempts 4 `
+                    -MaxTotalWaitSeconds 120 `
+                    -ScriptBlock {
+                        Invoke-RestMethod `
+                            -Method Get `
+                            -Uri $Uri `
+                            -Headers $headers `
+                            -ErrorAction Stop
+                    }
+                $requestSucceeded = $true
+                break
+            }
+            catch {
+                $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
+                $responseBody = Get-WingetPkgsGitHubApiFailureResponseBody -ErrorRecord $_
+                $responseDetail = if ([string]::IsNullOrWhiteSpace($responseBody)) {
+                    ''
+                }
+                else {
+                    " Response body: $responseBody"
+                }
+
+                if ($statusCode -eq 422 -and $attempt -lt $maximumTransientAttempts) {
+                    Write-Warning "GitHub $OperationName returned HTTP 422 on attempt $attempt of $maximumTransientAttempts; retrying.$responseDetail"
+                    Start-Sleep -Seconds $attempt
+                    continue
+                }
+
+                $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
+                if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
+                    if (-not [string]::IsNullOrWhiteSpace($responseDetail)) {
+                        Write-Warning "GitHub $OperationName failed with HTTP $statusCode.$responseDetail"
+                    }
+                    throw
+                }
+                $nextTier = $credentialTiers[$tierIndex + 1]
+                Write-Warning "GitHub $OperationName with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label).$responseDetail"
+                break
+            }
+        }
+        if ($requestSucceeded) {
+            break
+        }
+    }
+    if (-not $requestSucceeded) {
+        throw "GitHub $OperationName returned no response."
+    }
+
+    return $response
+}
+
+function Find-WingetPkgsExistingPrSearchMatch {
+    <#
+    .SYNOPSIS
+        Pages through a GitHub Search query and returns the first matching candidate.
+
+    .DESCRIPTION
+        Validates every Search response shape (items, total_count,
+        incomplete_results, page size) and fails closed on anomalies so an
+        uncertain search never turns into a no-duplicate decision. The
+        candidate evaluator receives each item and returns $true to stop the
+        search with that item as the match; it may throw to surface malformed
+        candidates.
+    #>
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Query,
+        [Parameter(Mandatory = $true)] [scriptblock] $CandidateEvaluator,
+        [Parameter()] [string] $OperationName = 'existing-PR search',
+        [Parameter()] [string] $AdditionalQueryParameters = ''
+    )
+
+    $encodedQuery = [uri]::EscapeDataString($Query)
     $pageSize = 100
     $maximumSearchResults = 1000
     $page = 1
     $retrievedCount = 0
     $totalCount = $null
-    $maximumSearchAttempts = 3
 
     while ($true) {
-        $response = $null
-        $credentialTiers = @(Get-WingetPkgsUpstreamReadCredentialTiers)
-        for ($tierIndex = 0; $tierIndex -lt $credentialTiers.Count; $tierIndex++) {
-            $tier = $credentialTiers[$tierIndex]
-            $headers = @{
-                Accept                 = 'application/vnd.github+json'
-                'X-GitHub-Api-Version' = '2022-11-28'
-                'User-Agent'           = 'winget-pkgs-updates'
-            }
-            if (-not [string]::IsNullOrWhiteSpace($tier.Token)) {
-                $headers.Authorization = "Bearer $($tier.Token)"
-            }
-            for ($attempt = 1; $attempt -le $maximumSearchAttempts; $attempt++) {
-                try {
-                    $searchUri = "https://api.github.com/search/issues?q=$encodedQuery&per_page=$pageSize&page=$page"
-                    $response = Invoke-WithGitHubRateLimitRetry `
-                        -OperationName "existing-PR search page $page" `
-                        -MaxAttempts 4 `
-                        -MaxTotalWaitSeconds 120 `
-                        -ScriptBlock {
-                            Invoke-RestMethod `
-                                -Method Get `
-                                -Uri $searchUri `
-                                -Headers $headers `
-                                -ErrorAction Stop
-                        }
-                    break
-                }
-                catch {
-                    $statusCode = Get-WingetPkgsUpstreamReadFailureStatusCode -ErrorRecord $_
-                    $responseBody = Get-WingetPkgsGitHubApiFailureResponseBody -ErrorRecord $_
-                    $responseDetail = if ([string]::IsNullOrWhiteSpace($responseBody)) {
-                        ''
-                    }
-                    else {
-                        " Response body: $responseBody"
-                    }
-
-                    if ($statusCode -eq 422 -and $attempt -lt $maximumSearchAttempts) {
-                        Write-Warning "GitHub existing-PR search page $page returned HTTP 422 on attempt $attempt of $maximumSearchAttempts; retrying.$responseDetail"
-                        Start-Sleep -Seconds $attempt
-                        continue
-                    }
-
-                    $isLastTier = $tierIndex -eq ($credentialTiers.Count - 1)
-                    if ($isLastTier -or -not (Test-WingetPkgsUpstreamReadFailoverStatus -StatusCode $statusCode)) {
-                        if (-not [string]::IsNullOrWhiteSpace($responseDetail)) {
-                            Write-Warning "GitHub existing-PR search page $page failed with HTTP $statusCode.$responseDetail"
-                        }
-                        throw
-                    }
-                    $nextTier = $credentialTiers[$tierIndex + 1]
-                    Write-Warning "Existing-PR search page $page with $($tier.Label) failed with HTTP $statusCode; retrying with $($nextTier.Label).$responseDetail"
-                    break
-                }
-            }
-            if ($null -ne $response) {
-                break
-            }
-        }
-        if ($null -eq $response) {
-            throw 'GitHub existing-PR search returned no response.'
-        }
+        $searchUri = "https://api.github.com/search/issues?q=$encodedQuery&per_page=$pageSize&page=$page$AdditionalQueryParameters"
+        $response = Invoke-WingetPkgsUpstreamReadRequest -Uri $searchUri -OperationName "$OperationName page $page"
 
         $itemsProperty = $response.PSObject.Properties['items']
         $totalCountProperty = $response.PSObject.Properties['total_count']
         if ($null -eq $itemsProperty -or $null -eq $totalCountProperty -or $null -eq $itemsProperty.Value) {
-            throw 'GitHub existing-PR search returned an incomplete response.'
+            throw "GitHub $OperationName returned an incomplete response."
         }
 
         $incompleteResultsProperty = $response.PSObject.Properties['incomplete_results']
         if ($null -ne $incompleteResultsProperty) {
             $incompleteResults = $false
             if (-not [bool]::TryParse("$($incompleteResultsProperty.Value)", [ref] $incompleteResults)) {
-                throw 'GitHub existing-PR search returned an invalid incomplete_results value.'
+                throw "GitHub $OperationName returned an invalid incomplete_results value."
             }
             if ($incompleteResults) {
-                throw 'GitHub existing-PR search reported incomplete_results=true; refusing to make a duplicate decision.'
+                throw "GitHub $OperationName reported incomplete_results=true; refusing to make a duplicate decision."
             }
         }
 
         $responseTotalCount = 0
         if (-not [int]::TryParse("$($totalCountProperty.Value)", [ref] $responseTotalCount) -or $responseTotalCount -lt 0) {
-            throw 'GitHub existing-PR search returned an invalid total_count.'
+            throw "GitHub $OperationName returned an invalid total_count."
         }
         if ($responseTotalCount -gt $maximumSearchResults) {
-            throw "GitHub existing-PR search returned $responseTotalCount candidate(s), exceeding the $maximumSearchResults-result API limit; refusing to make an incomplete duplicate decision."
+            throw "GitHub $OperationName returned $responseTotalCount candidate(s), exceeding the $maximumSearchResults-result API limit; refusing to make an incomplete duplicate decision."
         }
         if ($null -eq $totalCount) {
             $totalCount = $responseTotalCount
         }
         elseif ($totalCount -ne $responseTotalCount) {
-            throw 'GitHub existing-PR search changed total_count while paging; refusing to make a duplicate decision.'
+            throw "GitHub $OperationName changed total_count while paging; refusing to make a duplicate decision."
         }
 
         $existingPrs = @($itemsProperty.Value)
         if ($existingPrs.Count -gt $pageSize) {
-            throw "GitHub existing-PR search returned more than $pageSize candidates on one page."
+            throw "GitHub $OperationName returned more than $pageSize candidates on one page."
         }
 
         foreach ($existingPr in $existingPrs) {
             if ($null -eq $existingPr) {
-                throw 'GitHub existing-PR search returned an invalid candidate.'
+                throw "GitHub $OperationName returned an invalid candidate."
             }
 
-            $titleProperty = $existingPr.PSObject.Properties['title']
-            $stateProperty = $existingPr.PSObject.Properties['state']
-            if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
-                throw 'GitHub existing-PR search returned a candidate without a title or state.'
-            }
-
-            $state = "$($stateProperty.Value)".ToLowerInvariant()
-            if ($state -notin @('open', 'closed')) {
-                throw "GitHub existing-PR search returned an unrecognized PR state '$state'."
-            }
-
-            $pullRequestProperty = $existingPr.PSObject.Properties['pull_request']
-            $mergedAt = $null
-            if ($state -eq 'closed') {
-                if ($null -eq $pullRequestProperty -or $null -eq $pullRequestProperty.Value) {
-                    throw 'GitHub existing-PR search returned a closed PR without pull request metadata.'
-                }
-
-                $mergedAtProperty = $pullRequestProperty.Value.PSObject.Properties['merged_at']
-                if ($null -eq $mergedAtProperty) {
-                    throw 'GitHub existing-PR search returned a closed PR without merged_at metadata.'
-                }
-                $mergedAt = $mergedAtProperty.Value
-            }
-
-            if (-not (Test-WingetPkgsExistingPrTitle `
-                        -Title "$($titleProperty.Value)" `
-                        -PackageIdentifier $PackageIdentifier `
-                        -Version $Version)) {
-                continue
-            }
-
-            $isMatchingPr = $state -eq 'open' -or (-not $OnlyOpen -and -not [string]::IsNullOrWhiteSpace("$mergedAt"))
-            if ($isMatchingPr) {
-                Write-Host "Found existing PR: $($titleProperty.Value)"
-                Write-Host "-> $($existingPr.html_url)"
-                return $true
+            if (& $CandidateEvaluator $existingPr) {
+                return $existingPr
             }
         }
 
         $retrievedCount += $existingPrs.Count
         if ($retrievedCount -ge $totalCount) {
-            Write-Host "No matching PR found for $PackageIdentifier $Version in $Repository"
-            return $false
+            return $null
         }
         if ($existingPrs.Count -lt $pageSize) {
-            throw "GitHub existing-PR search returned $retrievedCount of $totalCount candidate(s); refusing to make an incomplete duplicate decision."
+            throw "GitHub $OperationName returned $retrievedCount of $totalCount candidate(s); refusing to make an incomplete duplicate decision."
         }
         $page++
     }
+}
+
+function Get-WingetPkgsManifestVersionPathPrefix {
+    <#
+    .SYNOPSIS
+        Builds the winget-pkgs manifest directory prefix for a package version.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $true)] [string] $Version
+    )
+
+    # winget-pkgs layout: manifests/<first letter lowercase>/<identifier with
+    # dots as directories>/<version>/, e.g.
+    # manifests/g/GodotLauncher/Launcher/1.11.1/.
+    $packagePath = $PackageIdentifier -replace '\.', '/'
+    $firstChar = $PackageIdentifier.Substring(0, 1).ToLowerInvariant()
+    return "manifests/$firstChar/$packagePath/$Version/"
+}
+
+function Test-WingetPkgsTitleNamesOtherPackage {
+    <#
+    .SYNOPSIS
+        Tests whether a PR title clearly names a different package identifier.
+
+    .DESCRIPTION
+        Used to skip pull request file reads for manifest-path candidates that
+        obviously belong to another package (bot and tool titles always spell
+        out the package identifier). A dotted token counts as another package
+        identifier only when at least two of its segments contain letters and
+        it neither contains the requested identifier nor equals the requested
+        version, so version-like tokens ('1.2.3', 'v1.2.3') never suppress a
+        candidate.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Title,
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $true)] [string] $Version
+    )
+
+    $dottedTokens = @([regex]::Matches($Title, '(?<![A-Za-z0-9._+-])[A-Za-z0-9_+-]+(?:\.[A-Za-z0-9_+-]+)+(?![A-Za-z0-9._+-])') | ForEach-Object { $_.Value })
+    foreach ($token in $dottedTokens) {
+        $letteredSegments = @($token.Split('.') | Where-Object { $_ -match '[A-Za-z]' })
+        if ($letteredSegments.Count -lt 2) {
+            continue
+        }
+        if ($token -ieq $Version -or $token -ieq "v$Version") {
+            continue
+        }
+        if ($token.IndexOf($PackageIdentifier, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            continue
+        }
+        return $true
+    }
+
+    return $false
+}
+
+function Find-WingetPkgsOpenPrForManifestPath {
+    <#
+    .SYNOPSIS
+        Finds an open PR whose changed files touch the package's manifest path.
+
+    .DESCRIPTION
+        Searches open pull requests that mention the version in their title
+        (human titles reliably carry the version even when they omit the
+        package identifier) and verifies each candidate's changed files
+        against the package's manifest version directory via the pull request
+        files API. Returns the first matching candidate or $null.
+    #>
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Repository,
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $true)] [string] $Version
+    )
+
+    $manifestPathPrefix = Get-WingetPkgsManifestVersionPathPrefix -PackageIdentifier $PackageIdentifier -Version $Version
+    $escapedVersion = $Version.Replace('"', '\"')
+    $searchQuery = "repo:$Repository is:pr is:open in:title `"$escapedVersion`""
+    $candidates = [System.Collections.Generic.List[object]]::new()
+
+    $candidateCollector = {
+        param($existingPr)
+
+        $titleProperty = $existingPr.PSObject.Properties['title']
+        $stateProperty = $existingPr.PSObject.Properties['state']
+        if ($null -eq $titleProperty -or $null -eq $stateProperty -or [string]::IsNullOrWhiteSpace("$($titleProperty.Value)")) {
+            throw 'GitHub existing-PR manifest-path search returned a candidate without a title or state.'
+        }
+        if ("$($stateProperty.Value)".ToLowerInvariant() -ne 'open') {
+            return $false
+        }
+
+        $numberProperty = $existingPr.PSObject.Properties['number']
+        $pullRequestNumber = 0
+        if ($null -eq $numberProperty -or -not [int]::TryParse("$($numberProperty.Value)", [ref] $pullRequestNumber) -or $pullRequestNumber -le 0) {
+            throw 'GitHub existing-PR manifest-path search returned a candidate without a pull request number.'
+        }
+
+        if (Test-WingetPkgsTitleNamesOtherPackage `
+                -Title "$($titleProperty.Value)" `
+                -PackageIdentifier $PackageIdentifier `
+                -Version $Version) {
+            return $false
+        }
+
+        $urlProperty = $existingPr.PSObject.Properties['html_url']
+        $candidates.Add([pscustomobject]@{
+            Number = $pullRequestNumber
+            Title  = "$($titleProperty.Value)"
+            Url    = if ($null -ne $urlProperty) { "$($urlProperty.Value)" } else { '' }
+        })
+        return $false
+    }
+
+    $null = Find-WingetPkgsExistingPrSearchMatch `
+        -Query $searchQuery `
+        -CandidateEvaluator $candidateCollector `
+        -OperationName 'existing-PR manifest-path search' `
+        -AdditionalQueryParameters '&sort=created&order=desc'
+
+    if ($candidates.Count -eq 0) {
+        return $null
+    }
+
+    $maximumCandidateFileReads = 25
+    $candidatesToCheck = @($candidates)
+    if ($candidatesToCheck.Count -gt $maximumCandidateFileReads) {
+        Write-Warning "The manifest-path duplicate check found $($candidatesToCheck.Count) open PR(s) mentioning version $Version; only the $maximumCandidateFileReads most recently created are compared against $manifestPathPrefix."
+        $candidatesToCheck = @($candidatesToCheck[0..($maximumCandidateFileReads - 1)])
+    }
+
+    foreach ($candidate in $candidatesToCheck) {
+        if (Test-WingetPkgsPullRequestTouchesPath -Repository $Repository -PullRequestNumber $candidate.Number -PathPrefix $manifestPathPrefix) {
+            return [pscustomobject]@{
+                Number             = $candidate.Number
+                Title              = $candidate.Title
+                Url                = $candidate.Url
+                ManifestPathPrefix = $manifestPathPrefix
+            }
+        }
+    }
+
+    return $null
+}
+
+function Test-WingetPkgsPullRequestTouchesPath {
+    <#
+    .SYNOPSIS
+        Tests whether a pull request changes any file under a path prefix.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Repository,
+        [Parameter(Mandatory = $true)] [int] $PullRequestNumber,
+        [Parameter(Mandatory = $true)] [string] $PathPrefix
+    )
+
+    $pageSize = 100
+    $maximumFilePages = 10
+    for ($page = 1; $page -le $maximumFilePages; $page++) {
+        $filesUri = "https://api.github.com/repos/$Repository/pulls/$PullRequestNumber/files?per_page=$pageSize&page=$page"
+        $response = Invoke-WingetPkgsUpstreamReadRequest -Uri $filesUri -OperationName "existing-PR files read for #$PullRequestNumber page $page"
+        $files = if ($null -eq $response) { @() } else { @($response) }
+        foreach ($file in $files) {
+            if ($null -eq $file) {
+                continue
+            }
+            $filenameProperty = $file.PSObject.Properties['filename']
+            if ($null -eq $filenameProperty -or [string]::IsNullOrWhiteSpace("$($filenameProperty.Value)")) {
+                throw "GitHub existing-PR files read for #$PullRequestNumber returned an entry without a filename."
+            }
+            if ("$($filenameProperty.Value)".StartsWith($PathPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $true
+            }
+        }
+        if ($files.Count -lt $pageSize) {
+            return $false
+        }
+    }
+
+    Write-Warning "Pull request #$PullRequestNumber in $Repository changes more than $($maximumFilePages * $pageSize) files; stopping the manifest-path comparison for it."
+    return $false
 }

--- a/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-MonitoredPackageAssets.ps1
@@ -21,8 +21,10 @@ function Test-MonitoredPackageAssets {
             usable name.
           - AssetMissing: at least one URL template matches no asset on the
             resolved release (details list the missing URLs).
-          - Inconclusive: the release carries more than 100 assets, so a missed
-            match cannot be distinguished from truncation.
+          - Inconclusive: the release carries more than 100 assets and the
+            remaining asset pages could not be retrieved, so a missed match
+            cannot be distinguished from truncation. Releases with more than
+            100 assets are otherwise fully paginated before matching.
           - Skipped: the entry has no repo/url pair to check.
 
     .OUTPUTS
@@ -83,6 +85,10 @@ function Test-MonitoredPackageAssets {
     $results = [System.Collections.Generic.List[object]]::new()
     $simple = [System.Collections.Generic.List[object]]::new()
     $withTagPattern = [System.Collections.Generic.List[object]]::new()
+    # Releases are shared across packages (e.g. every Electron major); memoize
+    # paginated asset lists per repo+tag so each truncated release is expanded
+    # at most once per sweep.
+    $assetPageCache = @{}
 
     foreach ($package in $Packages) {
         $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
@@ -112,7 +118,7 @@ function Test-MonitoredPackageAssets {
         }
     }
 
-    $releaseSelection = 'tagName name releaseAssets(first: 100) { totalCount nodes { downloadUrl } }'
+    $releaseSelection = 'tagName name releaseAssets(first: 100) { totalCount pageInfo { hasNextPage endCursor } nodes { downloadUrl } }'
 
     # Pass 1: packages that follow the repository's latest stable release.
     $simpleArray = @($simple)
@@ -129,7 +135,7 @@ function Test-MonitoredPackageAssets {
         for ($i = 0; $i -lt $slice.Count; $i++) {
             $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "a$i"
             $release = Get-WingetGraphQlFieldValue -InputObject $repository -Name 'latestRelease'
-            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $slice[$i] -Repository $repository -Release $release))
+            $results.Add((Resolve-WingetMonitoredAssetStatus -Package $slice[$i] -Repository $repository -Release $release -GraphQlInvoker $GraphQlInvoker -AssetPageCache $assetPageCache))
         }
     }
 
@@ -185,7 +191,7 @@ function Test-MonitoredPackageAssets {
                 Sort-Object -Property @{ Expression = { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'publishedAt')" } } -Descending)
         $release = if ($matching.Count -gt 0) { $matching[0] } else { $null }
 
-        $results.Add((Resolve-WingetMonitoredAssetStatus -Package $package -Repository ([PSCustomObject]@{ present = $true }) -Release $release -NoReleaseStatus 'NoMatchingRelease'))
+        $results.Add((Resolve-WingetMonitoredAssetStatus -Package $package -Repository ([PSCustomObject]@{ present = $true }) -Release $release -NoReleaseStatus 'NoMatchingRelease' -GraphQlInvoker $GraphQlInvoker -AssetPageCache $assetPageCache))
     }
 
     return @($results | Sort-Object -Property PackageId)
@@ -201,7 +207,9 @@ function Resolve-WingetMonitoredAssetStatus {
         [Parameter(Mandatory = $true)] $Package,
         [Parameter()] $Repository,
         [Parameter()] $Release,
-        [Parameter()] [string] $NoReleaseStatus = 'NoRelease'
+        [Parameter()] [string] $NoReleaseStatus = 'NoRelease',
+        [Parameter()] [scriptblock] $GraphQlInvoker,
+        [Parameter()] [hashtable] $AssetPageCache
     )
 
     $packageId = Get-WingetPrecheckPackageField -Package $Package -Name 'id'
@@ -249,6 +257,23 @@ function Resolve-WingetMonitoredAssetStatus {
     $assetUrls = @($assetNodes | ForEach-Object { [string](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'downloadUrl') })
     $totalCountValue = Get-WingetGraphQlFieldValue -InputObject $assetsObject -Name 'totalCount'
     $assetsTruncated = $null -ne $totalCountValue -and [int]$totalCountValue -gt $assetUrls.Count
+    $assetPaginationDetail = $null
+
+    # Releases with more than 100 assets (e.g. binbat.*, Winix.*) would
+    # otherwise be permanently Inconclusive; page through the remaining
+    # assets so every asset is examined before classifying a miss.
+    if ($assetsTruncated -and $null -ne $GraphQlInvoker) {
+        $expansion = Expand-WingetMonitoredReleaseAssetUrls `
+            -Repo $repo `
+            -Tag $tag `
+            -AssetsObject $assetsObject `
+            -InitialUrls $assetUrls `
+            -GraphQlInvoker $GraphQlInvoker `
+            -AssetPageCache $AssetPageCache
+        $assetUrls = @($expansion.Urls)
+        $assetsTruncated = -not $expansion.Complete
+        $assetPaginationDetail = $expansion.Detail
+    }
 
     $installerValues = @($url -split '\s+' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     $assetTemplates = [System.Collections.Generic.List[string]]::new()
@@ -300,7 +325,8 @@ function Resolve-WingetMonitoredAssetStatus {
 
     if ($missing.Count -gt 0) {
         if ($assetsTruncated) {
-            return & $newResult 'Inconclusive' "The release lists more than $($assetUrls.Count) assets; unmatched URL(s) may exist beyond the first page: $($missing -join ' ')" $tag
+            $paginationNote = if ([string]::IsNullOrWhiteSpace($assetPaginationDetail)) { '' } else { " ($assetPaginationDetail)" }
+            return & $newResult 'Inconclusive' "The release lists more than $($assetUrls.Count) assets and the remaining pages could not be retrieved$paginationNote; unmatched URL(s) may exist beyond the retrieved assets: $($missing -join ' ')" $tag
         }
         return & $newResult 'AssetMissing' "No release asset matches: $($missing -join ' ')" $tag
     }
@@ -312,4 +338,103 @@ function Resolve-WingetMonitoredAssetStatus {
         ''
     }
     return & $newResult 'OK' "All GitHub release-asset URL templates resolve against release ${tag}.$deferredNote" $tag
+}
+
+function Expand-WingetMonitoredReleaseAssetUrls {
+    <#
+    .SYNOPSIS
+        Pages through a release's remaining asset URLs beyond the first 100.
+
+    .DESCRIPTION
+        Follows the releaseAssets pageInfo cursor of an already-fetched release
+        until every asset URL is retrieved. Results are memoized per repo+tag
+        because multiple monitored packages often share one release. Failures
+        never throw: the caller keeps its truncation flag and reports
+        Inconclusive with the returned detail.
+
+    .OUTPUTS
+        PSCustomObject with Urls (string[]), Complete (bool), Detail (string).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] [string] $Repo,
+        [Parameter(Mandatory = $true)] [string] $Tag,
+        [Parameter(Mandatory = $true)] $AssetsObject,
+        [Parameter()] [AllowEmptyCollection()] [string[]] $InitialUrls = @(),
+        [Parameter(Mandatory = $true)] [scriptblock] $GraphQlInvoker,
+        [Parameter()] [hashtable] $AssetPageCache
+    )
+
+    $cacheKey = "$Repo|$Tag"
+    if ($null -ne $AssetPageCache -and $AssetPageCache.ContainsKey($cacheKey)) {
+        return $AssetPageCache[$cacheKey]
+    }
+
+    $urls = [System.Collections.Generic.List[string]]::new()
+    foreach ($url in $InitialUrls) { $urls.Add($url) }
+
+    $complete = $false
+    $detail = $null
+    $pageInfo = Get-WingetGraphQlFieldValue -InputObject $AssetsObject -Name 'pageInfo'
+    if ($null -eq $pageInfo) {
+        $detail = 'release asset pagination metadata unavailable'
+    }
+    else {
+        $owner, $name = $Repo.Split('/', 2)
+        $maximumAssetPages = 100
+        try {
+            for ($pageIndex = 0; $pageIndex -lt $maximumAssetPages; $pageIndex++) {
+                if (-not [bool](Get-WingetGraphQlFieldValue -InputObject $pageInfo -Name 'hasNextPage')) {
+                    $complete = $true
+                    break
+                }
+                $endCursor = [string](Get-WingetGraphQlFieldValue -InputObject $pageInfo -Name 'endCursor')
+                if ([string]::IsNullOrWhiteSpace($endCursor)) {
+                    $detail = 'release asset pagination returned no endCursor'
+                    break
+                }
+
+                $query = "query { repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { release(tagName: $(ConvertTo-WingetGraphQlStringLiteral -Value $Tag)) { releaseAssets(first: 100, after: $(ConvertTo-WingetGraphQlStringLiteral -Value $endCursor)) { pageInfo { hasNextPage endCursor } nodes { downloadUrl } } } } }"
+                $response = & $GraphQlInvoker $query
+                $release = Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject (Get-WingetGraphQlFieldValue -InputObject $response -Name 'data') -Name 'repository') -Name 'release'
+                $pagedAssets = Get-WingetGraphQlFieldValue -InputObject $release -Name 'releaseAssets'
+                if ($null -eq $pagedAssets) {
+                    $detail = 'release asset pagination returned no releaseAssets payload'
+                    break
+                }
+
+                $pagedNodesValue = Get-WingetGraphQlFieldValue -InputObject $pagedAssets -Name 'nodes'
+                foreach ($node in @($pagedNodesValue)) {
+                    if ($null -eq $node) { continue }
+                    $urls.Add([string](Get-WingetGraphQlFieldValue -InputObject $node -Name 'downloadUrl'))
+                }
+
+                $pageInfo = Get-WingetGraphQlFieldValue -InputObject $pagedAssets -Name 'pageInfo'
+                if ($null -eq $pageInfo) {
+                    $detail = 'release asset pagination returned no pageInfo'
+                    break
+                }
+            }
+            if (-not $complete -and $null -eq $detail) {
+                $detail = "release asset pagination stopped after $maximumAssetPages pages"
+            }
+        }
+        catch {
+            $detail = "release asset pagination failed: $($_.Exception.Message)"
+        }
+    }
+
+    if (-not $complete) {
+        Write-Warning "Could not page through all release assets of $Repo@${Tag}: $detail"
+    }
+
+    $result = [PSCustomObject]@{
+        Urls     = @($urls)
+        Complete = $complete
+        Detail   = $detail
+    }
+    if ($null -ne $AssetPageCache) {
+        $AssetPageCache[$cacheKey] = $result
+    }
+    return $result
 }

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -169,21 +169,23 @@ Describe 'Test-ExistingPRs' {
         if ($result -ne $false) {
             throw 'The anonymous final tier unexpectedly reported a duplicate.'
         }
-        if ($global:ExistingPrSearchRequests.Count -ne 9) {
-            throw "Expected 4 primary retries, 4 fallback retries, and one anonymous attempt, got $($global:ExistingPrSearchRequests.Count) request(s)."
+        if ($global:ExistingPrSearchRequests.Count -ne 18) {
+            throw "Expected both search stages to run 4 primary retries, 4 fallback retries, and one anonymous attempt each, got $($global:ExistingPrSearchRequests.Count) request(s)."
         }
-        foreach ($index in 0..3) {
-            if ($global:ExistingPrSearchRequests[$index].Headers.Authorization -notlike '*primary-read-token') {
-                throw "Attempt $($index + 1) did not use the primary read token."
+        foreach ($stageOffset in @(0, 9)) {
+            foreach ($index in 0..3) {
+                if ($global:ExistingPrSearchRequests[$stageOffset + $index].Headers.Authorization -notlike '*primary-read-token') {
+                    throw "Attempt $($stageOffset + $index + 1) did not use the primary read token."
+                }
             }
-        }
-        foreach ($index in 4..7) {
-            if ($global:ExistingPrSearchRequests[$index].Headers.Authorization -notlike '*fallback-read-token') {
-                throw "Attempt $($index + 1) did not use the fallback read token."
+            foreach ($index in 4..7) {
+                if ($global:ExistingPrSearchRequests[$stageOffset + $index].Headers.Authorization -notlike '*fallback-read-token') {
+                    throw "Attempt $($stageOffset + $index + 1) did not use the fallback read token."
+                }
             }
-        }
-        if ($global:ExistingPrSearchRequests[8].Headers.ContainsKey('Authorization')) {
-            throw 'The final anonymous attempt sent a credential.'
+            if ($global:ExistingPrSearchRequests[$stageOffset + 8].Headers.ContainsKey('Authorization')) {
+                throw 'The final anonymous attempt sent a credential.'
+            }
         }
     }
 
@@ -259,8 +261,8 @@ Describe 'Test-ExistingPRs' {
         if ($result -ne $false) {
             throw 'The successful retry unexpectedly reported a duplicate.'
         }
-        if ($global:ExistingPrSearchRequests.Count -ne 3) {
-            throw "Expected three attempts after transient HTTP 422 responses, got $($global:ExistingPrSearchRequests.Count)."
+        if ($global:ExistingPrSearchRequests.Count -ne 4) {
+            throw "Expected three title-search attempts after transient HTTP 422 responses plus one manifest-path search, got $($global:ExistingPrSearchRequests.Count)."
         }
         if ($global:ExistingPrSearchSleeps.Count -ne 2 -or
             $global:ExistingPrSearchSleeps[0] -ne 1 -or
@@ -361,8 +363,8 @@ Describe 'Test-ExistingPRs' {
         if ($result -ne $false) {
             throw 'A closed-unmerged upstream PR was treated as a duplicate.'
         }
-        if ($global:ExistingPrSearchRequests.Count -ne 1) {
-            throw "Duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of one."
+        if ($global:ExistingPrSearchRequests.Count -ne 2) {
+            throw "Duplicate detection performed $($global:ExistingPrSearchRequests.Count) requests instead of two (title search plus manifest-path search)."
         }
     }
 
@@ -415,18 +417,28 @@ Describe 'Test-ExistingPRs' {
     It 'ignores substring and tokenized title search candidates' {
         InModuleScope WingetMaintainerModule {
             Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                if ($Uri -match '/pulls/\d+/files') {
+                    return @(
+                        [pscustomobject]@{ filename = 'manifests/t/Test/PackagePro/1.0.0/Test.PackagePro.installer.yaml' },
+                        [pscustomobject]@{ filename = 'manifests/t/Test/Package/1.0.0.1/Test.Package.installer.yaml' }
+                    )
+                }
                 return [pscustomobject]@{
                     total_count = 2
                     items = @(
                         [pscustomobject]@{
                             title        = 'Update version: Test.PackagePro version 1.0.0'
                             state        = 'open'
+                            number       = 103
                             html_url     = 'https://github.com/microsoft/winget-pkgs/pull/103'
                             pull_request = [pscustomobject]@{ merged_at = $null }
                         },
                         [pscustomobject]@{
                             title        = 'Update version: Test.Package version 1.0.0.1'
                             state        = 'open'
+                            number       = 104
                             html_url     = 'https://github.com/microsoft/winget-pkgs/pull/104'
                             pull_request = [pscustomobject]@{ merged_at = $null }
                         }
@@ -559,13 +571,15 @@ Describe 'Test-ExistingPRs' {
         if ($result -ne $false) {
             throw 'An empty upstream PR search unexpectedly found a match.'
         }
-        if ($global:ExistingPrSearchRequests.Count -ne 1) {
-            throw "OnlyOpen performed $($global:ExistingPrSearchRequests.Count) search requests instead of one."
+        if ($global:ExistingPrSearchRequests.Count -ne 2) {
+            throw "OnlyOpen performed $($global:ExistingPrSearchRequests.Count) search requests instead of two (title search plus manifest-path search)."
         }
 
-        $query = [uri]::UnescapeDataString(([uri] $global:ExistingPrSearchRequests[0].Uri).Query)
-        if ($query -notmatch 'is:open' -or $query -match 'is:merged') {
-            throw "OnlyOpen used an unexpected query: $query"
+        foreach ($request in $global:ExistingPrSearchRequests) {
+            $query = [uri]::UnescapeDataString(([uri] $request.Uri).Query)
+            if ($query -notmatch 'is:open' -or $query -match 'is:merged') {
+                throw "OnlyOpen used an unexpected query: $query"
+            }
         }
     }
 
@@ -619,6 +633,184 @@ Describe 'Test-ExistingPRs' {
 
         if ($global:ExistingPrSearchRequests.Count -ne 1) {
             throw 'A malformed primary response was converted into a fallback no-duplicate decision.'
+        }
+    }
+
+    It 'detects an open PR by manifest path when the title omits the package identifier' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                if ($Uri -match '/pulls/555/files') {
+                    return @(
+                        [pscustomobject]@{ filename = 'manifests/t/Test/Package/1.0.0/Test.Package.installer.yaml' }
+                    )
+                }
+                if ($Uri -match 'Test\.Package') {
+                    # Title search: the human PR title omits the package identifier.
+                    return [pscustomobject]@{ total_count = 0; items = @() }
+                }
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Submitting Test Package 1.0.0'
+                            state        = 'open'
+                            number       = 555
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/555'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $true) {
+            throw 'An open PR touching the manifest path was not detected.'
+        }
+
+        $fileRequests = @($global:ExistingPrSearchRequests | Where-Object { $_.Uri -match '/pulls/555/files' })
+        if ($fileRequests.Count -ne 1) {
+            throw "Expected exactly one PR files read, got $($fileRequests.Count)."
+        }
+        $versionSearches = @($global:ExistingPrSearchRequests | Where-Object {
+            $_.Uri -match 'search/issues' -and $_.Uri -notmatch 'Test\.Package'
+        })
+        if ($versionSearches.Count -ne 1) {
+            throw "Expected exactly one manifest-path candidate search, got $($versionSearches.Count)."
+        }
+        $query = [uri]::UnescapeDataString(([uri] $versionSearches[0].Uri).Query)
+        if ($query -notmatch 'is:open' -or $query -notmatch 'in:title "1\.0\.0"') {
+            throw "The manifest-path candidate search used an unexpected query: $query"
+        }
+    }
+
+    It 'does not treat a manifest-path candidate for a different version directory as a duplicate' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                if ($Uri -match '/pulls/556/files') {
+                    return @(
+                        [pscustomobject]@{ filename = 'manifests/t/Test/Package/1.0.0.1/Test.Package.installer.yaml' }
+                    )
+                }
+                if ($Uri -match 'Test\.Package') {
+                    return [pscustomobject]@{ total_count = 0; items = @() }
+                }
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'Submitting Test Package 1.0.0'
+                            state        = 'open'
+                            number       = 556
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/556'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $false) {
+            throw 'A PR touching a different version directory was treated as a duplicate.'
+        }
+    }
+
+    It 'skips manifest-path file reads for candidates that name another package' {
+        InModuleScope WingetMaintainerModule {
+            Mock Invoke-RestMethod {
+                param($Method, $Uri, $Headers, $ErrorAction)
+
+                $global:ExistingPrSearchRequests.Add([pscustomobject]@{
+                    Method  = $Method
+                    Uri     = $Uri
+                    Headers = $Headers
+                })
+                if ($Uri -match '/pulls/') {
+                    throw 'The manifest-path check must not read files of PRs that name another package.'
+                }
+                if ($Uri -match 'Test\.Package') {
+                    return [pscustomobject]@{ total_count = 0; items = @() }
+                }
+                return [pscustomobject]@{
+                    total_count = 1
+                    items = @(
+                        [pscustomobject]@{
+                            title        = 'New version: Other.Package version 1.0.0'
+                            state        = 'open'
+                            number       = 700
+                            html_url     = 'https://github.com/microsoft/winget-pkgs/pull/700'
+                            pull_request = [pscustomobject]@{ merged_at = $null }
+                        }
+                    )
+                }
+            }
+        }
+
+        $result = Test-ExistingPRs `
+            -PackageIdentifier 'Test.Package' `
+            -Version '1.0.0' `
+            -Repository 'microsoft/winget-pkgs'
+
+        if ($result -ne $false) {
+            throw 'A candidate naming another package changed the duplicate decision.'
+        }
+        if (@($global:ExistingPrSearchRequests | Where-Object { $_.Uri -match '/pulls/' }).Count -ne 0) {
+            throw 'A candidate naming another package triggered a PR files read.'
+        }
+    }
+
+    It 'builds manifest path prefixes and classifies other-package titles correctly' {
+        $helperResults = InModuleScope WingetMaintainerModule {
+            [pscustomobject]@{
+                SimplePrefix   = Get-WingetPkgsManifestVersionPathPrefix -PackageIdentifier 'GodotLauncher.Launcher' -Version '1.11.1'
+                MultiDotPrefix = Get-WingetPkgsManifestVersionPathPrefix -PackageIdentifier 'A.B.C' -Version '2.0'
+                OtherPackage   = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'New version: heymaikol.NetworkDoctor 1.11.1' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                OwnPackage     = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Update GodotLauncher.Launcher to 1.11.1' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                VersionToken   = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Submitting Godot Launcher v1.11.1' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+            }
+        }
+
+        if ($helperResults.SimplePrefix -cne 'manifests/g/GodotLauncher/Launcher/1.11.1/') {
+            throw "Unexpected manifest path prefix: $($helperResults.SimplePrefix)"
+        }
+        if ($helperResults.MultiDotPrefix -cne 'manifests/a/A/B/C/2.0/') {
+            throw "Unexpected multi-dot manifest path prefix: $($helperResults.MultiDotPrefix)"
+        }
+        if (-not $helperResults.OtherPackage) {
+            throw 'A title naming another package identifier was not classified as such.'
+        }
+        if ($helperResults.OwnPackage) {
+            throw 'A title naming the requested package identifier was misclassified as another package.'
+        }
+        if ($helperResults.VersionToken) {
+            throw 'A version-like dotted token was misclassified as another package identifier.'
         }
     }
 }

--- a/tests/TestGeneratedInstallerArchitecture.Tests.ps1
+++ b/tests/TestGeneratedInstallerArchitecture.Tests.ps1
@@ -1,0 +1,222 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$module = Import-Module (Join-Path $repositoryRoot 'modules/WingetMaintainerModule/WingetMaintainerModule.psd1') -Force -PassThru
+
+function New-GeneratedInstallerManifest {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Root,
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $true)] [string] $Version,
+        [Parameter(Mandatory = $true)] [object[]] $Entries
+    )
+
+    $firstChar = $PackageIdentifier.Substring(0, 1).ToLowerInvariant()
+    $packagePath = $PackageIdentifier -replace '\.', '/'
+    $directory = Join-Path $Root "manifests/$firstChar/$packagePath/$Version"
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+
+    $lines = @(
+        "PackageIdentifier: $PackageIdentifier"
+        "PackageVersion: $Version"
+        'Installers:'
+    )
+    foreach ($entry in $Entries) {
+        $lines += "- Architecture: $($entry.Architecture)"
+        $lines += "  InstallerUrl: $($entry.InstallerUrl)"
+    }
+    $lines += 'ManifestType: installer'
+    Set-Content -Path (Join-Path $directory "$PackageIdentifier.installer.yaml") -Value ($lines -join "`n")
+}
+
+function New-PreviousInstallerManifestContent {
+    param(
+        [Parameter(Mandatory = $true)] [object[]] $Entries
+    )
+
+    $lines = @('Installers:')
+    foreach ($entry in $Entries) {
+        $lines += "- Architecture: $($entry.Architecture)"
+        $lines += "  InstallerUrl: $($entry.InstallerUrl)"
+    }
+    $lines += 'ManifestType: installer'
+    return ($lines -join "`n")
+}
+
+function Invoke-ArchitectureValidation {
+    param(
+        [Parameter(Mandatory = $true)] [string] $ManifestOutPath,
+        [Parameter(Mandatory = $true)] [string] $PackageIdentifier,
+        [Parameter(Mandatory = $true)] [string] $CurrentVersion,
+        [Parameter(Mandatory = $true)] [string[]] $RequestedInstallerValues,
+        [Parameter()] [string] $PreviousVersion = '',
+        [Parameter()] [string] $PreviousManifestContent = ''
+    )
+
+    return & $module {
+        param($OutPath, $Id, $Current, $Requested, $Previous, $PreviousContent)
+
+        $script:StubPreviousManifestContent = $PreviousContent
+        function Invoke-WebRequest {
+            param($Uri, [switch]$UseBasicParsing)
+
+            if ([string]::IsNullOrWhiteSpace($script:StubPreviousManifestContent)) {
+                throw 'The previous manifest fetch must not run for this test.'
+            }
+            return [pscustomobject]@{ Content = $script:StubPreviousManifestContent }
+        }
+
+        try {
+            if ([string]::IsNullOrWhiteSpace($Previous)) {
+                Test-GeneratedInstallerArchitecture `
+                    -PackageIdentifier $Id `
+                    -CurrentVersion $Current `
+                    -ManifestOutPath $OutPath `
+                    -RequestedInstallerValues $Requested | Out-Null
+            }
+            else {
+                Test-GeneratedInstallerArchitecture `
+                    -PackageIdentifier $Id `
+                    -CurrentVersion $Current `
+                    -ManifestOutPath $OutPath `
+                    -RequestedInstallerValues $Requested `
+                    -PreviousVersion $Previous | Out-Null
+            }
+            [pscustomobject]@{ Threw = $false; Message = $null }
+        }
+        catch {
+            [pscustomobject]@{ Threw = $true; Message = "$($_.Exception.Message)" }
+        }
+    } $ManifestOutPath $PackageIdentifier $CurrentVersion $RequestedInstallerValues $PreviousVersion $PreviousManifestContent
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "winget-arch-tests-$([Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+
+try {
+    Write-Host 'TEST: a generated architecture superset of the previous manifest passes (dual-arch winmatsch output)'
+    # Verified case Mibuw.miPDFsignCommunity: the published manifest lists the
+    # setup exe under x86 only while the generator correctly emits the same
+    # URL under x86 and x64.
+    $root = Join-Path $testRoot 'superset'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Mibuw.miPDFsignCommunity' -Version '1.0.1' -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.0.1/setup.exe' },
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/1.0.1/setup.exe' }
+    )
+    $previousContent = New-PreviousInstallerManifestContent -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.0.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Mibuw.miPDFsignCommunity' `
+        -CurrentVersion '1.0.1' `
+        -RequestedInstallerValues @('https://example.com/download/1.0.1/setup.exe') `
+        -PreviousVersion '1.0.0' `
+        -PreviousManifestContent $previousContent
+    if ($outcome.Threw) {
+        throw "A dual-arch superset was rejected as drift: $($outcome.Message)"
+    }
+
+    Write-Host 'TEST: a previously published architecture that disappears still throws'
+    $root = Join-Path $testRoot 'replaced'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Test.Package' -Version '2.0.0' -Entries @(
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' }
+    )
+    $previousContent = New-PreviousInstallerManifestContent -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Test.Package' `
+        -CurrentVersion '2.0.0' `
+        -RequestedInstallerValues @('https://example.com/download/2.0.0/setup.exe') `
+        -PreviousVersion '1.9.0' `
+        -PreviousManifestContent $previousContent
+    if (-not $outcome.Threw) {
+        throw 'A replaced architecture (x86 -> x64) was not flagged as drift.'
+    }
+    if ($outcome.Message -notmatch 'Generated architecture drift detected' -or $outcome.Message -notmatch 'x86') {
+        throw "The drift error did not name the missing architecture: $($outcome.Message)"
+    }
+
+    Write-Host 'TEST: dropping one of several previously published architectures throws'
+    $root = Join-Path $testRoot 'narrowed'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Test.Package' -Version '2.0.0' -Entries @(
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' }
+    )
+    $previousContent = New-PreviousInstallerManifestContent -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' },
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Test.Package' `
+        -CurrentVersion '2.0.0' `
+        -RequestedInstallerValues @('https://example.com/download/2.0.0/setup.exe') `
+        -PreviousVersion '1.9.0' `
+        -PreviousManifestContent $previousContent
+    if (-not $outcome.Threw -or $outcome.Message -notmatch 'x86') {
+        throw "Narrowing x86+x64 to x64 was not flagged as drift: $($outcome | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'TEST: matching multi-architecture sets with an extra architecture pass'
+    $root = Join-Path $testRoot 'extended'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Test.Package' -Version '2.0.0' -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' },
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' },
+        [pscustomobject]@{ Architecture = 'arm64'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' }
+    )
+    $previousContent = New-PreviousInstallerManifestContent -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' },
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Test.Package' `
+        -CurrentVersion '2.0.0' `
+        -RequestedInstallerValues @('https://example.com/download/2.0.0/setup.exe') `
+        -PreviousVersion '1.9.0' `
+        -PreviousManifestContent $previousContent
+    if ($outcome.Threw) {
+        throw "A preserved multi-architecture set with an addition was rejected: $($outcome.Message)"
+    }
+
+    Write-Host 'TEST: URLs absent from the previous manifest are not compared'
+    $root = Join-Path $testRoot 'changed-url'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Test.Package' -Version '2.0.0' -Entries @(
+        [pscustomobject]@{ Architecture = 'x64'; InstallerUrl = 'https://example.com/download/2.0.0/renamed.exe' }
+    )
+    $previousContent = New-PreviousInstallerManifestContent -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/1.9.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Test.Package' `
+        -CurrentVersion '2.0.0' `
+        -RequestedInstallerValues @('https://example.com/download/2.0.0/renamed.exe') `
+        -PreviousVersion '1.9.0' `
+        -PreviousManifestContent $previousContent
+    if ($outcome.Threw) {
+        throw "A renamed installer URL was compared against unrelated previous entries: $($outcome.Message)"
+    }
+
+    Write-Host 'TEST: explicit architecture hints still fail on a mismatch'
+    $root = Join-Path $testRoot 'hinted'
+    New-GeneratedInstallerManifest -Root $root -PackageIdentifier 'Test.Package' -Version '2.0.0' -Entries @(
+        [pscustomobject]@{ Architecture = 'x86'; InstallerUrl = 'https://example.com/download/2.0.0/setup.exe' }
+    )
+    $outcome = Invoke-ArchitectureValidation `
+        -ManifestOutPath $root `
+        -PackageIdentifier 'Test.Package' `
+        -CurrentVersion '2.0.0' `
+        -RequestedInstallerValues @('https://example.com/download/2.0.0/setup.exe|x64')
+    if (-not $outcome.Threw -or $outcome.Message -notmatch 'Generated architecture mismatch') {
+        throw "A hinted architecture mismatch was not flagged: $($outcome | ConvertTo-Json -Compress)"
+    }
+
+    Write-Host 'All Test-GeneratedInstallerArchitecture tests passed.'
+}
+finally {
+    Remove-Item -Path $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/TestMonitoredPackageAssets.Tests.ps1
+++ b/tests/TestMonitoredPackageAssets.Tests.ps1
@@ -192,9 +192,79 @@ Write-Host 'TEST: truncated asset lists downgrade a miss to Inconclusive'
 $invoker = New-FakeGraphQlInvoker -RepositoriesByAlias @{
     'a0' = [PSCustomObject]@{ latestRelease = (New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/other.msi') -TotalCount 150) }
 }
-$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $invoker)
+$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $invoker 3>$null)
 if ($results[0].Status -ne 'Inconclusive') {
     throw "Expected Inconclusive on truncated assets, got: $($results[0] | ConvertTo-Json -Compress)"
+}
+
+Write-Host 'TEST: asset lists beyond 100 entries are paginated before matching'
+$script:AssetPageQueries = 0
+$pagedRelease = New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/other.msi') -TotalCount 150
+$pagedRelease.releaseAssets | Add-Member -NotePropertyName pageInfo -NotePropertyValue ([PSCustomObject]@{ hasNextPage = $true; endCursor = 'cursor-1' })
+$pagedInvoker = {
+    param([string] $Query)
+
+    if ($Query -match 'after:') {
+        $script:AssetPageQueries++
+        if ($Query -notmatch '"cursor-1"') {
+            throw "The asset pagination query did not reuse the first page's endCursor: $Query"
+        }
+        return [PSCustomObject]@{
+            data = [PSCustomObject]@{
+                repository = [PSCustomObject]@{
+                    release = [PSCustomObject]@{
+                        releaseAssets = [PSCustomObject]@{
+                            pageInfo = [PSCustomObject]@{ hasNextPage = $false; endCursor = $null }
+                            nodes    = @([PSCustomObject]@{ downloadUrl = 'https://github.com/owner/ok/releases/download/v1.2.3/app-1.2.3-x64.msi' })
+                        }
+                    }
+                }
+            }
+        }
+    }
+    $aliases = @([regex]::Matches($Query, '(?m)^\s*(?<Alias>[at]\d+):') | ForEach-Object { $_.Groups['Alias'].Value })
+    $data = [ordered]@{}
+    foreach ($alias in $aliases) {
+        $data[$alias] = [PSCustomObject]@{ latestRelease = $pagedRelease }
+    }
+    [PSCustomObject]@{ data = [PSCustomObject]$data }
+}
+$twoSharedRepoPackages = @(
+    [PSCustomObject]@{
+        id   = 'Test.Ok'
+        repo = 'owner/ok'
+        url  = 'https://github.com/owner/ok/releases/download/v{VERSION}/app-{VERSION}-x64.msi|x64'
+    },
+    [PSCustomObject]@{
+        id   = 'Test.OkTwin'
+        repo = 'owner/ok'
+        url  = 'https://github.com/owner/ok/releases/download/v{VERSION}/app-{VERSION}-x64.msi|x64'
+    }
+)
+$results = @(Test-MonitoredPackageAssets -Packages $twoSharedRepoPackages -GraphQlInvoker $pagedInvoker)
+foreach ($result in $results) {
+    if ($result.Status -ne 'OK') {
+        throw "Expected the paginated asset match to report OK, got: $($result | ConvertTo-Json -Compress)"
+    }
+}
+if ($script:AssetPageQueries -ne 1) {
+    throw "Expected one memoized asset pagination query for the shared release, got $script:AssetPageQueries."
+}
+
+Write-Host 'TEST: failed asset pagination keeps a miss Inconclusive'
+$brokenRelease = New-Release -Tag 'v1.2.3' -AssetUrls @('https://github.com/owner/ok/releases/download/v1.2.3/other.msi') -TotalCount 150
+$brokenRelease.releaseAssets | Add-Member -NotePropertyName pageInfo -NotePropertyValue ([PSCustomObject]@{ hasNextPage = $true; endCursor = 'cursor-1' })
+$brokenInvoker = {
+    param([string] $Query)
+
+    if ($Query -match 'after:') {
+        return [PSCustomObject]@{ data = $null }
+    }
+    return [PSCustomObject]@{ data = [PSCustomObject]@{ a0 = [PSCustomObject]@{ latestRelease = $brokenRelease } } }
+}
+$results = @(Test-MonitoredPackageAssets -Packages $packages -GraphQlInvoker $brokenInvoker 3>$null)
+if ($results[0].Status -ne 'Inconclusive') {
+    throw "Expected Inconclusive when asset pagination fails, got: $($results[0] | ConvertTo-Json -Compress)"
 }
 
 Write-Host 'TEST: entries without repo/url are skipped'


### PR DESCRIPTION
Implements backlog items P5.1, P5.2 and P5.3 from the 2026-08-19 audit. Three independent hardening fixes; `Update-WingetPackage.ps1` is untouched (P5.4 is owned by a sibling session).

## P5.1 — Duplicate-PR search by manifest path (`Test-ExistingPRs.ps1`)

The title-only search misses human PRs whose titles omit the package identifier — verified case: upstream #419315 *"Submitting Godot Launcher 1.11.1"* raced the bot into duplicate #419629 (closed Resolution-Duplicate). Upstream's own moderation bot identifies duplicates by **manifest path**.

- After the title search finds nothing, a second stage searches **open** PRs whose title mentions the version (human titles reliably carry the version even when they omit the id) and verifies each candidate's changed files against `manifests/<first letter>/<identifier as directories>/<version>/` via the PR files API (paginated).
- Candidates whose titles clearly name a *different* package identifier are skipped without a files read; version-like dotted tokens (`1.2.3`, `v1.2.3`) never suppress a candidate. File reads are capped at the 25 most recently created candidates.
- The shared credential-tier failover (primary/fallback upstream read token → anonymous), HTTP 422 retries, rate-limit backoff, and fail-closed response-shape validation now live in reusable helpers (`Invoke-WingetPkgsUpstreamReadRequest`, `Find-WingetPkgsExistingPrSearchMatch`) used by both stages. Return contract (`bool`) unchanged; microsoft/winget-pkgs is only ever read.

## P5.2 — Release-asset pagination (`Test-MonitoredPackageAssets.ps1`)

Releases with >100 assets (`binbat.*`, `Winix.*`) were permanently `Inconclusive` because only the first GraphQL asset page was examined.

- The batched release selection now requests `pageInfo { hasNextPage endCursor }`, and truncated asset lists are paged through with follow-up `release(tagName:)` queries until complete, memoized per repo+tag (shared releases are expanded once per sweep).
- Output contract unchanged: `Inconclusive` still exists but now only when the remaining pages cannot be retrieved (pagination failure detail is included).

## P5.3 — Dual-arch drift relaxation (`Test-GeneratedInstallerArchitecture.ps1`)

The drift check required every generated entry's architecture to *equal* the single previously published architecture for the same normalized URL. winmatsch legitimately emits one URL under **both** x86 and x64 for dual-payload installers — verified case: Mibuw.miPDFsignCommunity always died with *"Generated architecture drift ... expected x86, got x64"*.

- The check now accepts a **superset**: every previously published architecture for a normalized URL must still be present among the generated entries; additional architectures for the same URL are fine.
- It throws only on genuine contradictions (a previously published architecture disappears or is replaced), with an error naming the missing architecture plus both sets. This also strengthens the previously unchecked multi-arch case (previous x86+x64 → generated x64-only now fails).

## Tests

- New `tests/TestGeneratedInstallerArchitecture.Tests.ps1` (6 cases: Mibuw superset pass, replaced-arch throw, narrowed multi-arch throw, extra-arch pass, changed-URL skip, hint-mismatch regression) — wired into `module-tests.yml`.
- `tests/Test-ExistingPRs.Tests.ps1`: 4 new tests for the manifest-path stage (detection when the title omits the id, version-directory boundary, other-package skip, helper unit checks) and existing expectations updated for the second search stage. 20/20 pass.
- `tests/TestMonitoredPackageAssets.Tests.ps1`: 2 new tests (pagination + memoization across shared releases; failed pagination stays `Inconclusive`).
- All 18 plain suites pass; Pester `Test-ExistingPRs` suite passes 20/20. The 8 failures in `Submit-WingetPackage`/`Test-SubmitFinalValidation`/`ForkBranchSubmission` are **pre-existing** local Pester 6 incompatibilities (`Assert-MockCalled` removed in Pester 6) — verified identical on the base branch with the changes stashed.