### PR TITLE
Add package-agnostic E2E installer analysis (script + self-hosted workflow)

### DIFF
--- a/.github/workflows/analyze-installer-e2e.yml
+++ b/.github/workflows/analyze-installer-e2e.yml
@@ -1,0 +1,84 @@
+name: Analyze Installer E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      urls:
+        description: 'Installer URL(s), space separated (alternative to pr)'
+        required: false
+      pr:
+        description: 'winget-pkgs PR number - installer URLs are extracted from its manifest'
+        required: false
+      packageId:
+        description: 'Demo package identifier used for the throwaway manifest'
+        required: false
+        default: 'Demo.Analysis'
+      skipSandbox:
+        description: 'Skip the Windows Sandbox install test'
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: "E2E: ${{ inputs.pr && format('PR #{0}', inputs.pr) || inputs.urls }}"
+    runs-on: [self-hosted, windows, x64]
+    timeout-minutes: 45
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run E2E analysis
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_URLS: ${{ inputs.urls }}
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_PACKAGEID: ${{ inputs.packageId }}
+          INPUT_SKIPSANDBOX: ${{ inputs.skipSandbox }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $urls = @($env:INPUT_URLS -split '[\s,]+' | Where-Object { $_ })
+          $pr = 0
+          [void] [int]::TryParse($env:INPUT_PR, [ref] $pr)
+
+          if (($urls.Count -gt 0) -eq ($pr -gt 0)) {
+            Write-Error 'Provide exactly one of "urls" or "pr".'
+            exit 1
+          }
+
+          $params = @{ PackageId = $env:INPUT_PACKAGEID }
+          if ($pr -gt 0) { $params.WingetPkgsPr = $pr } else { $params.InstallerUrl = $urls }
+          if ($env:INPUT_SKIPSANDBOX -eq 'true') { $params.SkipSandbox = $true }
+
+          & .\scripts\analyze\Invoke-InstallerE2E.ps1 @params
+          # Analysis failures (e.g. validation-failed) are findings, not workflow
+          # errors - the report carries them. Only hard script errors fail the job.
+
+      - name: Publish report to job summary
+        if: always()
+        shell: pwsh
+        run: |
+          $latest = Get-ChildItem -Path 'data\e2e-analysis' -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending | Select-Object -First 1
+          if ($latest -and (Test-Path (Join-Path $latest.FullName 'report.md'))) {
+            Get-Content (Join-Path $latest.FullName 'report.md') |
+              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          } else {
+            'No report.md was produced.' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+
+      - name: Upload report artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-analysis-${{ github.run_id }}
+          path: data/e2e-analysis/
+          retention-days: 30
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ scripts/package-cleanup/cleaned_packages.csv
 *.appx
 *.msix
 *.msixbundle
+
+data/e2e-analysis/

--- a/README.md
+++ b/README.md
@@ -33,3 +33,24 @@ For a reviewed installer architecture, type, or scope transition, set
 `allowStructuralRewrite: true` on that package's matrix entry. This approval is
 disabled by default and maps only to WinMatsch's `--allow-structural-rewrite`
 option.
+
+## End-to-end installer analysis
+
+`scripts/analyze/Invoke-InstallerE2E.ps1` answers "what would our pipeline do
+with this installer?" without touching any monitored package:
+
+```powershell
+# Direct URL(s)
+./scripts/analyze/Invoke-InstallerE2E.ps1 -InstallerUrl 'https://example.com/setup.exe'
+
+# Any winget-pkgs PR - installer URLs are extracted from the PR's manifests
+./scripts/analyze/Invoke-InstallerE2E.ps1 -WingetPkgsPr 421311
+```
+
+It runs `winmatsch analyze` per URL (architecture, installer type, silent
+switches, hashes, dependencies), generates a throwaway manifest with
+`winmatsch new` under a demo identifier (nothing is submitted), validates it,
+and - when Windows Sandbox is enabled - installs it via
+`scripts/validation/Test-Manifest-Sandbox.ps1`. `report.md` and `report.json`
+are written to `data/e2e-analysis/<timestamp>/` (gitignored). Use
+`-SkipSandbox`, `-SkipManifest`, or `-SkipAnalyze` to shorten the loop.

--- a/scripts/analyze/Invoke-InstallerE2E.ps1
+++ b/scripts/analyze/Invoke-InstallerE2E.ps1
@@ -49,6 +49,7 @@ param(
     [switch] $SkipAnalyze,
     [switch] $SkipManifest,
     [switch] $SkipSandbox,
+    [switch] $KeepSandboxOpen,
 
     [string] $OutputDir
 )
@@ -246,7 +247,7 @@ if (-not $SkipSandbox) {
         # Test-Manifest-Sandbox expects the flat folder that directly contains the yaml files.
         $installerYaml = @($report.Manifest.Files | Where-Object { $_ -match '\.installer\.yaml$' } | Select-Object -First 1)
         $sandboxManifestPath = if ($installerYaml) { Split-Path -Parent $installerYaml } else { $report.Manifest.Path }
-        & $sandboxScript -ManifestPath $sandboxManifestPath
+        & $sandboxScript -ManifestPath $sandboxManifestPath -KeepSandboxOpen:$KeepSandboxOpen
         $sandboxExit = $LASTEXITCODE
         $report.Sandbox = [ordered]@{ ExitCode = $sandboxExit }
         Write-Host "Sandbox exit code: $sandboxExit (0 = success)"

--- a/scripts/analyze/Invoke-InstallerE2E.ps1
+++ b/scripts/analyze/Invoke-InstallerE2E.ps1
@@ -1,0 +1,321 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Package-agnostic end-to-end probe: URL (or winget-pkgs PR) -> analyze ->
+    demo manifest -> optional sandbox install -> report.
+
+.DESCRIPTION
+    Answers the question "what would our pipeline do with this installer?"
+    without touching any monitored package:
+
+      1. Resolve installer URLs - either given directly via -InstallerUrl or
+         extracted from a microsoft/winget-pkgs pull request (-WingetPkgsPr).
+      2. Run `winmatsch analyze` on every installer (architecture, installer
+         type, detected silent switches, hashes, signature, ...).
+      3. Generate a throwaway manifest with `winmatsch new` under a demo
+         package identifier. Nothing is submitted; names are placeholders.
+      4. Validate the demo manifest with `winmatsch validate`.
+      5. Optionally install it in Windows Sandbox via
+         scripts/validation/Test-Manifest-Sandbox.ps1 (skipped automatically
+         when the Sandbox feature is unavailable).
+      6. Write report.json and report.md to the output directory.
+
+.EXAMPLE
+    ./scripts/analyze/Invoke-InstallerE2E.ps1 -InstallerUrl 'https://example.com/setup.exe'
+
+.EXAMPLE
+    ./scripts/analyze/Invoke-InstallerE2E.ps1 -WingetPkgsPr 421311
+
+.EXAMPLE
+    ./scripts/analyze/Invoke-InstallerE2E.ps1 -WingetPkgsPr 421311 -SkipSandbox -PackageId 'Demo.PGlove'
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'Url')]
+    [string[]] $InstallerUrl,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Pr')]
+    [int] $WingetPkgsPr,
+
+    [Parameter(ParameterSetName = 'Pr')]
+    [string] $PrRepo = 'microsoft/winget-pkgs',
+
+    [string] $PackageId = 'Demo.Analysis',
+    [string] $Version,
+    [string] $Publisher = 'Demo Publisher',
+    [string] $PackageName = 'Demo Analysis Package',
+
+    [switch] $SkipAnalyze,
+    [switch] $SkipManifest,
+    [switch] $SkipSandbox,
+
+    [string] $OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path $repoRoot "data\e2e-analysis\$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+}
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+Import-Module (Join-Path $repoRoot 'modules\WingetMaintainerModule') -Force
+Install-WinMatsch
+
+$report = [ordered]@{
+    StartedAt = (Get-Date).ToString('o')
+    Source    = $PSCmdlet.ParameterSetName
+    PackageId = $PackageId
+    Urls      = @()
+    PrInfo    = $null
+    Analyses  = @()
+    Manifest  = $null
+    Sandbox   = $null
+}
+
+# --- 1. resolve installer URLs -------------------------------------------------
+
+if ($PSCmdlet.ParameterSetName -eq 'Pr') {
+    Write-Host "`n=== Resolving installer URLs from $PrRepo PR #$WingetPkgsPr ===" -ForegroundColor Cyan
+
+    $pr = gh pr view $WingetPkgsPr --repo $PrRepo --json files,headRefOid,headRepositoryOwner,title | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) { throw "gh pr view failed for PR #$WingetPkgsPr" }
+
+    $report.PrInfo = [ordered]@{
+        Number = $WingetPkgsPr
+        Title  = $pr.title
+        Owner  = $pr.headRepositoryOwner.login
+        Sha    = $pr.headRefOid
+    }
+
+    $installerFiles = @($pr.files | Where-Object { $_.path -match '\.installer\.ya?ml$' })
+    if ($installerFiles.Count -eq 0) { throw "PR #$WingetPkgsPr contains no *.installer.yaml manifest" }
+
+    $prManifestInfo = @()
+    $resolvedUrls = @()
+    foreach ($file in $installerFiles) {
+        $escapedPath = ($file.path -split '/' | ForEach-Object { [uri]::EscapeDataString($_) }) -join '/'
+        $rawUrl = "https://raw.githubusercontent.com/$($pr.headRepositoryOwner.login)/winget-pkgs/$($pr.headRefOid)/$escapedPath"
+        $content = ((Invoke-RestMethod -Uri $rawUrl) -join "`n") -split "`n"
+
+        $urlsInFile = @($content | Where-Object { $_ -match '^\s*InstallerUrl:\s*' } | ForEach-Object { ($_ -replace '^\s*InstallerUrl:\s*', '').Trim() })
+        $resolvedUrls += $urlsInFile
+        $prManifestInfo += [ordered]@{
+            Path    = $file.path
+            Version = (($content | Where-Object { $_ -match '^PackageVersion:' } | Select-Object -First 1) -replace '^PackageVersion:\s*', '').Trim()
+            Type    = (($content | Where-Object { $_ -match '^InstallerType:' } | Select-Object -First 1) -replace '^InstallerType:\s*', '').Trim()
+            Urls    = $urlsInFile
+        }
+    }
+    $InstallerUrl = @($resolvedUrls | Select-Object -Unique)
+    $report.PrInfo.Manifests = $prManifestInfo
+}
+
+if (-not $InstallerUrl -or $InstallerUrl.Count -eq 0) { throw 'No installer URLs to analyze.' }
+$report.Urls = $InstallerUrl
+Write-Host "Installer URL(s):" -ForegroundColor Cyan
+$InstallerUrl | ForEach-Object { Write-Host "  $_" }
+
+# --- 2. analyze -----------------------------------------------------------------
+
+if (-not $SkipAnalyze) {
+    foreach ($url in $InstallerUrl) {
+        Write-Host "`n=== Analyzing $url ===" -ForegroundColor Cyan
+        $safeName = ([uri]$url).Segments[-1] -replace '[^\w\.-]', '_'
+        $analysisPath = Join-Path $OutputDir "analyze-$safeName.json"
+
+        $json = & winmatsch analyze $url --format json --interaction never --no-cache 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+        $json | Set-Content -LiteralPath $analysisPath -Encoding utf8
+
+        $parsed = $null
+        try { $parsed = $json | ConvertFrom-Json } catch { Write-Warning "analyze output was not JSON: $_" }
+
+        $report.Analyses += [ordered]@{
+            Url      = $url
+            ExitCode = $exitCode
+            RawPath  = $analysisPath
+            Result   = $parsed
+        }
+        Write-Host $json
+        if ($exitCode -ne 0) { Write-Warning "winmatsch analyze exited with $exitCode for $url" }
+    }
+}
+
+# --- 3. demo manifest -----------------------------------------------------------
+
+if (-not $SkipManifest) {
+    Write-Host "`n=== Generating demo manifest for $PackageId ===" -ForegroundColor Cyan
+
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        $Version = '1.0.0'
+        # Prefer a product version detected during analysis over the placeholder.
+        foreach ($analysis in $report.Analyses) {
+            $candidate = $null
+            if ($analysis.Result -and $analysis.Result.PSObject.Properties['product']) {
+                $candidate = $analysis.Result.product.version
+            }
+            if ($candidate -and $candidate -match '^\d+(\.\d+){0,3}$') { $Version = $candidate; break }
+        }
+    }
+
+    $manifestDir = Join-Path $OutputDir 'manifest'
+    $newArgs = @(
+        'new', $PackageId
+        '--version', $Version
+        '--urls'
+    ) + $InstallerUrl + @(
+        '--publisher', $Publisher
+        '--package-name', $PackageName
+        '--short-description', 'Throwaway manifest for end-to-end pipeline analysis'
+        '--license', 'Proprietary'
+        '--skip-pr-check'
+        '--interaction', 'never'
+        '--format', 'json'
+        '--no-cache'
+        '--output', $manifestDir
+    )
+    if ($env:GITHUB_TOKEN) { $newArgs += @('--token', $env:GITHUB_TOKEN) }
+
+    $displayArgs = $newArgs | ForEach-Object { if ($_ -eq $env:GITHUB_TOKEN) { '***' } else { $_ } }
+    Write-Host "Running: winmatsch $($displayArgs -join ' ')"
+    $newOutput = & winmatsch @newArgs 2>&1 | Out-String
+    $newExit = $LASTEXITCODE
+    Write-Host $newOutput
+    $newOutput | Set-Content -LiteralPath (Join-Path $OutputDir 'manifest-new.log') -Encoding utf8
+
+    $newParsed = $null
+    try { $newParsed = $newOutput | ConvertFrom-Json } catch { }
+    $newResultCode = if ($newParsed -and $newParsed.PSObject.Properties['resultCode']) { $newParsed.resultCode } else { "exit$newExit" }
+
+    $generatedFiles = @()
+    if (Test-Path $manifestDir) {
+        $generatedFiles = @(Get-ChildItem -Path $manifestDir -Recurse -Filter '*.yaml' |
+            Where-Object { $_.FullName -notmatch '\.winmatsch-transaction' } |
+            ForEach-Object { $_.FullName })
+    }
+
+    $report.Manifest = [ordered]@{
+        ExitCode         = $newExit
+        ResultCode       = $newResultCode
+        Version          = $Version
+        Path             = $manifestDir
+        Files            = $generatedFiles
+        ValidateExitCode = $null
+        ValidateOutput   = $null
+    }
+
+    # --- 4. validate --------------------------------------------------------------
+    if ($generatedFiles.Count -gt 0) {
+        Write-Host "`n=== Validating demo manifest ===" -ForegroundColor Cyan
+        $validateOutput = & winmatsch validate $generatedFiles --interaction never --format json 2>&1 | Out-String
+        $report.Manifest.ValidateExitCode = $LASTEXITCODE
+        $report.Manifest.ValidateOutput = $validateOutput
+        Write-Host $validateOutput
+    }
+    else {
+        Write-Warning 'No manifest files were generated; skipping validation and sandbox.'
+        $SkipSandbox = $true
+    }
+}
+else {
+    $SkipSandbox = $true
+}
+
+# --- 5. sandbox -----------------------------------------------------------------
+
+if (-not $SkipSandbox) {
+    $sandboxAvailable = $false
+    try {
+        $feature = Get-WindowsOptionalFeature -Online -FeatureName 'Containers-DisposableClientVM' -ErrorAction Stop
+        $sandboxAvailable = ($feature.State -eq 'Enabled')
+    }
+    catch {
+        Write-Warning "Cannot query Windows Sandbox feature state (needs elevation?): $($_.Exception.Message)"
+    }
+
+    if (-not $sandboxAvailable) {
+        Write-Warning 'Windows Sandbox is not enabled on this machine; skipping sandbox install.'
+    }
+    else {
+        Write-Host "`n=== Installing demo manifest in Windows Sandbox ===" -ForegroundColor Cyan
+        $sandboxScript = Join-Path $repoRoot 'scripts\validation\Test-Manifest-Sandbox.ps1'
+        # Test-Manifest-Sandbox expects the flat folder that directly contains the yaml files.
+        $installerYaml = @($report.Manifest.Files | Where-Object { $_ -match '\.installer\.yaml$' } | Select-Object -First 1)
+        $sandboxManifestPath = if ($installerYaml) { Split-Path -Parent $installerYaml } else { $report.Manifest.Path }
+        & $sandboxScript -ManifestPath $sandboxManifestPath
+        $sandboxExit = $LASTEXITCODE
+        $report.Sandbox = [ordered]@{ ExitCode = $sandboxExit }
+        Write-Host "Sandbox exit code: $sandboxExit (0 = success)"
+    }
+}
+
+# --- 6. report ------------------------------------------------------------------
+
+$report.FinishedAt = (Get-Date).ToString('o')
+$reportPath = Join-Path $OutputDir 'report.json'
+($report | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+$md = [System.Text.StringBuilder]::new()
+[void] $md.AppendLine("# E2E installer analysis - $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')")
+[void] $md.AppendLine()
+if ($report.PrInfo) {
+    [void] $md.AppendLine("**Source:** $PrRepo PR #$($report.PrInfo.Number) - $($report.PrInfo.Title)")
+}
+else {
+    [void] $md.AppendLine('**Source:** direct URL(s)')
+}
+[void] $md.AppendLine()
+foreach ($analysis in $report.Analyses) {
+    [void] $md.AppendLine("## $($analysis.Url)")
+    [void] $md.AppendLine()
+    [void] $md.AppendLine("- analyze exit code: $($analysis.ExitCode)")
+    $r = $analysis.Result
+    if ($r -and $r.installers) {
+        foreach ($inst in $r.installers) {
+            $prop = { param($o, $n) if ($o.PSObject.Properties[$n]) { $o.$n } else { $null } }
+            [void] $md.AppendLine("- arch: $(& $prop $inst 'architecture') | type: $(& $prop $inst 'installerType') | scope: $(& $prop $inst 'scope')")
+            $switches = & $prop $inst 'switches'
+            if ($switches) { [void] $md.AppendLine("- switches: $($switches | ConvertTo-Json -Compress)") }
+            $sha = & $prop $inst 'sha256'
+            if (-not $sha -and $r.PSObject.Properties['sha256']) { $sha = $r.sha256 }
+            if ($sha) { [void] $md.AppendLine("- sha256: $sha") }
+        }
+    }
+    [void] $md.AppendLine()
+}
+if ($report.Manifest) {
+    [void] $md.AppendLine("## Demo manifest ($PackageId $Version)")
+    [void] $md.AppendLine()
+    [void] $md.AppendLine("- generation: $($report.Manifest.ResultCode) (exit $($report.Manifest.ExitCode))")
+    [void] $md.AppendLine("- validation exit code: $($report.Manifest.ValidateExitCode)")
+    [void] $md.AppendLine("- path: $($report.Manifest.Path)")
+    [void] $md.AppendLine()
+}
+[void] $md.AppendLine('## Sandbox')
+[void] $md.AppendLine()
+if ($report.Sandbox) {
+    [void] $md.AppendLine("- exit code: $($report.Sandbox.ExitCode) (0 = installed successfully)")
+}
+else {
+    [void] $md.AppendLine('- skipped')
+}
+$mdPath = Join-Path $OutputDir 'report.md'
+$md.ToString() | Set-Content -LiteralPath $mdPath -Encoding utf8
+
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+Write-Host "  URLs analyzed : $($report.Analyses.Count)"
+if ($report.Manifest) {
+    $validateExit = if ($null -ne $report.Manifest.ValidateExitCode) { $report.Manifest.ValidateExitCode } else { 'n/a' }
+    Write-Host "  Manifest      : $($report.Manifest.ResultCode) (exit $($report.Manifest.ExitCode)), validate exit $validateExit"
+}
+if ($report.Sandbox) {
+    Write-Host "  Sandbox       : exit $($report.Sandbox.ExitCode)"
+}
+else {
+    Write-Host "  Sandbox       : skipped"
+}
+Write-Host "  Report        : $mdPath"

--- a/scripts/validation/Test-Manifest-Sandbox.ps1
+++ b/scripts/validation/Test-Manifest-Sandbox.ps1
@@ -40,7 +40,11 @@ Param(
     [switch] $SkipManifestValidation,
     [switch] $Prerelease,
     [switch] $EnableExperimentalFeatures,
-    [switch] $Clean
+    [switch] $Clean,
+    # Keep the sandbox window open after the install finishes so a human can
+    # inspect the machine state. Defaults to on for interactive local runs and
+    # off in CI (GitHub Actions / Azure Pipelines / generic CI).
+    [switch] $KeepSandboxOpen
 )
 
 . (Join-Path $PSScriptRoot 'GitHubApiCache.ps1')
@@ -877,18 +881,40 @@ $TimeoutSeconds = 900 # 15 minutes
 $ElapsedSeconds = 0
 $CheckIntervalSeconds = 2
 
+$isCiEnvironment = ($env:CI -eq 'true') -or ($env:GITHUB_ACTIONS -eq 'true') -or ($env:TF_BUILD -eq 'true')
+$canPrompt = [Environment]::UserInteractive -and -not [Console]::IsInputRedirected -and -not $isCiEnvironment
+$keepSandboxOpenEffective = $KeepSandboxOpen.IsPresent -or $canPrompt
+
 $sandboxCompleted = $false
 while ($ElapsedSeconds -lt $TimeoutSeconds) {
     if ((Test-Path $LogsFolder) -and (Test-Path $FinishedFile)) {
         Write-Information "--> Sandbox installation completed successfully"
         $sandboxCompleted = $true
-        
-        # Kill the sandbox processes now that installation is complete
-        Write-Information "--> Closing Windows Sandbox"
-        Stop-NamedProcess -ProcessName 'WindowsSandboxClient'
-        Stop-NamedProcess -ProcessName 'WindowsSandboxRemoteSession'
-        Start-Sleep -Seconds 20 # Allow time for the sandbox to close gracefully
-        
+
+        if ($keepSandboxOpenEffective) {
+            # The logs folder is a read-write mapped folder, so all results are
+            # already on the host - the sandbox only needs to stay alive for
+            # manual inspection of the machine state.
+            Write-Host "--> Sandbox left open for inspection. Logs stream live to: $LogsFolder" -ForegroundColor Yellow
+            if ($canPrompt) {
+                Read-Host '--> Look around in the sandbox, then press ENTER to close it'
+                Write-Information "--> Closing Windows Sandbox"
+                Stop-NamedProcess -ProcessName 'WindowsSandboxClient'
+                Stop-NamedProcess -ProcessName 'WindowsSandboxRemoteSession'
+                Start-Sleep -Seconds 20 # Allow time for the sandbox to close gracefully
+            }
+            else {
+                Write-Host '--> Close the sandbox window when done; all state is discarded on close.' -ForegroundColor Yellow
+            }
+        }
+        else {
+            # Kill the sandbox processes now that installation is complete
+            Write-Information "--> Closing Windows Sandbox"
+            Stop-NamedProcess -ProcessName 'WindowsSandboxClient'
+            Stop-NamedProcess -ProcessName 'WindowsSandboxRemoteSession'
+            Start-Sleep -Seconds 20 # Allow time for the sandbox to close gracefully
+        }
+
         break
     }
     


### PR DESCRIPTION
## Summary

Adds a package-agnostic end-to-end probe that answers *"what would our pipeline do with this installer?"* — from any installer URL or any `microsoft/winget-pkgs` PR — without touching monitored packages.

### `scripts/analyze/Invoke-InstallerE2E.ps1`

1. Resolves installer URLs — directly via `-InstallerUrl` or extracted from a winget-pkgs PR via `-WingetPkgsPr`
2. Runs `winmatsch analyze` per URL (architecture, installer type, silent switches, hashes, dependencies)
3. Generates a throwaway manifest with `winmatsch new` under a demo identifier — **nothing is submitted**
4. Validates the demo manifest with `winmatsch validate`
5. Optionally installs it in Windows Sandbox via `scripts/validation/Test-Manifest-Sandbox.ps1`
6. Writes `report.md` + `report.json` to `data/e2e-analysis/<timestamp>/` (gitignored)

### `.github/workflows/analyze-installer-e2e.yml`

workflow_dispatch wrapper running on `[self-hosted, windows, x64]` so the Windows Sandbox test is available. Inputs: `urls` *or* `pr`, optional `packageId` / `skipSandbox`. Report goes to the job summary and is uploaded as an artifact.

### `Test-Manifest-Sandbox.ps1`: `-KeepSandboxOpen`

Keeps the sandbox window open after install completion so the machine state can be inspected manually. Defaults to **on for interactive local runs** (CI env vars unset, input not redirected) and **off on runners** — automated pipelines are unchanged. Logs already stream live into the mapped folder; the script prints that and waits for ENTER before closing.

## Dogfooding: microsoft/winget-pkgs#421311

The tool was validated against the real-world PR that motivated it ([microsoft/winget-pkgs#421311](https://github.com/microsoft/winget-pkgs/pull/421311)) and independently reproduced the upstream `Validation-Unattended-Failed` findings:

- **VLD6011**: archive.org rotates download-node redirects between requests → URL not pinnable (WinMatsch `PreflightGate.cs`, stricter than upstream's hash-only check)
- The EXE is a **7-Zip SFX stub**, not Inno — the declared `/s` + `/SILENT` switches do nothing
- The SFX payload contains **no installer at all** — it packs the author's build toolchain (`app-builder.exe` = electron-builder helper, `rg.exe`, `7za.exe`, `build-pglove.bat` with a hardcoded dev-machine path), so nothing ever registers in ARP
- A hand-written demo manifest with correct SFX switches (`-y -gm2`) installed silently in the sandbox (exit 0) — proving the switch and URL issues are separate from the payload problem
- Control test with the official 7-Zip MSI passes analyze → manifest → validate cleanly

## Test plan

- [x] `Invoke-InstallerE2E.ps1 -WingetPkgsPr 421311` — full run, correct failure diagnosis
- [x] `Invoke-InstallerE2E.ps1 -InstallerUrl <7-zip msi>` — full green run
- [x] Hand-written SFX manifest through `Test-Manifest-Sandbox.ps1` locally
- [x] Workflow YAML validated
- [x] PSScriptAnalyzer parse check on both edited scripts

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>