### PR TITLE
Precheck resilience: retry 5xx, per-batch fail-open, winget source-index fallback

### DIFF
--- a/modules/WingetMaintainerModule/Private/GitHubApiCache.ps1
+++ b/modules/WingetMaintainerModule/Private/GitHubApiCache.ps1
@@ -106,6 +106,15 @@ function Test-GitHubRateLimitErrorDetails {
     )
 }
 
+function Test-GitHubTransientServerErrorDetails {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object] $Details
+    )
+
+    return $Details.StatusCode -in 500, 502, 503, 504
+}
+
 function Invoke-WithGitHubRateLimitRetry {
     <#
     .SYNOPSIS
@@ -113,10 +122,13 @@ function Invoke-WithGitHubRateLimitRetry {
 
     .DESCRIPTION
         Retries only rate-limit failures (HTTP 429, or 403 with an exhausted quota).
-        Wait time honors Retry-After / X-RateLimit-Reset headers when present and
-        falls back to exponential backoff. On exhaustion it throws an exception with
-        Data['StatusCode'] = 429 so callers (e.g. credential-tier failover) can still
-        detect the rate limit.
+        With -RetryTransientServerErrors, transient server failures (HTTP 500/502/
+        503/504) are retried as well. Wait time honors Retry-After /
+        X-RateLimit-Reset headers when present and falls back to exponential
+        backoff. On rate-limit exhaustion it throws an exception with
+        Data['StatusCode'] = 429 so callers (e.g. credential-tier failover) can
+        still detect the rate limit; exhausted transient server errors rethrow
+        the original failure.
     #>
     param(
         [Parameter(Mandatory = $true)]
@@ -124,6 +136,9 @@ function Invoke-WithGitHubRateLimitRetry {
 
         [Parameter()]
         [string] $OperationName = 'GitHub API request',
+
+        [Parameter()]
+        [switch] $RetryTransientServerErrors,
 
         [Parameter()]
         [ValidateRange(1, 10)]
@@ -147,7 +162,9 @@ function Invoke-WithGitHubRateLimitRetry {
         }
         catch {
             $details = Get-GitHubApiErrorDetails -ErrorRecord $_
-            if (!(Test-GitHubRateLimitErrorDetails -Details $details)) {
+            $isRateLimit = Test-GitHubRateLimitErrorDetails -Details $details
+            $isTransientServerError = $RetryTransientServerErrors.IsPresent -and (Test-GitHubTransientServerErrorDetails -Details $details)
+            if (-not $isRateLimit -and -not $isTransientServerError) {
                 throw
             }
 
@@ -167,6 +184,12 @@ function Invoke-WithGitHubRateLimitRetry {
             }
 
             if ($attempt -eq $MaxAttempts -or $delaySeconds -gt $remainingWaitBudget) {
+                if (-not $isRateLimit) {
+                    # Exhausted transient server errors rethrow the original
+                    # failure so callers see the real status code instead of a
+                    # synthetic rate-limit error.
+                    throw
+                }
                 $exhausted = [System.Exception]::new(
                     "GitHub API rate limit exhausted for $OperationName. Reset: $resetAt. Retry the workflow after the reset or provide a token with available quota."
                 )
@@ -177,7 +200,12 @@ function Invoke-WithGitHubRateLimitRetry {
                 throw $exhausted
             }
 
-            Write-Warning "GitHub API rate limit reached. Retrying in $delaySeconds seconds (attempt $($attempt + 1)/$MaxAttempts; reset: $resetAt)."
+            if ($isRateLimit) {
+                Write-Warning "GitHub API rate limit reached. Retrying in $delaySeconds seconds (attempt $($attempt + 1)/$MaxAttempts; reset: $resetAt)."
+            }
+            else {
+                Write-Warning "GitHub API transient server error (HTTP $($details.StatusCode)) for $OperationName. Retrying in $delaySeconds seconds (attempt $($attempt + 1)/$MaxAttempts)."
+            }
             & $Sleep $delaySeconds
             $totalWaitSeconds += $delaySeconds
         }

--- a/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
+++ b/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
@@ -48,6 +48,7 @@ function Invoke-WingetPrecheckGraphQlRequest {
         -OperationName 'GitHub GraphQL update precheck' `
         -MaxAttempts 5 `
         -MaxTotalWaitSeconds 240 `
+        -RetryTransientServerErrors `
         -ScriptBlock {
             $response = Invoke-RestMethod `
                 -Method Post `
@@ -197,6 +198,13 @@ function Select-GitHubPackagesNeedingUpdate {
         already published are skipped; every ambiguous case is included so a
         precheck miss can never suppress a real update (fail-open).
 
+        GraphQL failures are contained per batch: packages in a failed batch are
+        included (Reason 'PrecheckBatchFailed') while other batches still produce
+        normal skip decisions. When the winget-pkgs published-versions query
+        fails, the winget source index (a CDN copy of the catalog) supplies the
+        published versions instead, so a transient GitHub error no longer forces
+        the whole run open.
+
     .OUTPUTS
         PSCustomObject with Include and Skipped lists. Each entry carries the
         original Package object plus a Reason string.
@@ -239,11 +247,21 @@ function Select-GitHubPackagesNeedingUpdate {
         # included without a check (fail-open).
         [Parameter()]
         [ValidateRange(0, 1000)]
-        [int] $MaxOpenPrChecks = 30
+        [int] $MaxOpenPrChecks = 30,
+
+        # Injectable for tests: returns winget source-index rows (objects with
+        # PackageIdentifier and WingetVersion properties) used as the
+        # published-versions fallback when a winget-pkgs batch query fails.
+        # Defaults to Get-WingetSourceIndexPackage.
+        [Parameter()]
+        [scriptblock] $SourceIndexProvider
     )
 
     if ($null -eq $GraphQlInvoker) {
         $GraphQlInvoker = { param([string] $Query) Invoke-WingetPrecheckGraphQlRequest -Query $Query }
+    }
+    if ($null -eq $SourceIndexProvider) {
+        $SourceIndexProvider = { Get-WingetSourceIndexPackage }
     }
 
     $openPrCheckEnabled = -not [string]::IsNullOrWhiteSpace($StateFilePath)
@@ -317,8 +335,11 @@ function Select-GitHubPackagesNeedingUpdate {
     }
 
     # Pass 1: latest release tag per unique repository, batched with aliases.
+    # A failed batch marks its repositories so their packages fail open below,
+    # while other batches still produce normal skip decisions.
     $uniqueRepos = @($comparable | ForEach-Object { Get-WingetPrecheckPackageField -Package $_ -Name 'repo' } | Sort-Object -Unique)
     $latestTagByRepo = @{}
+    $failedRepoLookups = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
     for ($offset = 0; $offset -lt $uniqueRepos.Count; $offset += $BatchSize) {
         $repoSlice = @($uniqueRepos[$offset..([Math]::Min($offset + $BatchSize, $uniqueRepos.Count) - 1)])
         $fields = for ($i = 0; $i -lt $repoSlice.Count; $i++) {
@@ -326,7 +347,17 @@ function Select-GitHubPackagesNeedingUpdate {
             "r$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { latestRelease { tagName } }"
         }
         $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
-        $response = & $GraphQlInvoker $query
+        $response = $null
+        try {
+            $response = & $GraphQlInvoker $query
+        }
+        catch {
+            Write-Warning "Update precheck release query failed for a batch of $($repoSlice.Count) repositories: $($_.Exception.Message). Including their packages."
+            foreach ($failedRepo in $repoSlice) {
+                $null = $failedRepoLookups.Add($failedRepo)
+            }
+            continue
+        }
         $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
 
         for ($i = 0; $i -lt $repoSlice.Count; $i++) {
@@ -342,6 +373,11 @@ function Select-GitHubPackagesNeedingUpdate {
     $candidates = [System.Collections.Generic.List[object]]::new()
     foreach ($package in @($comparable)) {
         $repo = Get-WingetPrecheckPackageField -Package $package -Name 'repo'
+
+        if ($failedRepoLookups.Contains($repo)) {
+            $include.Add([PSCustomObject]@{ Package = $package; Reason = 'PrecheckBatchFailed' })
+            continue
+        }
 
         $latestTag = [string]$latestTagByRepo[$repo]
         if ([string]::IsNullOrWhiteSpace($latestTag)) {
@@ -361,7 +397,8 @@ function Select-GitHubPackagesNeedingUpdate {
     # Pass 1b: resolve versions for packages whose version needs release
     # metadata beyond the latest tag (tagPattern / ReleaseName / {ARPVERSION}),
     # batched with one aliased repository field per package. Any resolution
-    # failure includes the package unconditionally (fail-open).
+    # failure includes the package unconditionally (fail-open); a failed batch
+    # query includes only that batch.
     $resolvableArray = @($resolvable)
     for ($offset = 0; $offset -lt $resolvableArray.Count; $offset += $BatchSize) {
         $packageSlice = @($resolvableArray[$offset..([Math]::Min($offset + $BatchSize, $resolvableArray.Count) - 1)])
@@ -384,7 +421,17 @@ function Select-GitHubPackagesNeedingUpdate {
             "u$($i): repository(owner: $(ConvertTo-WingetGraphQlStringLiteral -Value $owner), name: $(ConvertTo-WingetGraphQlStringLiteral -Value $name)) { $selection }"
         }
         $query = "query {`n" + (($fields | ForEach-Object { "  $_" }) -join "`n") + "`n}"
-        $response = & $GraphQlInvoker $query
+        $response = $null
+        try {
+            $response = & $GraphQlInvoker $query
+        }
+        catch {
+            Write-Warning "Update precheck release-metadata query failed for a batch of $($packageSlice.Count) packages: $($_.Exception.Message). Including them."
+            foreach ($slicePackage in $packageSlice) {
+                $include.Add([PSCustomObject]@{ Package = $slicePackage; Reason = 'PrecheckBatchFailed' })
+            }
+            continue
+        }
         $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
 
         for ($i = 0; $i -lt $packageSlice.Count; $i++) {
@@ -401,8 +448,14 @@ function Select-GitHubPackagesNeedingUpdate {
     }
 
     # Pass 2: published versions per package from microsoft/winget-pkgs, batched
-    # as multiple object() fields under a single repository field.
-    $publishedEntriesByPackageId = @{}
+    # as multiple object() fields under a single repository field. When a batch
+    # fails even after retries, the winget source index (a CDN copy of the
+    # catalog that lags master by a few hours) supplies the published versions
+    # instead — the lag can only cause an extra include, never a false skip.
+    # Packages the fallback cannot resolve are included.
+    $publishedStateByPackageId = @{}
+    $sourceIndexVersionsById = $null
+    $sourceIndexLoadAttempted = $false
     $candidatesArray = @($candidates)
     for ($offset = 0; $offset -lt $candidatesArray.Count; $offset += $BatchSize) {
         $candidateSlice = @($candidatesArray[$offset..([Math]::Min($offset + $BatchSize, $candidatesArray.Count) - 1)])
@@ -414,16 +467,68 @@ function Select-GitHubPackagesNeedingUpdate {
         $query = "query {`n  repository(owner: `"microsoft`", name: `"winget-pkgs`") {`n" +
             (($fields | ForEach-Object { "    $_" }) -join "`n") +
             "`n  }`n}"
-        $response = & $GraphQlInvoker $query
-        $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
-        $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name 'repository'
-        if ($null -eq $repository) {
-            throw 'GitHub GraphQL update precheck could not read microsoft/winget-pkgs.'
+        $repository = $null
+        $batchFailure = $null
+        try {
+            $response = & $GraphQlInvoker $query
+            $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
+            $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name 'repository'
+            if ($null -eq $repository) {
+                throw 'GitHub GraphQL update precheck could not read microsoft/winget-pkgs.'
+            }
+        }
+        catch {
+            $batchFailure = $_.Exception.Message
+        }
+
+        if ($null -eq $batchFailure) {
+            for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
+                $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
+                $treeObject = Get-WingetGraphQlFieldValue -InputObject $repository -Name "p$i"
+                if ($null -eq $treeObject) {
+                    $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Missing'; Versions = @() }
+                    continue
+                }
+                $entriesValue = Get-WingetGraphQlFieldValue -InputObject $treeObject -Name 'entries'
+                $entries = if ($null -eq $entriesValue) { @() } else { @($entriesValue) }
+                $publishedVersions = @($entries |
+                        Where-Object { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'type')" -eq 'tree' } |
+                        ForEach-Object { [string](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'name') })
+                $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Resolved'; Versions = $publishedVersions }
+            }
+            continue
+        }
+
+        Write-Warning "Update precheck winget-pkgs query failed for a batch of $($candidateSlice.Count) packages: $batchFailure. Falling back to the winget source index."
+        if (-not $sourceIndexLoadAttempted) {
+            $sourceIndexLoadAttempted = $true
+            try {
+                $indexVersions = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                foreach ($row in @(& $SourceIndexProvider)) {
+                    $rowId = [string](Get-WingetGraphQlFieldValue -InputObject $row -Name 'PackageIdentifier')
+                    $rowVersion = [string](Get-WingetGraphQlFieldValue -InputObject $row -Name 'WingetVersion')
+                    if (-not [string]::IsNullOrWhiteSpace($rowId) -and -not [string]::IsNullOrWhiteSpace($rowVersion)) {
+                        $indexVersions[$rowId] = $rowVersion
+                    }
+                }
+                $sourceIndexVersionsById = $indexVersions
+            }
+            catch {
+                # Fail-open: without the index, failed batches stay included.
+                Write-Warning "Winget source index fallback unavailable: $($_.Exception.Message). Including the affected packages."
+            }
         }
 
         for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
             $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
-            $publishedEntriesByPackageId[$packageId] = Get-WingetGraphQlFieldValue -InputObject $repository -Name "p$i"
+            if ($null -ne $sourceIndexVersionsById -and $sourceIndexVersionsById.ContainsKey($packageId)) {
+                $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Resolved'; Versions = @([string]$sourceIndexVersionsById[$packageId]) }
+            }
+            else {
+                # Not in the index (brand-new package, or index unavailable): the
+                # precheck cannot prove it is published, so it stays included.
+                $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Failed'; Versions = @() }
+            }
         }
     }
 
@@ -432,20 +537,19 @@ function Select-GitHubPackagesNeedingUpdate {
         $version = [string]$candidate.Version
         $packageId = Get-WingetPrecheckPackageField -Package $package -Name 'id'
 
-        $treeObject = $publishedEntriesByPackageId[$packageId]
-        if ($null -eq $treeObject) {
+        $publishedState = $publishedStateByPackageId[$packageId]
+        if ($null -eq $publishedState -or $publishedState.Status -eq 'Failed') {
+            $include.Add([PSCustomObject]@{ Package = $package; Reason = 'PrecheckBatchFailed'; Version = $version })
+            continue
+        }
+
+        if ($publishedState.Status -eq 'Missing') {
             Write-Warning "Package $packageId was not found in microsoft/winget-pkgs. Skipping it in the update precheck."
             $skipped.Add([PSCustomObject]@{ Package = $package; Reason = 'PackageMissing' })
             continue
         }
 
-        $entriesValue = Get-WingetGraphQlFieldValue -InputObject $treeObject -Name 'entries'
-        $entries = if ($null -eq $entriesValue) { @() } else { @($entriesValue) }
-        $publishedVersions = @($entries |
-                Where-Object { "$(Get-WingetGraphQlFieldValue -InputObject $_ -Name 'type')" -eq 'tree' } |
-                ForEach-Object { [string](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'name') })
-
-        $match = Find-WingetPublishedVersionMatch -Version $version -PublishedVersions $publishedVersions
+        $match = Find-WingetPublishedVersionMatch -Version $version -PublishedVersions @($publishedState.Versions)
         if ($null -ne $match) {
             $skipped.Add([PSCustomObject]@{ Package = $package; Reason = 'AlreadyPublished'; Version = $version })
         }

--- a/tests/GitHubApiCache.Tests.ps1
+++ b/tests/GitHubApiCache.Tests.ps1
@@ -162,6 +162,74 @@ try {
     Assert-Equal -Actual $retryAfterSleepDurations[0] -Expected 7 -Message 'The retry-after delay was not honored.'
     Assert-Equal -Actual $tooManyRequestsResult[0].tag_name -Expected 'v1.0.0' -Message 'The HTTP 429 retry result was incorrect.'
 
+    Write-Host 'TEST: transient server errors retry when opted in'
+    $transientAttempts = [System.Collections.Generic.List[int]]::new()
+    $transientSleeps = [System.Collections.Generic.List[int]]::new()
+    $transientResult = Invoke-WithGitHubRateLimitRetry `
+        -ScriptBlock {
+            $transientAttempts.Add(1)
+            if ($transientAttempts.Count -eq 1) {
+                $exception = [System.Exception]::new('Bad gateway')
+                $exception.Data['StatusCode'] = 502
+                throw $exception
+            }
+            return 'recovered'
+        } `
+        -OperationName 'transient test' `
+        -RetryTransientServerErrors `
+        -Sleep { param([int]$Seconds) $transientSleeps.Add($Seconds) } `
+        -UtcNowProvider $utcNowProvider `
+        -WarningAction SilentlyContinue
+
+    Assert-Equal -Actual $transientAttempts.Count -Expected 2 -Message 'The HTTP 502 request was not retried.'
+    Assert-Equal -Actual $transientSleeps[0] -Expected 5 -Message 'The transient retry backoff delay was incorrect.'
+    Assert-Equal -Actual $transientResult -Expected 'recovered' -Message 'The transient retry result was incorrect.'
+
+    Write-Host 'TEST: transient server errors are not retried without opt-in'
+    $nonOptInAttempts = [System.Collections.Generic.List[int]]::new()
+    $nonOptInMessage = $null
+    try {
+        Invoke-WithGitHubRateLimitRetry `
+            -ScriptBlock {
+                $nonOptInAttempts.Add(1)
+                $exception = [System.Exception]::new('Bad gateway')
+                $exception.Data['StatusCode'] = 502
+                throw $exception
+            } `
+            -Sleep { param([int]$Seconds) } `
+            -UtcNowProvider $utcNowProvider
+    }
+    catch {
+        $nonOptInMessage = $_.Exception.Message
+    }
+
+    Assert-Equal -Actual $nonOptInAttempts.Count -Expected 1 -Message 'The HTTP 502 request was retried without opt-in.'
+    Assert-Equal -Actual $nonOptInMessage -Expected 'Bad gateway' -Message 'The non-opt-in failure was not rethrown as-is.'
+
+    Write-Host 'TEST: exhausted transient server errors rethrow the original failure'
+    $exhaustedAttempts = [System.Collections.Generic.List[int]]::new()
+    $exhaustedStatusCode = $null
+    try {
+        Invoke-WithGitHubRateLimitRetry `
+            -ScriptBlock {
+                $exhaustedAttempts.Add(1)
+                $exception = [System.Exception]::new('Service unavailable')
+                $exception.Data['StatusCode'] = 503
+                throw $exception
+            } `
+            -RetryTransientServerErrors `
+            -MaxAttempts 2 `
+            -Sleep { param([int]$Seconds) } `
+            -UtcNowProvider $utcNowProvider `
+            -WarningAction SilentlyContinue
+    }
+    catch {
+        $exhaustedStatusCode = $_.Exception.Data['StatusCode']
+    }
+
+    Assert-Equal -Actual $exhaustedAttempts.Count -Expected 2 -Message 'The exhausted transient request attempt count was incorrect.'
+    Assert-Equal -Actual $exhaustedStatusCode -Expected 503 -Message 'The exhausted transient failure did not keep its original status code.'
+
     Write-Host 'TEST: distant rate-limit reset fails with actionable guidance'
     $distantResetInvoker = {
         param([hashtable]$Parameters)

--- a/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+++ b/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
@@ -185,24 +185,91 @@ Assert-Equal 0 $empty.IncludeCount 'empty input produces empty include list'
 Assert-Equal 0 $empty.SkippedCount 'empty input produces empty skipped list'
 Assert-Equal 0 $empty.QueryCount 'empty input makes no GraphQL calls'
 
-# 5) A failing manifest read (repository null) throws so the caller can fail open.
-$threw = & $module {
+# 5) A failed winget-pkgs read falls back to the winget source index: indexed
+#    versions still produce skip/include decisions, unindexed packages fail open.
+$indexFallback = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(owner: "[^"]+", name: "([^"]+)"\)')) {
+                $tag = switch ($alias.Groups[2].Value) {
+                    'outdated' { 'v2.0.0' }
+                    default    { 'v1.0.0' }
+                }
+                $data[$alias.Groups[1].Value] = @{ latestRelease = @{ tagName = $tag } }
+            }
+            return @{ data = $data }
+        }
+        return @{ data = @{ repository = $null } }
+    }
+    $sourceIndex = {
+        @(
+            [PSCustomObject]@{ PackageIdentifier = 'Vendor.Published'; WingetVersion = '1.0.0' },
+            [PSCustomObject]@{ PackageIdentifier = 'Vendor.Outdated'; WingetVersion = '1.0.0' }
+        )
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Published'; repo = 'vendor/published'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Outdated'; repo = 'vendor/outdated'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Unindexed'; repo = 'vendor/unindexed'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -SourceIndexProvider $sourceIndex -WarningAction SilentlyContinue
+}
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $indexFallback 'Vendor.Published') 'index fallback skips versions the index already lists'
+Assert-Equal 'Include:NewVersion' (Get-ReasonFor $indexFallback 'Vendor.Outdated') 'index fallback includes versions newer than the index'
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $indexFallback 'Vendor.Unindexed') 'packages missing from the index fail open'
+
+# 5b) When the source index is also unavailable, failed batches fail open.
+$indexUnavailable = & $module {
     $invoker = {
         param([string] $Query)
         if ($Query -notmatch 'winget-pkgs') {
             return @{ data = @{ r0 = @{ latestRelease = @{ tagName = 'v1.0.0' } } } }
         }
-        return @{ data = @{ repository = $null } }
+        throw 'winget-pkgs read boom'
     }
-
-    try {
-        $null = Select-GitHubPackagesNeedingUpdate -Packages @(@{ id = 'Vendor.A'; repo = 'vendor/a'; url = 'https://example.com/{VERSION}.exe' }) -GraphQlInvoker $invoker
-        return $false
-    } catch {
-        return $_.Exception.Message -match 'winget-pkgs'
-    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(@{ id = 'Vendor.A'; repo = 'vendor/a'; url = 'https://example.com/{VERSION}.exe' }) -GraphQlInvoker $invoker -SourceIndexProvider { throw 'index download failed' } -WarningAction SilentlyContinue
 }
-Assert-Equal $true $threw 'null winget-pkgs repository response throws'
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $indexUnavailable 'Vendor.A') 'failed batch without a usable index fails open'
+
+# 5c) A failed release batch only fails open its own packages; other batches
+#     still produce normal skip decisions.
+$partialPass1 = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            if ($Query -match '"bad"') { throw 'release query boom' }
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(')) {
+                $data[$alias.Groups[1].Value] = @{ latestRelease = @{ tagName = 'v1.0.0' } }
+            }
+            return @{ data = $data }
+        }
+        $repoData = @{}
+        foreach ($alias in [regex]::Matches($Query, '(p\d+): object\(')) {
+            $repoData[$alias.Groups[1].Value] = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) }
+        }
+        return @{ data = @{ repository = $repoData } }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Bad'; repo = 'vendor/bad'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Good'; repo = 'vendor/good'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -BatchSize 1 -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $partialPass1 'Vendor.Bad') 'failed release batch includes its packages'
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $partialPass1 'Vendor.Good') 'other release batches still skip published packages'
+
+# 5d) A failed release-metadata batch includes its resolvable packages.
+$resolvableFailure = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -match 'u\d+: repository') { throw 'metadata query boom' }
+        if ($Query -notmatch 'winget-pkgs') { return @{ data = @{} } }
+        return @{ data = @{ repository = @{} } }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(@{ id = 'Vendor.Tagged'; repo = 'vendor/tagged'; url = 'https://example.com/{VERSION}.exe'; tagPattern = '^v1\..*' }) -GraphQlInvoker $invoker -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $resolvableFailure 'Vendor.Tagged') 'failed release-metadata batch includes its packages'
 
 # 6) GraphQL rate limits (HTTP 200 + RATE_LIMITED error) are retried by the default invoker.
 $rateLimit = & $module {
@@ -238,6 +305,34 @@ $rateLimit = & $module {
 Assert-Equal 2 $rateLimit.Calls 'RATE_LIMITED response is retried'
 Assert-Equal $true $rateLimit.Ok 'successful retry returns the GraphQL payload'
 Assert-Equal '5' $rateLimit.Sleeps 'retry uses backoff delay'
+
+# 6b) Transient server errors (HTTP 5xx) are retried by the default invoker.
+$transient = & $module {
+    $script:restCalls = 0
+    $env:WINGET_UPSTREAM_READ_TOKEN = 'test-token'
+
+    function script:Invoke-RestMethod {
+        param($Method, $Uri, $Headers, $Body, $ContentType)
+        $script:restCalls++
+        if ($script:restCalls -eq 1) {
+            $exception = [System.Exception]::new('Response status code does not indicate success: 502 (Bad Gateway).')
+            $exception.Data['StatusCode'] = 502
+            throw $exception
+        }
+        return @{ data = @{ ok = $true } }
+    }
+    function script:Start-Sleep { param($Seconds) }
+
+    $response = Invoke-WingetPrecheckGraphQlRequest -Query 'query { viewer { login } }' -WarningAction SilentlyContinue
+
+    Remove-Item function:Invoke-RestMethod
+    Remove-Item function:Start-Sleep
+    Remove-Item env:WINGET_UPSTREAM_READ_TOKEN
+
+    [PSCustomObject]@{ Calls = $script:restCalls; Ok = $response.data.ok }
+}
+Assert-Equal 2 $transient.Calls 'HTTP 502 response is retried by the default invoker'
+Assert-Equal $true $transient.Ok 'successful 502 retry returns the GraphQL payload'
 
 # 7) Open-PR cache: fresh marker skips, stale/mismatched markers trigger a live
 #    check, tester results are recorded, and tester failures fail open.


### PR DESCRIPTION
## Problem

In run [32251561023](https://github.com/b0t-at/winget-pkgs-updates/actions/runs/32251561023) ~22 of 30 generate jobs were no-op packages that needed no update. Root cause: the GraphQL update precheck failed open **all-or-nothing** — a single un-retried HTTP 502 propagated to the script-level catch in `Select-PackagesNeedingUpdate.ps1`, making **all 990 packages** "eligible" with 30 picked at random.

## Fix (three layers)

1. **Retry transient 5xx** — `Invoke-WithGitHubRateLimitRetry` gains an opt-in `-RetryTransientServerErrors` switch (HTTP 500/502/503/504 retry with the existing backoff); the GraphQL precheck invoker opts in. Non-retryable errors still rethrow immediately, and exhausted transient errors rethrow the *original* exception instead of a synthetic 429.
2. **Per-batch fail-open** — each GraphQL batch (release lookup, release-metadata, published-manifest) is now wrapped individually: a failed batch only marks *its own* packages as `Include: PrecheckBatchFailed` while every other batch keeps real skip/include results. A single bad response no longer opens the whole run.
3. **Winget source-index fallback** — when a published-manifest (pass 2) batch fails, the precheck lazily downloads the winget source-index DB once (`Get-WingetSourceIndexPackage`, injectable via new `-SourceIndexProvider` param) and resolves published versions from it. The index lags master by only hours, so this can only cause a harmless extra include — never a false skip.

Design invariant: **only positive evidence (master read or index row) skips a package; every failure path includes it.**

## Tests

- `tests/GitHubApiCache.Tests.ps1`: +3 tests — opted-in 5xx retry, no-opt-in immediate rethrow, exhaustion preserves original error.
- `tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1`: former "null repository throws" test replaced by index-fallback scenarios (index skip / index include / unindexed fail-open / index-unavailable fail-open), per-batch isolation tests (failed batch includes only its packages), and a 502-retry test through the real invoker.
- All 14 plain CI suites pass locally; script-level suite unchanged-green.