### PR TITLE
Post-merge review fixes: script-packages needs-decision parity, config-PR validation coverage, duplicate-search precision, GraphQL partial-error fail-open

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -6,6 +6,12 @@ on:
       - ".github/workflows/module-tests.yml"
       - "modules/WingetMaintainerModule/**"
       - "tests/**"
+      # Configuration inputs validated by GitHubReleaseMonitoringConfiguration.Tests.ps1:
+      # a config-only PR must not bypass the stream-config and sidecar-consistency guards.
+      - "github-releases-monitored.yml"
+      - ".github/workflows-data/**"
+      - ".github/workflows-templates/**"
+      - ".github/workflows/update-github-packages-*.yml"
   push:
     branches:
       - main
@@ -13,6 +19,10 @@ on:
       - ".github/workflows/module-tests.yml"
       - "modules/WingetMaintainerModule/**"
       - "tests/**"
+      - "github-releases-monitored.yml"
+      - ".github/workflows-data/**"
+      - ".github/workflows-templates/**"
+      - ".github/workflows/update-github-packages-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/update-script-packages.yml
+++ b/.github/workflows/update-script-packages.yml
@@ -144,8 +144,44 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Record needs-decision marker
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
+        shell: pwsh
+        env:
+          JOB_NAME: Generate ${{ matrix.PackageName }}
+          MATRIX_PACKAGENAME: ${{ matrix.PackageName }}
+          STEPS_GENERATE_OUTPUTS_VERSION: ${{ steps.generate.outputs.version }}
+          STEPS_GENERATE_OUTPUTS_GENERATOR: ${{ steps.generate.outputs.generator }}
+          STEPS_GENERATE_OUTPUTS_EXIT_CODE: ${{ steps.generate.outputs.generator-exit-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR_CODE: ${{ steps.generate.outputs.error-code }}
+          STEPS_GENERATE_OUTPUTS_ERROR: ${{ steps.generate.outputs.error }}
+        run: |
+          New-Item -ItemType Directory -Force -Path ./needs-decision | Out-Null
+
+          @{
+            job       = "$env:JOB_NAME"
+            package   = "$env:MATRIX_PACKAGENAME"
+            version   = "$env:STEPS_GENERATE_OUTPUTS_VERSION"
+            generator = "$env:STEPS_GENERATE_OUTPUTS_GENERATOR"
+            exitCode  = "$env:STEPS_GENERATE_OUTPUTS_EXIT_CODE"
+            errorCode = "$env:STEPS_GENERATE_OUTPUTS_ERROR_CODE"
+            error     = "$env:STEPS_GENERATE_OUTPUTS_ERROR"
+          } | ConvertTo-Json | Out-File -FilePath ./needs-decision/question.json -Encoding utf8
+
+          Get-Content -Path ./needs-decision/question.json
+
+      - name: Upload needs-decision marker
+        if: ${{ !cancelled() && steps.generate.outputs.reason == 'QuestionsRequired' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: needs-decision__${{ matrix.PackageName }}
+          path: ./needs-decision
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Record generation failure
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         shell: pwsh
         env:
           JOB_NAME: Generate ${{ matrix.PackageName }}
@@ -176,7 +212,7 @@ jobs:
           Get-Content -Path ./generate-failure/failure.json
 
       - name: Upload generation failure marker
-        if: failure()
+        if: ${{ failure() && steps.generate.outputs.reason != 'QuestionsRequired' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
@@ -235,6 +271,55 @@ jobs:
         with:
           pattern: generate-failure__*
           path: ./generate-failures
+
+      - name: Download needs-decision markers
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: needs-decision__*
+          path: ./needs-decisions
+
+      - name: Summarize packages needing a decision
+        if: always()
+        shell: pwsh
+        run: |
+          $files = @(Get-ChildItem -Path ./needs-decisions -Filter *.json -Recurse -ErrorAction SilentlyContinue)
+
+          if ($files.Count -eq 0) {
+            Write-Host "No packages are waiting on a safety-question decision."
+            return
+          }
+
+          $rows = @(foreach ($file in $files) {
+            try {
+              Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+            }
+            catch {
+              Write-Warning "Could not read $($file.FullName): $($_.Exception.Message)"
+            }
+          })
+
+          $summary = @(
+            "## :warning: Packages waiting on a safety-question decision ($($rows.Count))"
+            ""
+            "The generator stopped at a fail-closed safety question. Review each package's"
+            "matrix entry (``WebsiteURL``, ``With`` overrides)."
+            ""
+            "| Package | Version | Question | Detail |"
+            "| --- | --- | --- | --- |"
+          )
+
+          foreach ($row in ($rows | Sort-Object -Property package)) {
+            $cells = @($row.package, $row.version, $row.errorCode, $row.error) | ForEach-Object {
+              $text = ("$_" -replace '\s*[\r\n]+\s*', ' ').Trim()
+              if ([string]::IsNullOrWhiteSpace($text)) { '-' } else { $text.Replace('|', '\|') }
+            }
+            $summary += "| $($cells -join ' | ') |"
+          }
+
+          ($summary -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          Write-Host "Reported $($rows.Count) package(s) needing a decision in the job summary."
 
       - name: Summarize failed generations
         if: always()
@@ -804,7 +889,9 @@ jobs:
     name: Notify Failure
     needs: [generate-manifest, collect-generated, validate-and-test, collect-validated, submit-pr]
     runs-on: ubuntu-latest
-    if: always() && failure() && vars.NTFY_URL != ''
+    # Run on every failure - even without NTFY_URL - so the missing-variable
+    # warning below is visible instead of the job being silently skipped.
+    if: always() && failure()
     
     steps:
       - name: Checkout
@@ -812,7 +899,14 @@ jobs:
         with:
           persist-credentials: false
       
+      - name: Warn when NTFY_URL is not configured
+        if: vars.NTFY_URL == ''
+        shell: pwsh
+        run: |
+          Write-Host "::warning::NTFY_URL not configured — failure notifications disabled"
+
       - name: Send failure notification
+        if: vars.NTFY_URL != ''
         shell: pwsh
         run: |
           $runUrl = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
+++ b/modules/WingetMaintainerModule/Public/Select-GitHubPackagesNeedingUpdate.ps1
@@ -96,6 +96,56 @@ function Get-WingetPrecheckPackageField {
     return [string]$value
 }
 
+function Get-WingetPrecheckErroredAlias {
+    <#
+    .SYNOPSIS
+        Attributes GraphQL partial errors to the aliased fields of a batch query.
+
+    .DESCRIPTION
+        A GraphQL response can be HTTP 200 with an errors array and partially
+        null data: per-alias errors carry the failed field's response path
+        (e.g. ["p3"] or ["repository", "p3"]). A null aliased object WITH a
+        corresponding error entry is a failed lookup, not evidence of absence,
+        so callers must not treat it as a skip decision. Returns the batch
+        aliases the errors attribute to, plus WholeBatchFailed when the
+        response cannot be trusted at all: data is null/absent, or an error
+        exists whose path matches none of the expected aliases (fail-open,
+        identical handling to a thrown batch).
+    #>
+    param(
+        [Parameter()] $Response,
+        [Parameter(Mandatory = $true)] [AllowEmptyCollection()] [string[]] $ExpectedAliases
+    )
+
+    $aliasSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$ExpectedAliases, [System.StringComparer]::Ordinal)
+    $errorsValue = Get-WingetGraphQlFieldValue -InputObject $Response -Name 'errors'
+    $graphQlErrors = if ($null -eq $errorsValue) { @() } else { @($errorsValue) }
+
+    $erroredAliases = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $hasUnattributableErrors = $false
+    foreach ($graphQlError in $graphQlErrors) {
+        $pathValue = Get-WingetGraphQlFieldValue -InputObject $graphQlError -Name 'path'
+        $pathEntries = if ($null -eq $pathValue) { @() } else { @($pathValue) }
+        $matched = $false
+        foreach ($pathEntry in $pathEntries) {
+            if ($aliasSet.Contains("$pathEntry")) {
+                $null = $erroredAliases.Add("$pathEntry")
+                $matched = $true
+            }
+        }
+        if (-not $matched) {
+            $hasUnattributableErrors = $true
+        }
+    }
+
+    $data = Get-WingetGraphQlFieldValue -InputObject $Response -Name 'data'
+
+    return [PSCustomObject]@{
+        ErroredAliases   = $erroredAliases
+        WholeBatchFailed = ($null -eq $data) -or ($graphQlErrors.Count -gt 0 -and $hasUnattributableErrors)
+    }
+}
+
 function Resolve-WingetPrecheckReleaseVersion {
     <#
     .SYNOPSIS
@@ -200,7 +250,11 @@ function Select-GitHubPackagesNeedingUpdate {
 
         GraphQL failures are contained per batch: packages in a failed batch are
         included (Reason 'PrecheckBatchFailed') while other batches still produce
-        normal skip decisions. When the winget-pkgs published-versions query
+        normal skip decisions. Partial GraphQL errors (HTTP 200 with an errors
+        array) are attributed per aliased field: an errored alias is a failed
+        lookup — never evidence of a missing release or manifest folder — and
+        unattributable errors or null data fail the whole batch. When the
+        winget-pkgs published-versions query
         fails, the winget source index (a CDN copy of the catalog) supplies the
         published versions instead, so a transient GitHub error no longer forces
         the whole run open.
@@ -365,9 +419,24 @@ function Select-GitHubPackagesNeedingUpdate {
             }
             continue
         }
+        $graphQlErrorInfo = Get-WingetPrecheckErroredAlias -Response $response -ExpectedAliases @(for ($i = 0; $i -lt $repoSlice.Count; $i++) { "r$i" })
+        if ($graphQlErrorInfo.WholeBatchFailed) {
+            Write-Warning "Update precheck release query returned unattributable GraphQL errors for a batch of $($repoSlice.Count) repositories. Including their packages."
+            foreach ($failedRepo in $repoSlice) {
+                $null = $failedRepoLookups.Add($failedRepo)
+            }
+            continue
+        }
         $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
 
         for ($i = 0; $i -lt $repoSlice.Count; $i++) {
+            if ($graphQlErrorInfo.ErroredAliases.Contains("r$i")) {
+                # A per-alias error is a failed lookup, not evidence the
+                # repository has no releases; only positive evidence may skip.
+                Write-Warning "Update precheck release query returned an error for repository $($repoSlice[$i]). Including its packages."
+                $null = $failedRepoLookups.Add($repoSlice[$i])
+                continue
+            }
             $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "r$i"
             $latestRelease = Get-WingetGraphQlFieldValue -InputObject $repository -Name 'latestRelease'
             $tagName = Get-WingetGraphQlFieldValue -InputObject $latestRelease -Name 'tagName'
@@ -441,10 +510,25 @@ function Select-GitHubPackagesNeedingUpdate {
             }
             continue
         }
+        $graphQlErrorInfo = Get-WingetPrecheckErroredAlias -Response $response -ExpectedAliases @(for ($i = 0; $i -lt $packageSlice.Count; $i++) { "u$i" })
+        if ($graphQlErrorInfo.WholeBatchFailed) {
+            Write-Warning "Update precheck release-metadata query returned unattributable GraphQL errors for a batch of $($packageSlice.Count) packages. Including them."
+            foreach ($slicePackage in $packageSlice) {
+                $include.Add([PSCustomObject]@{ Package = $slicePackage; Reason = 'PrecheckBatchFailed' })
+            }
+            continue
+        }
         $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
 
         for ($i = 0; $i -lt $packageSlice.Count; $i++) {
             $slicePackage = $packageSlice[$i]
+            if ($graphQlErrorInfo.ErroredAliases.Contains("u$i")) {
+                # A per-alias error is a failed lookup, not an unresolvable
+                # version source; include the package like a failed batch.
+                Write-Warning "Update precheck release-metadata query returned an error for package $(Get-WingetPrecheckPackageField -Package $slicePackage -Name 'id'). Including it."
+                $include.Add([PSCustomObject]@{ Package = $slicePackage; Reason = 'PrecheckBatchFailed' })
+                continue
+            }
             $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name "u$i"
             $resolvedVersion = Resolve-WingetPrecheckReleaseVersion -Package $slicePackage -Repository $repository
             if ([string]::IsNullOrWhiteSpace([string]$resolvedVersion)) {
@@ -478,8 +562,13 @@ function Select-GitHubPackagesNeedingUpdate {
             "`n  }`n}"
         $repository = $null
         $batchFailure = $null
+        $graphQlErrorInfo = $null
         try {
             $response = & $GraphQlInvoker $query
+            $graphQlErrorInfo = Get-WingetPrecheckErroredAlias -Response $response -ExpectedAliases @(for ($i = 0; $i -lt $candidateSlice.Count; $i++) { "p$i" })
+            if ($graphQlErrorInfo.WholeBatchFailed) {
+                throw 'GitHub GraphQL update precheck returned unattributable errors for the winget-pkgs batch.'
+            }
             $data = Get-WingetGraphQlFieldValue -InputObject $response -Name 'data'
             $repository = Get-WingetGraphQlFieldValue -InputObject $data -Name 'repository'
             if ($null -eq $repository) {
@@ -490,9 +579,19 @@ function Select-GitHubPackagesNeedingUpdate {
             $batchFailure = $_.Exception.Message
         }
 
+        # Candidate indexes whose lookup failed: the whole slice after a failed
+        # call, or the individually errored aliases of an otherwise successful
+        # call. Both fall back to the winget source index below.
+        $failedCandidateIndexes = [System.Collections.Generic.List[int]]::new()
         if ($null -eq $batchFailure) {
             for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
                 $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
+                if ($graphQlErrorInfo.ErroredAliases.Contains("p$i")) {
+                    # A per-alias error is a failed lookup, never evidence the
+                    # manifest folder is absent; only positive evidence may skip.
+                    $failedCandidateIndexes.Add($i)
+                    continue
+                }
                 $treeObject = Get-WingetGraphQlFieldValue -InputObject $repository -Name "p$i"
                 if ($null -eq $treeObject) {
                     $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Missing'; Versions = @() }
@@ -505,10 +604,18 @@ function Select-GitHubPackagesNeedingUpdate {
                         ForEach-Object { [string](Get-WingetGraphQlFieldValue -InputObject $_ -Name 'name') })
                 $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Resolved'; Versions = $publishedVersions }
             }
-            continue
+            if ($failedCandidateIndexes.Count -eq 0) {
+                continue
+            }
+            Write-Warning "Update precheck winget-pkgs query returned errors for $($failedCandidateIndexes.Count) of $($candidateSlice.Count) packages in a batch. Falling back to the winget source index for them."
+        }
+        else {
+            Write-Warning "Update precheck winget-pkgs query failed for a batch of $($candidateSlice.Count) packages: $batchFailure. Falling back to the winget source index."
+            for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
+                $failedCandidateIndexes.Add($i)
+            }
         }
 
-        Write-Warning "Update precheck winget-pkgs query failed for a batch of $($candidateSlice.Count) packages: $batchFailure. Falling back to the winget source index."
         if (-not $sourceIndexLoadAttempted) {
             $sourceIndexLoadAttempted = $true
             try {
@@ -528,7 +635,7 @@ function Select-GitHubPackagesNeedingUpdate {
             }
         }
 
-        for ($i = 0; $i -lt $candidateSlice.Count; $i++) {
+        foreach ($i in $failedCandidateIndexes) {
             $packageId = Get-WingetPrecheckPackageField -Package $candidateSlice[$i].Package -Name 'id'
             if ($null -ne $sourceIndexVersionsById -and $sourceIndexVersionsById.ContainsKey($packageId)) {
                 $publishedStateByPackageId[$packageId] = [PSCustomObject]@{ Status = 'Resolved'; Versions = @([string]$sourceIndexVersionsById[$packageId]) }

--- a/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
+++ b/modules/WingetMaintainerModule/Public/Test-ExistingPRs.ps1
@@ -340,9 +340,13 @@ function Test-WingetPkgsTitleNamesOtherPackage {
         Used to skip pull request file reads for manifest-path candidates that
         obviously belong to another package (bot and tool titles always spell
         out the package identifier). A dotted token counts as another package
-        identifier only when at least two of its segments contain letters and
-        it neither contains the requested identifier nor equals the requested
-        version, so version-like tokens ('1.2.3', 'v1.2.3') never suppress a
+        identifier only when it plausibly IS a winget package identifier: at
+        least two of its dot-separated segments start with a letter, its final
+        segment is neither a known file extension (setup.exe, manifest.yaml)
+        nor a common top-level domain (example.com), it is not part of a URL
+        or a www-prefixed host name, and it neither contains the requested
+        identifier nor equals the requested version. File names, domains, and
+        version-like tokens ('1.2.3', 'v1.2.3') therefore never suppress a
         candidate.
     #>
     [CmdletBinding()]
@@ -353,10 +357,37 @@ function Test-WingetPkgsTitleNamesOtherPackage {
         [Parameter(Mandatory = $true)] [string] $Version
     )
 
-    $dottedTokens = @([regex]::Matches($Title, '(?<![A-Za-z0-9._+-])[A-Za-z0-9_+-]+(?:\.[A-Za-z0-9_+-]+)+(?![A-Za-z0-9._+-])') | ForEach-Object { $_.Value })
-    foreach ($token in $dottedTokens) {
-        $letteredSegments = @($token.Split('.') | Where-Object { $_ -match '[A-Za-z]' })
-        if ($letteredSegments.Count -lt 2) {
+    # File-name tokens (setup.exe) and domain tokens (example.com) look like
+    # dotted identifiers but never name a winget package; treating them as one
+    # suppressed genuine human duplicates (e.g. 'Add GodotLauncher setup.exe 1.11.1').
+    $fileExtensionSegments = @(
+        'exe', 'msi', 'msix', 'zip', 'appx', 'appinstaller', 'nupkg', 'yaml',
+        'yml', 'json', 'ps1', 'cmd', 'bat', 'dll', 'jar', 'deb', 'rpm', 'dmg',
+        'pkg', 'txt', 'md', 'sig', 'sha256', 'iso', '7z', 'gz', 'xz', 'bin'
+    )
+    $topLevelDomainSegments = @('com', 'org', 'net', 'io', 'dev', 'de', 'app', 'sh', 'co', 'uk', 'us', 'me', 'gg')
+
+    $dottedTokenMatches = @([regex]::Matches($Title, '(?<![A-Za-z0-9._+-])[A-Za-z0-9_+-]+(?:\.[A-Za-z0-9_+-]+)+(?![A-Za-z0-9._+-])'))
+    foreach ($tokenMatch in $dottedTokenMatches) {
+        $token = $tokenMatch.Value
+        $segments = $token.Split('.')
+        $letterLedSegments = @($segments | Where-Object { $_ -match '^[A-Za-z]' })
+        if ($letterLedSegments.Count -lt 2) {
+            continue
+        }
+        $finalSegment = $segments[-1].ToLowerInvariant()
+        if ($finalSegment -in $fileExtensionSegments) {
+            continue
+        }
+        if ($finalSegment -in $topLevelDomainSegments) {
+            continue
+        }
+        if ($segments[0] -ieq 'www') {
+            continue
+        }
+        # Tokens inside a URL (https://example.gallery/path) are host names or
+        # path components, not package identifiers.
+        if ($Title.Substring(0, $tokenMatch.Index) -match '(?i)[a-z][a-z0-9+.-]*://\S*$') {
             continue
         }
         if ($token -ieq $Version -or $token -ieq "v$Version") {

--- a/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
+++ b/tests/SelectGitHubPackagesNeedingUpdate.Tests.ps1
@@ -590,6 +590,125 @@ Assert-Equal 'Include:UnpredictableVersionSource' (Get-ReasonFor $resolved.Selec
 Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $resolved.Selection 'Vendor.TagWithArp') 'published ARPVERSION asset version is skipped'
 Assert-Equal $false ($resolved.ResolvableQueries -join ' ' -match 'tagarp') 'unsupported combination is never queried'
 
+# 12) GraphQL partial errors (HTTP 200 + errors array) never masquerade as
+#     positive evidence: an errored pass-2 alias is a failed lookup (not
+#     PackageMissing), sibling aliases keep their real results, and an
+#     error-free null object remains a legitimate missing-package skip.
+$partialErrors = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            $data = @{}
+            foreach ($alias in [regex]::Matches($Query, '(r\d+): repository\(')) {
+                $data[$alias.Groups[1].Value] = @{ latestRelease = @{ tagName = 'v2.0.0' } }
+            }
+            return @{ data = $data }
+        }
+        # Pass 2: p0 errors out with a null object, p1 resolves normally,
+        # p2 is null WITHOUT an error entry (manifest folder genuinely absent).
+        return @{
+            errors = @(@{ path = @('p0'); message = 'timeout reading tree' })
+            data   = @{ repository = @{
+                p0 = $null
+                p1 = @{ entries = @(@{ name = '2.0.0'; type = 'tree' }) }
+                p2 = $null
+            } }
+        }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Errored'; repo = 'vendor/errored'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Sibling'; repo = 'vendor/sibling'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Absent'; repo = 'vendor/absent'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -SourceIndexProvider { throw 'index unavailable' } -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $partialErrors 'Vendor.Errored') 'pass-2 per-alias error fails open instead of PackageMissing'
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $partialErrors 'Vendor.Sibling') 'error-free sibling alias in the same batch keeps its real result'
+Assert-Equal 'Skipped:PackageMissing' (Get-ReasonFor $partialErrors 'Vendor.Absent') 'null object without an error entry remains a missing-package skip'
+
+# 12b) A per-alias pass-2 error resolves through the winget source-index
+#      fallback when the index knows the package.
+$partialErrorIndexed = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            return @{ data = @{ r0 = @{ latestRelease = @{ tagName = 'v1.0.0' } } } }
+        }
+        return @{
+            errors = @(@{ path = @('p0'); message = 'timeout reading tree' })
+            data   = @{ repository = @{ p0 = $null } }
+        }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Errored'; repo = 'vendor/errored'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -SourceIndexProvider {
+        @([PSCustomObject]@{ PackageIdentifier = 'Vendor.Errored'; WingetVersion = '1.0.0' })
+    } -WarningAction SilentlyContinue
+}
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $partialErrorIndexed 'Vendor.Errored') 'per-alias pass-2 error resolves via the source-index fallback'
+
+# 12c) Errors with null data fail the whole batch open.
+$nullData = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            return @{ data = @{ r0 = @{ latestRelease = @{ tagName = 'v1.0.0' } } } }
+        }
+        return @{ errors = @(@{ message = 'total failure' }); data = $null }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.A'; repo = 'vendor/a'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -SourceIndexProvider { throw 'index unavailable' } -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $nullData 'Vendor.A') 'errors with null data fail the whole batch open'
+
+# 12d) A pass-1 per-alias error becomes a failed repository lookup instead of
+#      "repo without releases"; the error-free sibling keeps its skip decision.
+$pass1Partial = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -notmatch 'winget-pkgs') {
+            # r0 errors out, r1 resolves; aliases follow the sorted unique
+            # repository list (vendor/errored before vendor/good).
+            return @{
+                errors = @(@{ path = @('r0'); message = 'server error' })
+                data   = @{ r0 = $null; r1 = @{ latestRelease = @{ tagName = 'v1.0.0' } } }
+            }
+        }
+        $repoData = @{}
+        foreach ($alias in [regex]::Matches($Query, '(p\d+): object\(')) {
+            $repoData[$alias.Groups[1].Value] = @{ entries = @(@{ name = '1.0.0'; type = 'tree' }) }
+        }
+        return @{ data = @{ repository = $repoData } }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Errored'; repo = 'vendor/errored'; url = 'https://example.com/{VERSION}.exe' },
+        @{ id = 'Vendor.Good'; repo = 'vendor/good'; url = 'https://example.com/{VERSION}.exe' }
+    ) -GraphQlInvoker $invoker -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $pass1Partial 'Vendor.Errored') 'pass-1 per-alias error becomes a failed repo lookup'
+Assert-Equal 'Skipped:AlreadyPublished' (Get-ReasonFor $pass1Partial 'Vendor.Good') 'pass-1 sibling alias without an error keeps its result'
+
+# 12e) A pass-1b per-alias error includes the package as batch-failed instead
+#      of mislabeling it an unresolvable version source.
+$pass1bPartial = & $module {
+    $invoker = {
+        param([string] $Query)
+        if ($Query -match 'u\d+: repository') {
+            return @{
+                errors = @(@{ path = @('u0'); message = 'server error' })
+                data   = @{ u0 = $null }
+            }
+        }
+        if ($Query -notmatch 'winget-pkgs') { return @{ data = @{} } }
+        return @{ data = @{ repository = @{} } }
+    }
+    Select-GitHubPackagesNeedingUpdate -Packages @(
+        @{ id = 'Vendor.Tagged'; repo = 'vendor/tagged'; url = 'https://example.com/{VERSION}.exe'; tagPattern = '^v1\..*' }
+    ) -GraphQlInvoker $invoker -WarningAction SilentlyContinue
+}
+Assert-Equal 'Include:PrecheckBatchFailed' (Get-ReasonFor $pass1bPartial 'Vendor.Tagged') 'pass-1b per-alias error includes the package as batch-failed'
+
+
 if ($script:failures -gt 0) {
     Write-Host "$script:failures assertion(s) failed."
     exit 1

--- a/tests/Test-ExistingPRs.Tests.ps1
+++ b/tests/Test-ExistingPRs.Tests.ps1
@@ -794,6 +794,26 @@ Describe 'Test-ExistingPRs' {
                     -Title 'Submitting Godot Launcher v1.11.1' `
                     -PackageIdentifier 'GodotLauncher.Launcher' `
                     -Version '1.11.1'
+                FileNameToken  = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Add GodotLauncher setup.exe 1.11.1' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                DomainToken    = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Submitting Godot Launcher 1.11.1 from godotlauncher.org' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                UrlToken       = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Add Godot Launcher 1.11.1 (see https://downloads.example.gallery/godot.launcher.portable)' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                OtherIdToken   = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'New version: Contoso.OtherApp 2.0' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
+                PureVersions   = Test-WingetPkgsTitleNamesOtherPackage `
+                    -Title 'Bump Godot Launcher from 1.10.2 to 1.11.1' `
+                    -PackageIdentifier 'GodotLauncher.Launcher' `
+                    -Version '1.11.1'
             }
         }
 
@@ -811,6 +831,21 @@ Describe 'Test-ExistingPRs' {
         }
         if ($helperResults.VersionToken) {
             throw 'A version-like dotted token was misclassified as another package identifier.'
+        }
+        if ($helperResults.FileNameToken) {
+            throw 'A file-name token (setup.exe) was misclassified as another package identifier.'
+        }
+        if ($helperResults.DomainToken) {
+            throw 'A domain-like token was misclassified as another package identifier.'
+        }
+        if ($helperResults.UrlToken) {
+            throw 'A URL-embedded token was misclassified as another package identifier.'
+        }
+        if (-not $helperResults.OtherIdToken) {
+            throw 'A title naming a genuinely different package identifier was not classified as such.'
+        }
+        if ($helperResults.PureVersions) {
+            throw 'Pure version tokens were misclassified as another package identifier.'
         }
     }
 }


### PR DESCRIPTION
Four independent fixes for post-merge review findings from #191/#193/#194/#195.

## 1. `update-script-packages.yml` silently swallowed QuestionsRequired stops (medium)

**Problem:** Since #191 reset `$global:LASTEXITCODE` on exit-4/QuestionsRequired, a safety-question stop in the script-packages workflow ended GREEN with no trace — it had no needs-decision record/upload steps, no summary, and no QuestionsRequired exclusion on its failure steps. Its notify job was also silently skipped when `NTFY_URL` is unset.

**Fix:** Mirrored the needs-decision semantics from `update-github-packages-1-z.yml`, adapted to this workflow's `matrix.PackageName` variable: record/upload needs-decision marker steps gated on `!cancelled() && steps.generate.outputs.reason == 'QuestionsRequired'`, generate-failure steps excluded via `failure() && steps.generate.outputs.reason != 'QuestionsRequired'`, download + "packages waiting on a safety-question decision" summary in `collect-generated`, and the `NTFY_URL not configured` warning step in `notify-failure` (job now runs on every failure). The workflow is standalone (only `update-github-packages-*` files are generated from `.github/workflows-templates/github-releases.yml` via `orchestrate_gh-packages.py`), so it was edited directly.

**Tests:** YAML parse + `zizmor --offline` clean; conditions reference the same `reason` output emitted by the shared `Update-WingetPackage` module path both workflows use.

## 2. Stream-config validation didn't run on config-only PRs (medium)

**Problem:** The #194 guard lives in `tests/GitHubReleaseMonitoringConfiguration.Tests.ps1`, run only by `module-tests.yml`, whose path filters covered just the workflow file, module, and tests. A PR touching only `github-releases-monitored.yml` or the `.github/workflows-data/*.packages.json` sidecar bypassed the check — exactly the reintroduction vector the guard closes.

**Fix:** Added `github-releases-monitored.yml`, `.github/workflows-data/**`, `.github/workflows-templates/**`, and `.github/workflows/update-github-packages-*.yml` to both the `pull_request` and `push` path lists — the last two because the suite also validates template/generated-workflow drift and sidecar consistency against those files.

**Tests:** Suite passes; YAML + zizmor clean.

## 3. Duplicate-PR title heuristic suppressed too aggressively (medium)

**Problem:** `Test-WingetPkgsTitleNamesOtherPackage` (#193) discarded a manifest-path candidate when its title contained ANY dotted token that wasn't the target id — so `Add GodotLauncher setup.exe 1.11.1` (filename) and domain-containing titles were suppressed, precisely the human-PR class the manifest-path stage exists to catch.

**Fix:** A dotted token now counts as "names another package" only when it plausibly IS a winget package id: ≥2 dot-separated segments each starting with a letter, final segment not a known file extension (exe/msi/msix/zip/…/7z/gz/xz/bin) and not a common TLD (com/org/net/io/dev/de/app/sh/co/uk/us/me/gg), token not part of a URL and not a `www.` host, plus the existing target-id/version self-match exclusions. Function contract and single caller unchanged.

**Tests:** `Test-ExistingPRs.Tests.ps1` extended: `Add GodotLauncher setup.exe 1.11.1` not suppressed; `New version: Contoso.OtherApp 2.0` still suppressed; domain/URL titles not suppressed; pure version tokens not suppressed. 20/20 Pester tests pass.

## 4. GraphQL partial errors caused false PackageMissing skips (medium)

**Problem:** A GraphQL response can be HTTP 200 with an `errors` array and partially-null `data` (per-alias errors carry `path: ["p3"]`). Pass 2 interpreted a null `p$i` object as "manifest folder absent" → `Skipped:PackageMissing` — an error masquerading as positive evidence of absence, violating the #195 invariant (only positive evidence may skip). Only RATE_LIMITED errors were detected; everything else flowed through silently, in all three passes.

**Fix:** New shared helper `Get-WingetPrecheckErroredAlias` attributes each error's `path` entries to the batch's aliases (handles both `["p3"]` and `["repository","p3"]` shapes). After every successful batch call: pass 1/1b per-alias errors put the repo/package into the failed-lookup path (`PrecheckBatchFailed`), pass 2 per-alias errors set the published state via the same source-index fallback as a thrown batch (`Resolved` from the index, else `Failed` → `PrecheckBatchFailed`). Unattributable errors or null/absent `data` fail the whole batch, identical to a thrown batch. A null object with no corresponding error entry remains a legitimate `PackageMissing` skip.

**Tests:** `SelectGitHubPackagesNeedingUpdate.Tests.ps1` extended (section 12): pass-2 per-alias error → `Include:PrecheckBatchFailed` (not `PackageMissing`); same-batch error-free sibling keeps its real result; source-index fallback variant resolves the errored alias; errors + null data fail the whole batch open; pass-1 and pass-1b per-alias errors → `Include:PrecheckBatchFailed`; error-free null object still `Skipped:PackageMissing`.

## Validation

- All 16 plain suites from `module-tests.yml` pass (`SUITE OK` × 16).
- Pester group: `Test-ExistingPRs` + `Test-ManifestRemoteReads` + `Test-SubmitFinalValidation` pass; 8 failures in `Submit-WingetPackage.Tests.ps1` are pre-existing local-environment failures — verified byte-identical (same 8 test names, 35 passed/8 failed) on a clean stashed baseline.
- `zizmor --offline` reports no findings on both edited workflows.